### PR TITLE
Order language vulnerability scans before OS scan

### DIFF
--- a/deepfence_console/deepaudit/main.go
+++ b/deepfence_console/deepaudit/main.go
@@ -637,7 +637,7 @@ func logErrorAndExit(errMsg string) {
 	os.Exit(1)
 }
 
-func getContainerVulnerabilities(imageName string, imageTarPath string, imageId string) {
+func saveContainerImage(imageName string, imageTarPath string, imageId string) *manifestItem {
 	global_image_id = imageId
 	path, err := save(imageName, global_image_id, imageTarPath)
 	if err != nil {
@@ -652,17 +652,17 @@ func getContainerVulnerabilities(imageName string, imageTarPath string, imageId 
 	if err != nil {
 		msg := fmt.Sprintf("Could not read image manifest: %s", err.Error())
 		logErrorAndExit(msg)
-		return
+		return manifestItem
 	}
 	layerIDs := manifestItem.LayerIds
 	layerPaths := manifestItem.Layers
 	if len(layerPaths) == 0 {
 		logErrorAndExit("Image layer path is empty")
-		return
+		return manifestItem
 	}
 	if len(layerIDs) == 0 {
 		logErrorAndExit("Image layer id is empty")
-		return
+		return manifestItem
 	}
 	if imageId == "" {
 		// reading image id from manifest file json path and tripping off extension
@@ -698,16 +698,26 @@ func getContainerVulnerabilities(imageName string, imageTarPath string, imageId 
 				msg := fmt.Sprintf("Unable to upload file %s to host %s. Reason %s",
 					fileName, managementConsoleUrl, err.Error())
 				sendScanLogsToLogstash(msg, "ERROR")
-				return
+				return manifestItem
 			}
 		}
 	}
+	return manifestItem
+}
+
+func getContainerVulnerabilities(imageName string, imageTarPath string, imageId string, manifestItem *manifestItem) {
+	path := tmp_path
+	// Retrieve history.
+	layerIDs := manifestItem.LayerIds
+	layerPaths := manifestItem.Layers
+	var fileName string
+	loopCntr := len(layerPaths)
 	if runtime.GOOS == "windows" {
 		fileName = path + "\\" + layerPaths[0]
 	} else {
 		fileName = path + "/" + layerPaths[0]
 	}
-	err = analyzeLayer(fileName, layerIDs[0], "")
+	err := analyzeLayer(fileName, layerIDs[0], "")
 	if err != nil {
 		msg := fmt.Sprintf("Could not analyze layer %s, moving on: %v", layerIDs[0], err)
 		sendScanLogsToLogstash(msg, "WARN")
@@ -1265,18 +1275,51 @@ func main() {
 		}
 	}()
 
+	var manifestItem *manifestItem
+	if imageName != "host" {
+		manifestItem = saveContainerImage(imageName, imageTarPath, imageId)
+	}
+
+	// language scan
+	if len(scanTypes) != 0 {
+		if updateDepCheckData {
+			depCheckErrMsg := checkDependencyData()
+			if depCheckErrMsg != "" {
+				logErrorAndExit(depCheckErrMsg)
+			}
+			fmt.Printf("Dependency data downloaded. Proceeding\n")
+		}
+
+		vulnerabilityDataPresent := true
+		fileFd, err := os.Open(depcheckDataDir)
+		if err != nil {
+			vulnerabilityDataPresent = false
+		} else {
+			_, err := fileFd.Readdir(1)
+			if err == io.EOF {
+				vulnerabilityDataPresent = false
+			}
+		}
+		if !vulnerabilityDataPresent {
+			sendScanLogsToLogstash("Language vulnerability database not yet updated. Results may be incomplete", "WARN")
+		} else {
+			// Scans for different languages
+			for _, scanLang := range scanTypes {
+				errVal = getLanguageVulnerabilities(scanLang, fileSet)
+				if errVal != "" {
+					sendScanLogsToLogstash(errVal, "WARN")
+				}
+			}
+		}
+	}
+
 	// base scan
 	if imageName == "host" {
 		isHostScan = true
 		hostMountPath = strings.Replace(imageTarPath, "layer.tar", "", -1)
 		getHostVulnerabilities(hostName, imageTarPath)
 	} else {
-		getContainerVulnerabilities(imageName, imageTarPath, imageId)
-	}
-
-	if len(scanTypes) == 0 {
-		completeScan()
-		return
+		getContainerVulnerabilities(imageName, imageTarPath, imageId, manifestItem)
 	}
 
 	fileSystemsDir := "/data/fileSystems/"
@@ -1310,44 +1353,5 @@ func main() {
 		deleteFiles(fileSystemsDir, "*.tar")
 	}
 
-	// language scan
-	if updateDepCheckData {
-		//fmt.Printf("Now trying to lock access to dependency data \n")
-		//if runtime.GOOS == "windows" {
-		//	lockFileName = windowsSysTempDir + "/depcheck-download.lock"
-		//}
-		//lock := fslock.New(lockFileName)
-		//if lock.Lock() != nil {
-		//	return
-		//}
-		depCheckErrMsg := checkDependencyData()
-		//lock.Unlock()
-		if depCheckErrMsg != "" {
-			logErrorAndExit(depCheckErrMsg)
-		}
-		fmt.Printf("Dependency data downloaded. Proceeding\n")
-	}
-
-	vulnerabilityDataPresent := true
-	fileFd, err := os.Open(depcheckDataDir)
-	if err != nil {
-		vulnerabilityDataPresent = false
-	} else {
-		_, err := fileFd.Readdir(1)
-		if err == io.EOF {
-			vulnerabilityDataPresent = false
-		}
-	}
-	if !vulnerabilityDataPresent {
-		sendScanLogsToLogstash("Language vulnerability database not yet updated. Results may be incomplete", "WARN")
-	} else {
-		// Scans for different languages
-		for _, scanLang := range scanTypes {
-			errVal = getLanguageVulnerabilities(scanLang, fileSet)
-			if errVal != "" {
-				sendScanLogsToLogstash(errVal, "WARN")
-			}
-		}
-	}
 	completeScan()
 }

--- a/deepfence_ui/app/scripts/components/node-details/cve-scan-form.js
+++ b/deepfence_ui/app/scripts/components/node-details/cve-scan-form.js
@@ -11,7 +11,7 @@ const renderCheckboxGroupField = ({input, meta, options}) => {
   const {touched, error} = meta;
   const inputValue = input.value;
 
-  const checkboxes = options.map(({label, value, disabled, defaultChecked}, index) => {
+  const checkboxes = options.map(({label, value, disabled}, index) => {
     const handleChange = (event) => {
       const arr = [...inputValue];
       if (event.target.checked) {
@@ -22,20 +22,14 @@ const renderCheckboxGroupField = ({input, meta, options}) => {
       return onChange(arr);
     };
     const checked = inputValue.includes(value);
-    const checkedAtt = {};
-    if (defaultChecked) {
-      checkedAtt.defaultChecked = true;
-      checkedAtt.checked = true;
-    } else {
-      checkedAtt.checked = checked;
-    }
     return (
       <div className="df-checkbox-button" key={label}>
         <input
           type="checkbox"
           name={`${name}[${index}]`}
+          id={`${name}[${index}]`}
           value={value}
-          {...checkedAtt}
+          checked={checked}
           onChange={handleChange}
           disabled={disabled}
         />
@@ -216,6 +210,6 @@ function mapStateToProps(state) {
 export default reduxForm({
   form: 'cve-scan',
   initialValues: Map({
-    scanType: ['base'],
+    scanType: ['base', 'java'],
   }),
 })(connect(mapStateToProps)(CVEScanForm));

--- a/deepfence_ui/app/scripts/components/node-details/cve-scan-form.js
+++ b/deepfence_ui/app/scripts/components/node-details/cve-scan-form.js
@@ -11,7 +11,7 @@ const renderCheckboxGroupField = ({input, meta, options}) => {
   const {touched, error} = meta;
   const inputValue = input.value;
 
-  const checkboxes = options.map(({label, value, disabled}, index) => {
+  const checkboxes = options.map(({label, value, disabled, defaultChecked}, index) => {
     const handleChange = (event) => {
       const arr = [...inputValue];
       if (event.target.checked) {
@@ -22,13 +22,20 @@ const renderCheckboxGroupField = ({input, meta, options}) => {
       return onChange(arr);
     };
     const checked = inputValue.includes(value);
+    const checkedAtt = {};
+    if (defaultChecked) {
+      checkedAtt.defaultChecked = true;
+      checkedAtt.checked = true;
+    } else {
+      checkedAtt.checked = checked;
+    }
     return (
       <div className="df-checkbox-button" key={label}>
         <input
           type="checkbox"
           name={`${name}[${index}]`}
           value={value}
-          checked={checked}
+          {...checkedAtt}
           onChange={handleChange}
           disabled={disabled}
         />
@@ -67,7 +74,7 @@ class CVEScanForm extends React.PureComponent {
       if (newProps.toggleAll) {
         change('scanType', CVE_SCAN_TYPE_OPTIONS.map(el => el.value));
       } else {
-        change('scanType', ['base']);
+        change('scanType', ['base', 'java']);
       }
     }
   }

--- a/deepfence_ui/app/scripts/components/vulnerability-view/registry-scan/cve-scan-form.js
+++ b/deepfence_ui/app/scripts/components/vulnerability-view/registry-scan/cve-scan-form.js
@@ -15,7 +15,7 @@ const renderCheckboxGroupField = ({input, meta, options}) => {
   const {touched, error} = meta;
   const inputValue = input.value;
 
-  const checkboxes = options.map(({label, value, disabled, defaultChecked}, index) => {
+  const checkboxes = options.map(({label, value, disabled}, index) => {
     const handleChange = (event) => {
       const arr = [...inputValue];
       if (event.target.checked) {
@@ -26,19 +26,14 @@ const renderCheckboxGroupField = ({input, meta, options}) => {
       return onChange(arr);
     };
     const checked = inputValue.includes(value);
-    const checkedAtt = {};
-    if (defaultChecked) {
-      checkedAtt.defaultChecked = true;
-    } else {
-      checkedAtt.checked = checked;
-    }
     return (
-      <div className="df-checkbox-button" key="label">
+      <div className="df-checkbox-button" key={label}>
         <input
           type="checkbox"
           name={`${name}[${index}]`}
+          id={`${name}[${index}]`}
           value={value}
-          {...checkedAtt}
+          checked={checked}
           onChange={handleChange}
           disabled={disabled}
         />
@@ -221,7 +216,7 @@ const mapStateToProps = state => ({
 export default reduxForm({
   form: 'cve-scan',
   initialValues: Map({
-    scanType: ['base'],
+    scanType: ['base', 'java'],
   }),
 })(connect(mapStateToProps, {
   clearScanContainerImageRegistryAction,

--- a/deepfence_ui/app/scripts/components/vulnerability-view/registry-scan/cve-scan-form.js
+++ b/deepfence_ui/app/scripts/components/vulnerability-view/registry-scan/cve-scan-form.js
@@ -15,7 +15,7 @@ const renderCheckboxGroupField = ({input, meta, options}) => {
   const {touched, error} = meta;
   const inputValue = input.value;
 
-  const checkboxes = options.map(({label, value, disabled}, index) => {
+  const checkboxes = options.map(({label, value, disabled, defaultChecked}, index) => {
     const handleChange = (event) => {
       const arr = [...inputValue];
       if (event.target.checked) {
@@ -26,13 +26,19 @@ const renderCheckboxGroupField = ({input, meta, options}) => {
       return onChange(arr);
     };
     const checked = inputValue.includes(value);
+    const checkedAtt = {};
+    if (defaultChecked) {
+      checkedAtt.defaultChecked = true;
+    } else {
+      checkedAtt.checked = checked;
+    }
     return (
       <div className="df-checkbox-button" key="label">
         <input
           type="checkbox"
           name={`${name}[${index}]`}
           value={value}
-          checked={checked}
+          {...checkedAtt}
           onChange={handleChange}
           disabled={disabled}
         />
@@ -74,7 +80,7 @@ class CVEScanForm extends React.PureComponent {
       if (newProps.toggleAll) {
         change('scanType', CVE_SCAN_TYPE_OPTIONS.map(el => el.value));
       } else {
-        change('scanType', ['base']);
+        change('scanType', ['base', 'java']);
       }
     }
   }

--- a/deepfence_ui/app/scripts/constants/menu-collection.js
+++ b/deepfence_ui/app/scripts/constants/menu-collection.js
@@ -109,7 +109,6 @@ export const CVE_SCAN_TYPE_OPTIONS = [
   {
     value: 'java',
     label: 'Java',
-    defaultChecked: true,
   },
   {
     value: 'js',

--- a/deepfence_ui/app/scripts/constants/menu-collection.js
+++ b/deepfence_ui/app/scripts/constants/menu-collection.js
@@ -109,6 +109,7 @@ export const CVE_SCAN_TYPE_OPTIONS = [
   {
     value: 'java',
     label: 'Java',
+    defaultChecked: true,
   },
   {
     value: 'js',


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- Change the order of scans to let language scans run first as language vulnerability data is downloaded first on a fresh console.
- Make Java as default in vulnerability scan options
-

@deepfence/engineering
