### PR TITLE
Do not allow non-read-only users to access add-cve-scan-log API

### DIFF
--- a/deepfence_backend/api/vulnerability_api.py
+++ b/deepfence_backend/api/vulnerability_api.py
@@ -1069,6 +1069,7 @@ def vulnerability_csv_download():
 
 @vulnerability_api.route("/add-cve-scan-log", methods=["POST"])
 @jwt_required
+@non_read_only_user
 def cve_scan():
     """
     Add a CVE scan document to Elastic search


### PR DESCRIPTION
Fixes #112  .

Changes proposed in this pull request:
- Restrict `add-cve-scan-log` endpoint to non-read-only users

@deepfence/engineering
