### PR TITLE
Update Http Endpoint integration output body to JSON format

### DIFF
--- a/deepfence_backend/models/integration.py
+++ b/deepfence_backend/models/integration.py
@@ -259,7 +259,7 @@ class HttpEndpoint(IntegrationTypes):
         notification_id = kwargs["notification_id"]
         resource_type = kwargs["resource_type"]
         from tasks.notification import send_http_endpoint_notification
-        send_http_endpoint_notification(self.pretty_print(), self.format_content(content_json), notification_id,
+        send_http_endpoint_notification(self.pretty_print(), content_json["contents"], notification_id,
                                         resource_type)
 
 


### PR DESCRIPTION
This updates the Http Endpoint integration to use the same JSON format as used in S3 integration endpoint. Currently, the format sent out in the Http Endpoint integration is a custom string, which requires custom parser on the API endpoint specified in the integration. With JSON output, json libraries available can be used to parse the POST body received on the API endpoint.

Closes #67 
