### PR TITLE
Added retries to check for report generation before download

### DIFF
--- a/deepfence_ui/app/scripts/components/vulnerability-view/cve-image-report-container.js
+++ b/deepfence_ui/app/scripts/components/vulnerability-view/cve-image-report-container.js
@@ -47,6 +47,10 @@ class CVEImageReportContainer extends React.PureComponent {
         const fetchReportStatus = dispatch(reportDownloadStatusAction());
         fetchReportStatus.then(async res => {
           if (res.data[0]) {
+            let tries = 0
+            const totalTries = 3
+            while (tries < totalTries){
+            // ==========================
             await new Promise(resolve => setTimeout(resolve, 2000));
             const downloadReport = dispatch(
               downloadReportAction({
@@ -56,10 +60,17 @@ class CVEImageReportContainer extends React.PureComponent {
             downloadReport.then(res => {
               if (!res) {
                 dispatch(toaster('Dowloading ...'));
+                tries = 3
+              } else if(tries + 1 < totalTries){
+                dispatch(toaster('File not generated yet, Trying again ..'));
+                tries = tries + 1
               } else {
-                dispatch(toaster('File not available, Try again Later'));
+                dispatch(toaster('File generation failed, Try again later'));
+                tries = tries + 1
               }
             });
+            // ==========================
+            }
           } else {
             dispatch(toaster('Report generation status failed'));
           }


### PR DESCRIPTION

Changes proposed in this pull request:
- Added retries to report generation on the vulnerability page

@deepfence/engineering
