### PR TITLE
Move fileset before language scan

### DIFF
--- a/deepfence_console/deepaudit/go.mod
+++ b/deepfence_console/deepaudit/go.mod
@@ -3,7 +3,7 @@ module github.com/deepfence/deepfence_console/deepaudit
 go 1.17
 
 require (
-	github.com/deepfence/vessel v0.4.4
+	github.com/deepfence/vessel v0.5.0
 	github.com/juju/fslock v0.0.0-20160525022230-4d5c94c67b4b
 )
 

--- a/deepfence_console/deepaudit/go.sum
+++ b/deepfence_console/deepaudit/go.sum
@@ -221,8 +221,8 @@ github.com/d2g/hardwareaddr v0.0.0-20190221164911-e7d9fbe030e4/go.mod h1:bMl4RjI
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deepfence/vessel v0.4.4 h1:nKQQH2z/JOI4rZZbmdojFlN3/+Hz8/IG9mQ73VVudcY=
-github.com/deepfence/vessel v0.4.4/go.mod h1:y3xYKNKrZ8R81ZXrFNIEC2xgPXSA/ytCL0OW1nUf898=
+github.com/deepfence/vessel v0.5.0 h1:dN5r8JFz7XofRi7LBU9ARF5J1SK1sT2wZrOy0Q3TBSY=
+github.com/deepfence/vessel v0.5.0/go.mod h1:y3xYKNKrZ8R81ZXrFNIEC2xgPXSA/ytCL0OW1nUf898=
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
 github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:
- Fileset creation moved before language scans, since it is required by language scans
- Updated deepfence/vessel version to allow correct image id from docker create

@deepfence/engineering
