### PR TITLE
Disable topology graph edge colors

### DIFF
--- a/deepfence_ui/app/scripts/components/multi-cloud/update.js
+++ b/deepfence_ui/app/scripts/components/multi-cloud/update.js
@@ -47,7 +47,7 @@ const cloudInfo = () => {
       fill: color || COLORS.NODE,
     },
     edgeStyle: {
-      stroke: color || COLORS.EDGE,
+      stroke: COLORS.EDGE,
     },
   };
 };


### PR DESCRIPTION
Changes proposed in this pull request:
- Topology graph now uses same colors for all edges.

@deepfence/engineering
