### PR TITLE
(fix) sidepanel doesnot change when filters are removed

### DIFF
--- a/deepfence_ui/app/scripts/components/node-filter-panel.js
+++ b/deepfence_ui/app/scripts/components/node-filter-panel.js
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import Select from 'react-select';
 import OutsideClickHandler from 'react-outside-click-handler';
-import { addTopologyFilter } from '../actions/app-actions';
+import { addTopologyFilter, removeTopologyFilter, setTopologyClickedNode } from '../actions/app-actions';
 import { fetchTopologyData } from './multi-cloud/topology-client';
 import TopologyFiltersBar from './topology-filter';
 
@@ -55,6 +55,15 @@ export default function NodeFiltersPanel(props) {
     setShowCloudProviderDropdown(false);
     setIndexValue(filterIndex);
   };
+
+  // remove the selected filter
+  const removeFilter = (filter) => {
+    dispatch(removeTopologyFilter(filter))
+
+    // setting last element as active node for side panel
+    const node = filter.at(-1);
+    dispatch(setTopologyClickedNode(node));
+  }
 
   const onChildFilterSelected = (e, filter) => {
     setShowChildDropDown(!showChildDropdown);
@@ -132,6 +141,7 @@ export default function NodeFiltersPanel(props) {
             setShowChildDropDown={setShowChildDropDown}
             handleOnChildFilterChange={onChildFilterSelected}
             addFilter={addChildFilter}
+            removeFilter={removeFilter}
             optionValues={optionValues}
           />
           <div>

--- a/deepfence_ui/app/scripts/components/topology-filter.js
+++ b/deepfence_ui/app/scripts/components/topology-filter.js
@@ -1,10 +1,8 @@
 import React from 'react';
-import { useDispatch } from 'react-redux';
 import Select from 'react-select';
 import { Tooltip } from 'react-tippy';
 import 'react-tippy/dist/tippy.css';
 import OutsideClickHandler from 'react-outside-click-handler';
-import { removeTopologyFilter } from '../actions/app-actions';
 
 const frontEllipsis = text => {
   const splitText = text.split(' AND ');
@@ -21,12 +19,12 @@ const TopologyFiltersBar = props => {
     showChildDropdown,
     handleOnChildFilterChange,
     addFilter,
+    removeFilter,
     styles,
     theme,
     optionValues,
     setShowChildDropDown,
   } = props;
-  const dispatch = useDispatch();
   const filtersList = filters.map((filter, index) => {
     const currentFilter = filter.reduce(
       (accumulator, currentValue) =>
@@ -45,15 +43,15 @@ const TopologyFiltersBar = props => {
               <div
                 className="fa fa-plus filter-remove-btn"
                 aria-hidden="true"
-                style={{ paddingLeft: '5px' }}
+                style={{ paddingLeft: '5px', cursor: 'pointer' }}
                 onClick={() => addFilter(index, filter)}
               />
             </div>
             <div
               className="fa fa-times filter-remove-btn"
-              onClick={() => dispatch(removeTopologyFilter(filter))}
               aria-hidden="true"
-              style={{ paddingLeft: '5px' }}
+              style={{ paddingLeft: '5px', cursor: 'pointer' }}
+              onClick={() => removeFilter(filter)}
             />
           </div>
         </Tooltip>

--- a/deepfence_ui/app/scripts/reducers/root.js
+++ b/deepfence_ui/app/scripts/reducers/root.js
@@ -3,7 +3,6 @@
 import debug from 'debug';
 import moment from 'moment';
 import {
-  fromJS,
   List as makeList,
   Map as makeMap,
   OrderedMap as makeOrderedMap,
@@ -22,7 +21,6 @@ import {
   TIME_BOUNDARY_OPTIONS,
 } from '../constants/dashboard-refresh-config';
 
-const log = debug('scope:app-store');
 const error = debug('scope:error');
 
 // Initial values
@@ -1380,8 +1378,7 @@ export function rootReducer(state = initialState, action) {
 
     case ActionTypes.ADD_TOPOLOGY_FILTER: {
       const api = state.get('topologyGraphAPI');
-      // eslint-disable-next-line prefer-destructuring
-      const filter = action.filter;
+      const { filter } = action;
       const node_id = filter[filter.length - 1].id;
       setTimeout(() => api.expandNode(node_id), 0);
       return state;
@@ -1389,8 +1386,7 @@ export function rootReducer(state = initialState, action) {
 
     case ActionTypes.REMOVE_TOPOLOGY_FILTER: {
       const api = state.get('topologyGraphAPI');
-      // eslint-disable-next-line prefer-destructuring
-      const filter = action.filter;
+      const { filter } = action;
       const node_id = filter[filter.length - 1].id;
       setTimeout(() => api.collapseNode(node_id), 0);
       return state;


### PR DESCRIPTION
this commit moves the 'removeFilter' function one component behind and
sets the node clicked id when filter is removed, same clicked id is
used by sidepanel to populate details for the active node.

Signed-off-by: harshvardhan karn <harshvardhan@deepfence.io>

ref: https://github.com/deepfence/ThreatMapper/issues/64