### PR TITLE
"Agent" is replaced by "Sensor" in topology metadata deepfence/enterp…

### DIFF
--- a/deepfence_agent/tools/apache/scope/probe/host/reporter.go
+++ b/deepfence_agent/tools/apache/scope/probe/host/reporter.go
@@ -87,9 +87,9 @@ var (
 		k8sClusterId:   {ID: k8sClusterId, Label: "Kubernetes Cluster Id", From: report.FromLatest, Priority: 25},
 		k8sClusterName: {ID: k8sClusterName, Label: "Kubernetes Cluster Name", From: report.FromLatest, Priority: 26},
 		UserDfndTags:   {ID: UserDfndTags, Label: "User Defined Tags", From: report.FromLatest, Priority: 27},
-		AgentVersion:   {ID: AgentVersion, Label: "Agent Version", From: report.FromLatest, Priority: 28},
+		AgentVersion:   {ID: AgentVersion, Label: "Sensor Version", From: report.FromLatest, Priority: 28},
 		IsUiVm:         {ID: IsUiVm, Label: "UI vm", From: report.FromLatest, Priority: 29},
-		AgentRunning:   {ID: AgentRunning, Label: "Agent", From: report.FromLatest, Priority: 33},
+		AgentRunning:   {ID: AgentRunning, Label: "Sensor", From: report.FromLatest, Priority: 33},
 	}
 
 	MetricTemplates = report.MetricTemplates{

--- a/deepfence_backend/tasks/cloud_discovery_task.py
+++ b/deepfence_backend/tasks/cloud_discovery_task.py
@@ -23,7 +23,7 @@ def fetch_vm_resources(cloud_discovery, cloud_provider):
         return
     if not cloud_data:
         return
-    probe_version = "3.3.19"
+    probe_version = "1.2.0"
     probe_report = {
         "Host": {
             "shape": "circle", "label": "host", "label_plural": "hosts", "nodes": {}, "controls": {},

--- a/deepfence_backend/tasks/cloud_discovery_task.py
+++ b/deepfence_backend/tasks/cloud_discovery_task.py
@@ -28,7 +28,7 @@ def fetch_vm_resources(cloud_discovery, cloud_provider):
         "Host": {
             "shape": "circle", "label": "host", "label_plural": "hosts", "nodes": {}, "controls": {},
             "metadata_templates": {
-                "version": {"id": "version", "label": "Agent Version", "priority": 27.0, "from": "latest"},
+                "version": {"id": "version", "label": "Sensor Version", "priority": 27.0, "from": "latest"},
                 "kubernetes_cluster_name": {"id": "kubernetes_cluster_name", "label": "Kubernetes Cluster Name",
                                             "priority": 25.0, "from": "latest"},
                 "interfaceNames": {"id": "interfaceNames", "label": "Interface Names", "priority": 15.0,
@@ -54,7 +54,7 @@ def fetch_vm_resources(cloud_discovery, cloud_provider):
                 "user_defined_tags": {"id": "user_defined_tags", "label": "User Defined Tags", "priority": 26.0,
                                       "from": "latest"},
                 "cloud_tags": {"id": "cloud_tags", "label": "Cloud Tags", "priority": 32.0, "from": "latest"},
-                "agent_running": {"id": "agent_running", "label": "Agent", "priority": 33.0, "from": "latest"},
+                "agent_running": {"id": "agent_running", "label": "Sensor", "priority": 33.0, "from": "latest"},
             },
             "metric_templates": {}
         }

--- a/deepfence_backend/websocket_api/scope_websocket_client/node_utils.go
+++ b/deepfence_backend/websocket_api/scope_websocket_client/node_utils.go
@@ -339,7 +339,7 @@ func (wsCli *WebsocketClient) formatTopologyHostData() {
 		topologyFilters = append(topologyFilters, TopologyFilterOption{Name: "user_defined_tags", Label: "User Defined Tags", Type: filterTypeStr, Options: filtersUserDefinedTags, NumberOptions: nil})
 	}
 	if len(filtersAgentVersion) > 0 {
-		topologyFilters = append(topologyFilters, TopologyFilterOption{Name: "version", Label: "Agent Version", Type: filterTypeStr, Options: filtersAgentVersion, NumberOptions: nil})
+		topologyFilters = append(topologyFilters, TopologyFilterOption{Name: "version", Label: "Sensor Version", Type: filterTypeStr, Options: filtersAgentVersion, NumberOptions: nil})
 	}
 	topologyFiltersJson, _ := JsonEncode(topologyFilters)
 	_, err = redisConn.Do("SETEX", wsCli.filterRedisKey, RedisExpiryTime, string(topologyFiltersJson))


### PR DESCRIPTION
…rise-roadmap#1377

Fixes #  "Agent" is replaced by "Sensor" in topology metadata 

Changes proposed in this pull request:
- replace Agent reference with sensors

@deepfence/engineering
