### PR TITLE
Remove ioutil package functions in favor of io and os package functions

### DIFF
--- a/deepfence_agent/fileuploader/fileUploader.go
+++ b/deepfence_agent/fileuploader/fileUploader.go
@@ -16,7 +16,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net"
 	"net/http"
@@ -129,7 +128,7 @@ func addNfsMountsToSkipDirs() {
 	outputFileName := dfInstallDir + "/tmp/nfs-mounts.txt"
 	cmdFileName := dfInstallDir + "/tmp/get-nfs.sh"
 	nfsCmd := fmt.Sprintf("findmnt -l -t nfs4 -n --output=TARGET > %s", outputFileName)
-	errVal := ioutil.WriteFile(cmdFileName, []byte(nfsCmd), 0600)
+	errVal := os.WriteFile(cmdFileName, []byte(nfsCmd), 0600)
 	if errVal != nil {
 		fmt.Printf("Error while writing nfs command %s \n", errVal.Error())
 		return
@@ -235,7 +234,7 @@ func buildClient() (*http.Client, error) {
 	}
 
 	// Load our trusted certificate path
-	pemData, err := ioutil.ReadFile(certPath)
+	pemData, err := os.ReadFile(certPath)
 	if err != nil {
 		return nil, err
 	}
@@ -379,31 +378,31 @@ func buildFileList(sourceDir string) error {
 	if err != nil {
 		return err
 	}
-	writeErr := ioutil.WriteFile(javaFiles, []byte(javaNames), 0600)
+	writeErr := os.WriteFile(javaFiles, []byte(javaNames), 0600)
 	if writeErr != nil {
 		fmt.Printf("Error while writing java files list %s\n", writeErr.Error())
 	}
-	writeErr = ioutil.WriteFile(jsFiles, []byte(jsNames), 0600)
+	writeErr = os.WriteFile(jsFiles, []byte(jsNames), 0600)
 	if writeErr != nil {
 		fmt.Printf("Error while writing js files list %s\n", writeErr.Error())
 	}
-	writeErr = ioutil.WriteFile(rubyFiles, []byte(rubyNames), 0600)
+	writeErr = os.WriteFile(rubyFiles, []byte(rubyNames), 0600)
 	if writeErr != nil {
 		fmt.Printf("Error while writing ruby files list %s\n", writeErr.Error())
 	}
-	writeErr = ioutil.WriteFile(pythonFiles, []byte(pythonNames), 0600)
+	writeErr = os.WriteFile(pythonFiles, []byte(pythonNames), 0600)
 	if writeErr != nil {
 		fmt.Printf("Error while writing python files list %s\n", writeErr.Error())
 	}
-	writeErr = ioutil.WriteFile(phpFiles, []byte(phpNames), 0600)
+	writeErr = os.WriteFile(phpFiles, []byte(phpNames), 0600)
 	if writeErr != nil {
 		fmt.Printf("Error while writing php files list %s\n", writeErr.Error())
 	}
-	writeErr = ioutil.WriteFile(nodejsFiles, []byte(nodejsNames), 0600)
+	writeErr = os.WriteFile(nodejsFiles, []byte(nodejsNames), 0600)
 	if writeErr != nil {
 		fmt.Printf("Error while writing nodejs files list %s\n", writeErr.Error())
 	}
-	writeErr = ioutil.WriteFile(dotnetFiles, []byte(dotnetNames), 0600)
+	writeErr = os.WriteFile(dotnetFiles, []byte(dotnetNames), 0600)
 	if writeErr != nil {
 		fmt.Printf("Error while writing dotnet files list %s\n", writeErr.Error())
 	}
@@ -453,7 +452,7 @@ func createAndUploadLanguageFiles(dstPath string, language string) error {
 		srcFileName = dotnetFiles
 	}
 	tarCmd := fmt.Sprintf("%s/bin/tar -rf %s -P --transform='s,%s,,' --files-from %s ", dfInstallDir, localFileName, mountPoint, srcFileName)
-	errVal := ioutil.WriteFile(tmpTarFile, []byte(tarCmd), 0600)
+	errVal := os.WriteFile(tmpTarFile, []byte(tarCmd), 0600)
 	if errVal != nil {
 		fmt.Println(errVal.Error())
 		return errVal
@@ -486,7 +485,7 @@ func getTmpScanId(scanId string) string {
 func uploadImageData(imageName string) (string, error) {
 	var errVal error
 	destFileName := "/data/cve-scan-upload/" + hostname + "/" + sanitizedScanId + "/layer.tar"
-	outputDir, outputErr := ioutil.TempDir("", sanitizedScanId)
+	outputDir, outputErr := os.MkdirTemp("", sanitizedScanId)
 	if outputErr != nil {
 		return outputDir, errVal
 	}

--- a/deepfence_agent/misc/deepfence/df-utils/cloud_metadata/cloud_metadata.go
+++ b/deepfence_agent/misc/deepfence/df-utils/cloud_metadata/cloud_metadata.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -38,7 +38,7 @@ func GetHTTPResponse(client *http.Client, method string, url string, body io.Rea
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusOK {
-		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return "", err
 		}
@@ -107,13 +107,13 @@ func GetAWSMetadata(onlyValidate bool) (CloudMetadata, error) {
 		if strings.HasPrefix(instanceID, "i-") && strings.HasPrefix(imageId, "ami-") {
 			return nil
 		}
-		sysVendor, err := ioutil.ReadFile("/sys/class/dmi/id/sys_vendor")
+		sysVendor, err := os.ReadFile("/sys/class/dmi/id/sys_vendor")
 		if err == nil {
 			if strings.Contains(string(sysVendor), "Amazon") {
 				return nil
 			}
 		}
-		productVersion, err := ioutil.ReadFile("/sys/class/dmi/id/product_version")
+		productVersion, err := os.ReadFile("/sys/class/dmi/id/product_version")
 		if err == nil {
 			if strings.Contains(string(productVersion), "amazon") {
 				return nil
@@ -171,7 +171,7 @@ func GetGoogleCloudMetadata(onlyValidate bool) (CloudMetadata, error) {
 		return gcpMetadata, err
 	}
 	verifyIfGcp := func() error {
-		productName, err := ioutil.ReadFile("/sys/class/dmi/id/product_name")
+		productName, err := os.ReadFile("/sys/class/dmi/id/product_name")
 		if err != nil {
 			return incorrectMetadataError
 		}
@@ -216,7 +216,7 @@ func GetAzureMetadata(onlyValidate bool) (CloudMetadata, error) {
 	client := &http.Client{Timeout: 10 * time.Second}
 	azureMetadata := CloudMetadata{CloudProvider: "azure"}
 	verifyIfAzure := func() error {
-		sysVendor, err := ioutil.ReadFile("/sys/class/dmi/id/sys_vendor")
+		sysVendor, err := os.ReadFile("/sys/class/dmi/id/sys_vendor")
 		if err != nil {
 			return incorrectMetadataError
 		}
@@ -268,7 +268,7 @@ func GetDigitalOceanMetadata(onlyValidate bool) (CloudMetadata, error) {
 		if dropletID == 0 {
 			return incorrectMetadataError
 		}
-		sysVendor, err := ioutil.ReadFile("/sys/class/dmi/id/sys_vendor")
+		sysVendor, err := os.ReadFile("/sys/class/dmi/id/sys_vendor")
 		if err != nil {
 			return incorrectMetadataError
 		}

--- a/deepfence_agent/misc/deepfence/df-utils/utils.go
+++ b/deepfence_agent/misc/deepfence/df-utils/utils.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/weaveworks/scope/common/hostname"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -78,7 +78,7 @@ func BuildHttpClientWithCert(certPath string) (*http.Client, error) {
 	client := &http.Client{Transport: transport}
 
 	// Load our trusted certificate path
-	pemData, err := ioutil.ReadFile(certPath)
+	pemData, err := os.ReadFile(certPath)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +111,7 @@ func GetKubernetesClusterId() string {
 		if err == nil {
 			defer resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
-				bodyBytes, err := ioutil.ReadAll(resp.Body)
+				bodyBytes, err := io.ReadAll(resp.Body)
 				if err == nil {
 					var kubeSystemNamespaceDetails k8sNamespaceDetails
 					err = json.Unmarshal(bodyBytes, &kubeSystemNamespaceDetails)
@@ -184,11 +184,11 @@ type k8sNodeInfo struct {
 }
 
 func getK8sCaCert() ([]byte, []byte, error) {
-	caCert, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
+	caCert, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
 	if err != nil {
 		return nil, nil, err
 	}
-	caToken, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
+	caToken, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
 	return caCert, caToken, err
 }
 
@@ -222,7 +222,7 @@ func GetKubernetesDetails() (string, string, string, string, error) {
 		if err == nil {
 			defer resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
-				bodyBytes, err := ioutil.ReadAll(resp.Body)
+				bodyBytes, err := io.ReadAll(resp.Body)
 				if err == nil {
 					var k8sCurrentNodeInfo k8sNodeInfo
 					err = json.Unmarshal(bodyBytes, &k8sCurrentNodeInfo)

--- a/deepfence_agent/misc/deepfence/procspy/proc.go
+++ b/deepfence_agent/misc/deepfence/procspy/proc.go
@@ -7,9 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"syscall"
 	"strings"
-	"io/ioutil"
+	"syscall"
 )
 
 var (
@@ -112,7 +111,7 @@ func walkProcPid(buf *bytes.Buffer) (map[uint64]Proc, error) {
 
 // procCmdname does a pid->cmdname(binary/app) lookup.
 func procCmdname(base string) string {
-	cmdline, err := ioutil.ReadFile(filepath.Join(base, "/cmdline"))
+	cmdline, err := os.ReadFile(filepath.Join(base, "/cmdline"))
 	if err != nil {
 		return ""
 	}

--- a/deepfence_agent/tools/apache/scope/app/router_test.go
+++ b/deepfence_agent/tools/apache/scope/app/router_test.go
@@ -2,7 +2,7 @@ package app_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -63,7 +63,7 @@ func TestReportPostHandler(t *testing.T) {
 			t.Fatalf("Error posting report %v", err)
 		}
 
-		_, err = ioutil.ReadAll(resp.Body)
+		_, err = io.ReadAll(resp.Body)
 		resp.Body.Close()
 		if err != nil {
 			t.Fatalf("Error posting report: %v", err)

--- a/deepfence_agent/tools/apache/scope/app/scope_test.go
+++ b/deepfence_agent/tools/apache/scope/app/scope_test.go
@@ -3,7 +3,6 @@ package app_test
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -60,7 +59,7 @@ func checkRequest(t *testing.T, ts *httptest.Server, method, path string, body [
 		t.Fatalf("Error getting %s %s: %s", method, path, err)
 	}
 
-	body, err = ioutil.ReadAll(res.Body)
+	body, err = io.ReadAll(res.Body)
 	res.Body.Close()
 	if err != nil {
 		t.Fatalf("%s %s body read error: %s", method, path, err)

--- a/deepfence_agent/tools/apache/scope/extras/example/searchapp/app.go
+++ b/deepfence_agent/tools/apache/scope/extras/example/searchapp/app.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -72,7 +71,7 @@ func get(target string) {
 	}
 	defer resp.Body.Close()
 	log.Printf("%s: %s", target, resp.Status)
-	if _, err := io.Copy(ioutil.Discard, resp.Body); err != nil {
+	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
 		log.Printf("%s: %v", target, err)
 		return
 	}

--- a/deepfence_agent/tools/apache/scope/extras/fixprobe/main.go
+++ b/deepfence_agent/tools/apache/scope/extras/fixprobe/main.go
@@ -5,9 +5,9 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/url"
+	"os"
 	"time"
 
 	"github.com/ugorji/go/codec"
@@ -36,7 +36,7 @@ func main() {
 	if *useFixture {
 		fixedReport = fixture.Report
 	} else {
-		b, err := ioutil.ReadFile(flag.Arg(0))
+		b, err := os.ReadFile(flag.Arg(0))
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/deepfence_agent/tools/apache/scope/probe/appclient/app_client.go
+++ b/deepfence_agent/tools/apache/scope/probe/appclient/app_client.go
@@ -3,7 +3,6 @@ package appclient
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/rpc"
@@ -308,7 +307,7 @@ func (c *appClient) publish(r io.Reader) error {
 		{Name: "status", Value: fmt.Sprint(resp.StatusCode)},
 	})
 	if resp.StatusCode != http.StatusOK {
-		text, _ := ioutil.ReadAll(resp.Body)
+		text, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf(resp.Status + ": " + string(text))
 	}
 	return nil

--- a/deepfence_agent/tools/apache/scope/probe/endpoint/conntrack.go
+++ b/deepfence_agent/tools/apache/scope/probe/endpoint/conntrack.go
@@ -4,6 +4,7 @@ package endpoint
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"sync"
 	"time"

--- a/deepfence_agent/tools/apache/scope/probe/endpoint/conntrack.go
+++ b/deepfence_agent/tools/apache/scope/probe/endpoint/conntrack.go
@@ -4,7 +4,6 @@ package endpoint
 
 import (
 	"fmt"
-	"io/ioutil"
 	"path/filepath"
 	"sync"
 	"time"
@@ -67,7 +66,7 @@ func newConntrackFlowWalker(useConntrack bool, procRoot string, bufferSize int, 
 var IsConntrackSupported = func(procRoot string) error {
 	// Make sure events are enabled, the conntrack CLI doesn't verify it
 	f := filepath.Join(procRoot, eventsPath)
-	contents, err := ioutil.ReadFile(f)
+	contents, err := os.ReadFile(f)
 	if err != nil {
 		return err
 	}

--- a/deepfence_agent/tools/apache/scope/probe/endpoint/ebpf.go
+++ b/deepfence_agent/tools/apache/scope/probe/endpoint/ebpf.go
@@ -164,7 +164,7 @@ func newEbpfTracker() (*EbpfTracker, error) {
 func (t *EbpfTracker) TCPEventV4(e tracer.TcpV4) {
 	if t.debugBPF {
 		debugBPFFile := "/var/run/scope/debug-bpf"
-		b, err := io.ReadFile("/var/run/scope/debug-bpf")
+		b, err := os.ReadFile("/var/run/scope/debug-bpf")
 		if err == nil && strings.TrimSpace(string(b[:])) == "stop" {
 			os.Remove(debugBPFFile)
 			log.Warnf("ebpf tracker stopped as requested by user")

--- a/deepfence_agent/tools/apache/scope/probe/endpoint/ebpf.go
+++ b/deepfence_agent/tools/apache/scope/probe/endpoint/ebpf.go
@@ -5,7 +5,6 @@ package endpoint
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"regexp"
@@ -165,7 +164,7 @@ func newEbpfTracker() (*EbpfTracker, error) {
 func (t *EbpfTracker) TCPEventV4(e tracer.TcpV4) {
 	if t.debugBPF {
 		debugBPFFile := "/var/run/scope/debug-bpf"
-		b, err := ioutil.ReadFile("/var/run/scope/debug-bpf")
+		b, err := io.ReadFile("/var/run/scope/debug-bpf")
 		if err == nil && strings.TrimSpace(string(b[:])) == "stop" {
 			os.Remove(debugBPFFile)
 			log.Warnf("ebpf tracker stopped as requested by user")

--- a/deepfence_agent/tools/apache/scope/probe/host/controls.go
+++ b/deepfence_agent/tools/apache/scope/probe/host/controls.go
@@ -2,7 +2,6 @@ package host
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -82,7 +81,7 @@ func (r *Reporter) getLogsFromAgent(req xfer.Request) xfer.Response {
 }
 
 func readFile(filepath string) ([]byte, error) {
-	return ioutil.ReadFile(filepath)
+	return os.ReadFile(filepath)
 }
 
 func getDfInstallDir() string {

--- a/deepfence_agent/tools/apache/scope/probe/host/system_linux.go
+++ b/deepfence_agent/tools/apache/scope/probe/host/system_linux.go
@@ -3,7 +3,6 @@ package host
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strconv"
@@ -60,7 +59,7 @@ var GetKernelReleaseAndVersion = func() (string, string, error) {
 
 // GetLoad returns the current load averages as metrics.
 var GetLoad = func(now time.Time) report.Metrics {
-	buf, err := ioutil.ReadFile("/proc/loadavg")
+	buf, err := os.ReadFile("/proc/loadavg")
 	if err != nil {
 		return nil
 	}
@@ -79,7 +78,7 @@ var GetLoad = func(now time.Time) report.Metrics {
 
 // GetUptime returns the uptime of the host.
 var GetUptime = func() (time.Duration, error) {
-	buf, err := ioutil.ReadFile("/proc/uptime")
+	buf, err := os.ReadFile("/proc/uptime")
 	if err != nil {
 		return 0, err
 	}

--- a/deepfence_agent/tools/apache/scope/probe/kubernetes/client.go
+++ b/deepfence_agent/tools/apache/scope/probe/kubernetes/client.go
@@ -654,7 +654,7 @@ func (c *client) GetLogs(namespaceID, podID string, containerNames []string) (io
 //	if err != nil {
 //		return nil, err
 //	}
-//	formattedObj := ioutil.NopCloser(bytes.NewReader([]byte(obj)))
+//	formattedObj := io.NopCloser(bytes.NewReader([]byte(obj)))
 //	readClosersWithLabel[formattedObj] = "describe"
 //
 //	return NewLogReadCloser(readClosersWithLabel), nil

--- a/deepfence_agent/tools/apache/scope/probe/kubernetes/logreadcloser_test.go
+++ b/deepfence_agent/tools/apache/scope/probe/kubernetes/logreadcloser_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -22,11 +21,11 @@ func TestLogReadCloser(t *testing.T) {
 	longestlabelLength := len(label0)
 
 	readClosersWithLabel := map[io.ReadCloser]string{}
-	r0 := ioutil.NopCloser(bytes.NewReader(data0))
+	r0 := io.NopCloser(bytes.NewReader(data0))
 	readClosersWithLabel[r0] = label0
-	r1 := ioutil.NopCloser(bytes.NewReader(data1))
+	r1 := io.NopCloser(bytes.NewReader(data1))
 	readClosersWithLabel[r1] = label1
-	r2 := ioutil.NopCloser(bytes.NewReader(data2))
+	r2 := io.NopCloser(bytes.NewReader(data2))
 	readClosersWithLabel[r2] = label2
 
 	l := kubernetes.NewLogReadCloser(readClosersWithLabel)

--- a/deepfence_agent/tools/apache/scope/probe/plugins/max_bytes_reader_internal_test.go
+++ b/deepfence_agent/tools/apache/scope/probe/plugins/max_bytes_reader_internal_test.go
@@ -3,13 +3,13 @@ package plugins
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 )
 
 func TestMaxBytesReaderReturnsAllDataIfSmaller(t *testing.T) {
-	result, err := ioutil.ReadAll(MaxBytesReader(ioutil.NopCloser(strings.NewReader("some data")), 1024, errors.New("test error")))
+	result, err := io.ReadAll(MaxBytesReader(io.NopCloser(strings.NewReader("some data")), 1024, errors.New("test error")))
 	if err != nil {
 		t.Error(err)
 	}
@@ -31,7 +31,7 @@ func TestMaxBytesReaderReturnsErrorIfLarger(t *testing.T) {
 		input.WriteByte(byte(i))
 	}
 
-	result, err := ioutil.ReadAll(MaxBytesReader(ioutil.NopCloser(input), 1024, errors.New("test error")))
+	result, err := io.ReadAll(MaxBytesReader(io.NopCloser(input), 1024, errors.New("test error")))
 	if err.Error() != "test error" {
 		t.Errorf("Expected error to be %q, got: %q", "test error", err.Error())
 	}
@@ -47,7 +47,7 @@ func TestMaxBytesReaderReturnsErrorIfLargerAndMassiveBufferGiven(t *testing.T) {
 	}
 
 	buffer := make([]byte, 1024+2)
-	reader := MaxBytesReader(ioutil.NopCloser(input), 1024, errors.New("test error"))
+	reader := MaxBytesReader(io.NopCloser(input), 1024, errors.New("test error"))
 
 	// First read is scoped down to the maximum
 	readCount, err := reader.Read(buffer)

--- a/deepfence_agent/tools/apache/scope/render/benchmark_test.go
+++ b/deepfence_agent/tools/apache/scope/render/benchmark_test.go
@@ -3,7 +3,7 @@ package render_test
 import (
 	"context"
 	"flag"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/ugorji/go/codec"
@@ -64,7 +64,7 @@ func loadReport() (report.Report, error) {
 		return fixture.Report, nil
 	}
 
-	b, err := ioutil.ReadFile(*benchReportFile)
+	b, err := os.ReadFile(*benchReportFile)
 	if err != nil {
 		return rpt, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/Microsoft/go-winio/backup.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/Microsoft/go-winio/backup.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"syscall"
@@ -82,7 +81,7 @@ func (r *BackupStreamReader) Next() (*BackupHeader, error) {
 				r.bytesLeft = 0
 			}
 		}
-		if _, err := io.Copy(ioutil.Discard, r); err != nil {
+		if _, err := io.Copy(io.Discard, r); err != nil {
 			return nil, err
 		}
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/aws/aws-sdk-go/aws/client/logger.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/aws/aws-sdk-go/aws/client/logger.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http/httputil"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -138,7 +137,7 @@ func logResponse(r *request.Request) {
 			req.ClientInfo.ServiceName, req.Operation.Name, string(b)))
 
 		if logBody {
-			b, err := ioutil.ReadAll(lw.buf)
+			b, err := io.ReadAll(lw.buf)
 			if err != nil {
 				lw.Logger.Log(fmt.Sprintf(logRespErrMsg,
 					req.ClientInfo.ServiceName, req.Operation.Name, err))

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/aws/aws-sdk-go/aws/corehandlers/handlers.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/aws/aws-sdk-go/aws/corehandlers/handlers.go
@@ -3,7 +3,7 @@ package corehandlers
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -145,7 +145,7 @@ func handleSendError(r *request.Request, err error) {
 			r.HTTPResponse = &http.Response{
 				StatusCode: int(code),
 				Status:     http.StatusText(int(code)),
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+				Body:       io.NopCloser(bytes.NewReader([]byte{})),
 			}
 			return
 		}
@@ -156,7 +156,7 @@ func handleSendError(r *request.Request, err error) {
 		r.HTTPResponse = &http.Response{
 			StatusCode: int(0),
 			Status:     http.StatusText(int(0)),
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+			Body:       io.NopCloser(bytes.NewReader([]byte{})),
 		}
 	}
 	// Catch all other request errors.

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/aws/aws-sdk-go/aws/session/session.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/aws/aws-sdk-go/aws/session/session.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 
@@ -424,7 +423,7 @@ func loadCustomCABundle(s *Session, bundle io.Reader) error {
 }
 
 func loadCertPool(r io.Reader) (*x509.CertPool, error) {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return nil, awserr.New("LoadCustomCABundleError",
 			"failed to read custom CA bundle PEM file", err)

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/v4.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/aws/aws-sdk-go/aws/signer/v4/v4.go
@@ -60,7 +60,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"sort"
@@ -356,7 +355,7 @@ func (v4 Signer) signWithBody(r *http.Request, body io.ReadSeeker, service, regi
 		if body != nil {
 			var ok bool
 			if reader, ok = body.(io.ReadCloser); !ok {
-				reader = ioutil.NopCloser(body)
+				reader = io.NopCloser(body)
 			}
 		}
 		r.Body = reader

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/aws/aws-sdk-go/internal/ini/ini_lexer.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/aws/aws-sdk-go/internal/ini/ini_lexer.go
@@ -3,7 +3,6 @@ package ini
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 )
@@ -57,7 +56,7 @@ type iniLexer struct{}
 // Tokenize will return a list of tokens during lexical analysis of the
 // io.Reader.
 func (l *iniLexer) Tokenize(r io.Reader) ([]Token, error) {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return nil, awserr.New(ErrCodeUnableToReadFile, "unable to read file", err)
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/aws/aws-sdk-go/private/protocol/payload.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/aws/aws-sdk-go/private/protocol/payload.go
@@ -2,7 +2,6 @@ package protocol
 
 import (
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -32,7 +31,7 @@ func (h HandlerPayloadUnmarshal) UnmarshalPayload(r io.Reader, v interface{}) er
 		HTTPResponse: &http.Response{
 			StatusCode: 200,
 			Header:     http.Header{},
-			Body:       ioutil.NopCloser(r),
+			Body:       io.NopCloser(r),
 		},
 		Data: v,
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/aws/aws-sdk-go/private/protocol/query/unmarshal_error.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/aws/aws-sdk-go/private/protocol/query/unmarshal_error.go
@@ -2,7 +2,7 @@ package query
 
 import (
 	"encoding/xml"
-	"io/ioutil"
+	"io"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -26,7 +26,7 @@ var UnmarshalErrorHandler = request.NamedHandler{Name: "awssdk.query.UnmarshalEr
 func UnmarshalError(r *request.Request) {
 	defer r.HTTPResponse.Body.Close()
 
-	bodyBytes, err := ioutil.ReadAll(r.HTTPResponse.Body)
+	bodyBytes, err := io.ReadAll(r.HTTPResponse.Body)
 	if err != nil {
 		r.Error = awserr.NewRequestFailure(
 			awserr.New("SerializationError", "failed to read from query HTTP response body", err),

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/aws/aws-sdk-go/private/protocol/rest/unmarshal.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/aws/aws-sdk-go/private/protocol/rest/unmarshal.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 	"strconv"
@@ -55,7 +54,7 @@ func unmarshalBody(r *request.Request, v reflect.Value) {
 					switch payload.Interface().(type) {
 					case []byte:
 						defer r.HTTPResponse.Body.Close()
-						b, err := ioutil.ReadAll(r.HTTPResponse.Body)
+						b, err := io.ReadAll(r.HTTPResponse.Body)
 						if err != nil {
 							r.Error = awserr.New("SerializationError", "failed to decode REST response", err)
 						} else {
@@ -63,7 +62,7 @@ func unmarshalBody(r *request.Request, v reflect.Value) {
 						}
 					case *string:
 						defer r.HTTPResponse.Body.Close()
-						b, err := ioutil.ReadAll(r.HTTPResponse.Body)
+						b, err := io.ReadAll(r.HTTPResponse.Body)
 						if err != nil {
 							r.Error = awserr.New("SerializationError", "failed to decode REST response", err)
 						} else {
@@ -75,15 +74,15 @@ func unmarshalBody(r *request.Request, v reflect.Value) {
 						case "io.ReadCloser":
 							payload.Set(reflect.ValueOf(r.HTTPResponse.Body))
 						case "io.ReadSeeker":
-							b, err := ioutil.ReadAll(r.HTTPResponse.Body)
+							b, err := io.ReadAll(r.HTTPResponse.Body)
 							if err != nil {
 								r.Error = awserr.New("SerializationError",
 									"failed to read response body", err)
 								return
 							}
-							payload.Set(reflect.ValueOf(ioutil.NopCloser(bytes.NewReader(b))))
+							payload.Set(reflect.ValueOf(io.NopCloser(bytes.NewReader(b))))
 						default:
-							io.Copy(ioutil.Discard, r.HTTPResponse.Body)
+							io.Copy(io.Discard, r.HTTPResponse.Body)
 							defer r.HTTPResponse.Body.Close()
 							r.Error = awserr.New("SerializationError",
 								"failed to decode REST response",

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/aws/aws-sdk-go/private/protocol/unmarshal.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/aws/aws-sdk-go/private/protocol/unmarshal.go
@@ -2,7 +2,6 @@ package protocol
 
 import (
 	"io"
-	"io/ioutil"
 
 	"github.com/aws/aws-sdk-go/aws/request"
 )
@@ -16,6 +15,6 @@ func UnmarshalDiscardBody(r *request.Request) {
 		return
 	}
 
-	io.Copy(ioutil.Discard, r.HTTPResponse.Body)
+	io.Copy(io.Discard, r.HTTPResponse.Body)
 	r.HTTPResponse.Body.Close()
 }

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/aws/aws-sdk-go/service/dynamodb/customizations.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/aws/aws-sdk-go/service/dynamodb/customizations.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"hash/crc32"
 	"io"
-	"io/ioutil"
 	"math"
 	"strconv"
 	"time"
@@ -96,7 +95,7 @@ func validateCRC32(r *request.Request) {
 	}
 
 	// Reset body for subsequent reads
-	r.HTTPResponse.Body = ioutil.NopCloser(bytes.NewReader(buf.Bytes()))
+	r.HTTPResponse.Body = io.NopCloser(bytes.NewReader(buf.Bytes()))
 
 	// Compute the CRC checksum
 	crc := crc32.ChecksumIEEE(buf.Bytes())

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/aws/aws-sdk-go/service/s3/bucket_location.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/aws/aws-sdk-go/service/s3/bucket_location.go
@@ -1,7 +1,7 @@
 package s3
 
 import (
-	"io/ioutil"
+	"io"
 	"regexp"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -78,7 +78,7 @@ func WithNormalizeBucketLocation(r *request.Request) {
 func buildGetBucketLocation(r *request.Request) {
 	if r.DataFilled() {
 		out := r.Data.(*GetBucketLocationOutput)
-		b, err := ioutil.ReadAll(r.HTTPResponse.Body)
+		b, err := io.ReadAll(r.HTTPResponse.Body)
 		if err != nil {
 			r.Error = awserr.New("SerializationError", "failed reading response body", err)
 			return

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/aws/aws-sdk-go/service/s3/statusok_error.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/aws/aws-sdk-go/service/s3/statusok_error.go
@@ -2,7 +2,7 @@ package s3
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -11,7 +11,7 @@ import (
 )
 
 func copyMultipartStatusOKUnmarhsalError(r *request.Request) {
-	b, err := ioutil.ReadAll(r.HTTPResponse.Body)
+	b, err := io.ReadAll(r.HTTPResponse.Body)
 	if err != nil {
 		r.Error = awserr.NewRequestFailure(
 			awserr.New("SerializationError", "unable to read response body", err),
@@ -21,7 +21,7 @@ func copyMultipartStatusOKUnmarhsalError(r *request.Request) {
 		return
 	}
 	body := bytes.NewReader(b)
-	r.HTTPResponse.Body = ioutil.NopCloser(body)
+	r.HTTPResponse.Body = io.NopCloser(body)
 	defer body.Seek(0, sdkio.SeekStart)
 
 	if body.Len() == 0 {

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/aws/aws-sdk-go/service/s3/unmarshal_error.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/aws/aws-sdk-go/service/s3/unmarshal_error.go
@@ -4,7 +4,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -21,7 +20,7 @@ type xmlErrorResponse struct {
 
 func unmarshalError(r *request.Request) {
 	defer r.HTTPResponse.Body.Close()
-	defer io.Copy(ioutil.Discard, r.HTTPResponse.Body)
+	defer io.Copy(io.Discard, r.HTTPResponse.Body)
 
 	// Bucket exists in a different region, and request needs
 	// to be made to the correct region.

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/bradfitz/gomemcache/memcache/memcache.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/bradfitz/gomemcache/memcache/memcache.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 
 	"strconv"
@@ -463,7 +462,7 @@ func parseGetResponse(r *bufio.Reader, cb func(*Item)) error {
 		if err != nil {
 			return err
 		}
-		it.Value, err = ioutil.ReadAll(io.LimitReader(r, int64(size)+2))
+		it.Value, err = io.ReadAll(io.LimitReader(r, int64(size)+2))
 		if err != nil {
 			return err
 		}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/cpuinfo.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/cpuinfo.go
@@ -1,7 +1,7 @@
 package linux
 
 import (
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -67,7 +67,7 @@ type Processor struct {
 var cpuinfoRegExp = regexp.MustCompile("([^:]*?)\\s*:\\s*(.*)$")
 
 func ReadCPUInfo(path string) (*CPUInfo, error) {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/diskstat.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/diskstat.go
@@ -1,7 +1,7 @@
 package linux
 
 import (
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -39,7 +39,7 @@ type DiskStat struct {
 // Note:
 // * Assumes a well formed file and will panic if it isn't.
 func ReadDiskStats(path string) ([]DiskStat, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/loadavg.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/loadavg.go
@@ -2,7 +2,7 @@ package linux
 
 import (
 	"errors"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 )
@@ -18,7 +18,7 @@ type LoadAvg struct {
 
 func ReadLoadAvg(path string) (*LoadAvg, error) {
 
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 
 	if err != nil {
 		return nil, err

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/meminfo.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/meminfo.go
@@ -1,7 +1,7 @@
 package linux
 
 import (
-	"io/ioutil"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -55,7 +55,7 @@ type MemInfo struct {
 }
 
 func ReadMemInfo(path string) (*MemInfo, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 
 	if err != nil {
 		return nil, err

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/net_tcp.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/net_tcp.go
@@ -1,7 +1,7 @@
 package linux
 
 import (
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 )
@@ -22,7 +22,7 @@ type NetTCPSocket struct {
 
 func ReadNetTCPSockets(path string, ip NetIPDecoder) (*NetTCPSockets, error) {
 
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 
 	if err != nil {
 		return nil, err

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/net_udp.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/net_udp.go
@@ -1,7 +1,7 @@
 package linux
 
 import (
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 )
@@ -17,7 +17,7 @@ type NetUDPSocket struct {
 
 func ReadNetUDPSockets(path string, ip NetIPDecoder) (*NetUDPSockets, error) {
 
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 
 	if err != nil {
 		return nil, err

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/netstat.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/netstat.go
@@ -1,7 +1,7 @@
 package linux
 
 import (
-	"io/ioutil"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -134,7 +134,7 @@ type NetStat struct {
 }
 
 func ReadNetStat(path string) (*NetStat, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 
 	if err != nil {
 		return nil, err

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/network_stat.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/network_stat.go
@@ -1,7 +1,7 @@
 package linux
 
 import (
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 )
@@ -27,7 +27,7 @@ type NetworkStat struct {
 }
 
 func ReadNetworkStat(path string) ([]NetworkStat, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 
 	if err != nil {
 		return nil, err

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/process_cmdline.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/process_cmdline.go
@@ -1,13 +1,13 @@
 package linux
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 )
 
 func ReadProcessCmdline(path string) (string, error) {
 
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 
 	if err != nil {
 		return "", err

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/process_io.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/process_io.go
@@ -1,7 +1,7 @@
 package linux
 
 import (
-	"io/ioutil"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -20,7 +20,7 @@ type ProcessIO struct {
 
 func ReadProcessIO(path string) (*ProcessIO, error) {
 
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 
 	if err != nil {
 		return nil, err

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/process_pid.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/process_pid.go
@@ -1,7 +1,6 @@
 package linux
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -10,7 +9,7 @@ import (
 
 func ReadMaxPID(path string) (uint64, error) {
 
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 
 	if err != nil {
 		return 0, err

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/process_stat.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/process_stat.go
@@ -1,7 +1,7 @@
 package linux
 
 import (
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -67,7 +67,7 @@ var processStatRegExp = regexp.MustCompile("^(\\d+)( \\(.*?\\) )(.*)$")
 
 func ReadProcessStat(path string) (*ProcessStat, error) {
 
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 
 	if err != nil {
 		return nil, err

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/process_statm.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/process_statm.go
@@ -1,7 +1,7 @@
 package linux
 
 import (
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 )
@@ -19,7 +19,7 @@ type ProcessStatm struct {
 
 func ReadProcessStatm(path string) (*ProcessStatm, error) {
 
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 
 	if err != nil {
 		return nil, err

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/process_status.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/process_status.go
@@ -1,7 +1,7 @@
 package linux
 
 import (
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 )
@@ -56,7 +56,7 @@ type ProcessStatus struct {
 
 func ReadProcessStatus(path string) (*ProcessStatus, error) {
 
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 
 	if err != nil {
 		return nil, err

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/sockstat.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/sockstat.go
@@ -1,7 +1,7 @@
 package linux
 
 import (
-	"io/ioutil"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -34,7 +34,7 @@ type SockStat struct {
 }
 
 func ReadSockStat(path string) (*SockStat, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 
 	if err != nil {
 		return nil, err

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/stat.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/stat.go
@@ -1,7 +1,7 @@
 package linux
 
 import (
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -65,7 +65,7 @@ func createCPUStat(fields []string) *CPUStat {
 }
 
 func ReadStat(path string) (*Stat, error) {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/uptime.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/uptime.go
@@ -1,7 +1,7 @@
 package linux
 
 import (
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -27,7 +27,7 @@ func (self *Uptime) CalculateIdle() float64 {
 }
 
 func ReadUptime(path string) (*Uptime, error) {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/vmstat.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/c9s/goprocinfo/linux/vmstat.go
@@ -1,7 +1,7 @@
 package linux
 
 import (
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 )
@@ -124,7 +124,7 @@ type VMStat struct {
 }
 
 func ReadVMStat(path string) (*VMStat, error) {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/deepfence/df-utils/cloud_metadata/cloud_metadata.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/deepfence/df-utils/cloud_metadata/cloud_metadata.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -38,7 +38,7 @@ func GetHTTPResponse(client *http.Client, method string, url string, body io.Rea
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusOK {
-		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return "", err
 		}
@@ -107,13 +107,13 @@ func GetAWSMetadata(onlyValidate bool) (CloudMetadata, error) {
 		if strings.HasPrefix(instanceID, "i-") && strings.HasPrefix(imageId, "ami-") {
 			return nil
 		}
-		sysVendor, err := ioutil.ReadFile("/sys/class/dmi/id/sys_vendor")
+		sysVendor, err := os.ReadFile("/sys/class/dmi/id/sys_vendor")
 		if err == nil {
 			if strings.Contains(string(sysVendor), "Amazon") {
 				return nil
 			}
 		}
-		productVersion, err := ioutil.ReadFile("/sys/class/dmi/id/product_version")
+		productVersion, err := os.ReadFile("/sys/class/dmi/id/product_version")
 		if err == nil {
 			if strings.Contains(string(productVersion), "amazon") {
 				return nil
@@ -171,7 +171,7 @@ func GetGoogleCloudMetadata(onlyValidate bool) (CloudMetadata, error) {
 		return gcpMetadata, err
 	}
 	verifyIfGcp := func() error {
-		productName, err := ioutil.ReadFile("/sys/class/dmi/id/product_name")
+		productName, err := os.ReadFile("/sys/class/dmi/id/product_name")
 		if err != nil {
 			return incorrectMetadataError
 		}
@@ -216,7 +216,7 @@ func GetAzureMetadata(onlyValidate bool) (CloudMetadata, error) {
 	client := &http.Client{Timeout: 10 * time.Second}
 	azureMetadata := CloudMetadata{CloudProvider: "azure"}
 	verifyIfAzure := func() error {
-		sysVendor, err := ioutil.ReadFile("/sys/class/dmi/id/sys_vendor")
+		sysVendor, err := os.ReadFile("/sys/class/dmi/id/sys_vendor")
 		if err != nil {
 			return incorrectMetadataError
 		}
@@ -268,7 +268,7 @@ func GetDigitalOceanMetadata(onlyValidate bool) (CloudMetadata, error) {
 		if dropletID == 0 {
 			return incorrectMetadataError
 		}
-		sysVendor, err := ioutil.ReadFile("/sys/class/dmi/id/sys_vendor")
+		sysVendor, err := os.ReadFile("/sys/class/dmi/id/sys_vendor")
 		if err != nil {
 			return incorrectMetadataError
 		}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/deepfence/df-utils/utils.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/deepfence/df-utils/utils.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/weaveworks/scope/common/hostname"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -78,7 +78,7 @@ func BuildHttpClientWithCert(certPath string) (*http.Client, error) {
 	client := &http.Client{Transport: transport}
 
 	// Load our trusted certificate path
-	pemData, err := ioutil.ReadFile(certPath)
+	pemData, err := os.ReadFile(certPath)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +111,7 @@ func GetKubernetesClusterId() string {
 		if err == nil {
 			defer resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
-				bodyBytes, err := ioutil.ReadAll(resp.Body)
+				bodyBytes, err := io.ReadAll(resp.Body)
 				if err == nil {
 					var kubeSystemNamespaceDetails k8sNamespaceDetails
 					err = json.Unmarshal(bodyBytes, &kubeSystemNamespaceDetails)
@@ -184,11 +184,11 @@ type k8sNodeInfo struct {
 }
 
 func getK8sCaCert() ([]byte, []byte, error) {
-	caCert, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
+	caCert, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
 	if err != nil {
 		return nil, nil, err
 	}
-	caToken, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
+	caToken, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
 	return caCert, caToken, err
 }
 
@@ -222,7 +222,7 @@ func GetKubernetesDetails() (string, string, string, string, error) {
 		if err == nil {
 			defer resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
-				bodyBytes, err := ioutil.ReadAll(resp.Body)
+				bodyBytes, err := io.ReadAll(resp.Body)
 				if err == nil {
 					var k8sCurrentNodeInfo k8sNodeInfo
 					err = json.Unmarshal(bodyBytes, &k8sCurrentNodeInfo)

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/deepfence/procspy/proc.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/deepfence/procspy/proc.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"syscall"
 	"strings"
-	"io/ioutil"
 )
 
 var (
@@ -112,7 +111,7 @@ func walkProcPid(buf *bytes.Buffer) (map[uint64]Proc, error) {
 
 // procCmdname does a pid->cmdname(binary/app) lookup.
 func procCmdname(base string) string {
-	cmdline, err := ioutil.ReadFile(filepath.Join(base, "/cmdline"))
+	cmdline, err := os.ReadFile(filepath.Join(base, "/cmdline"))
 	if err != nil {
 		return ""
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/docker/docker/pkg/fileutils/fileutils_unix.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/docker/docker/pkg/fileutils/fileutils_unix.go
@@ -4,7 +4,6 @@ package fileutils // import "github.com/docker/docker/pkg/fileutils"
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -13,7 +12,7 @@ import (
 // GetTotalUsedFds Returns the number of used File Descriptors by
 // reading it via /proc filesystem.
 func GetTotalUsedFds() int {
-	if fds, err := ioutil.ReadDir(fmt.Sprintf("/proc/%d/fd", os.Getpid())); err != nil {
+	if fds, err := os.ReadDir(fmt.Sprintf("/proc/%d/fd", os.Getpid())); err != nil {
 		logrus.Errorf("Error opening /proc/%d/fd: %s", os.Getpid(), err)
 	} else {
 		return len(fds)

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/docker/docker/pkg/ioutils/fswriters.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/docker/docker/pkg/ioutils/fswriters.go
@@ -2,7 +2,6 @@ package ioutils // import "github.com/docker/docker/pkg/ioutils"
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -11,7 +10,7 @@ import (
 // temporary file and closing it atomically changes the temporary file to
 // destination path. Writing and closing concurrently is not allowed.
 func NewAtomicFileWriter(filename string, perm os.FileMode) (io.WriteCloser, error) {
-	f, err := ioutil.TempFile(filepath.Dir(filename), ".tmp-"+filepath.Base(filename))
+	f, err := os.CreateTemp(filepath.Dir(filename), ".tmp-"+filepath.Base(filename))
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +93,7 @@ type AtomicWriteSet struct {
 // commit. If no temporary directory is given the system
 // default is used.
 func NewAtomicWriteSet(tmpDir string) (*AtomicWriteSet, error) {
-	td, err := ioutil.TempDir(tmpDir, "write-set-")
+	td, err := os.MkdirTemp(tmpDir, "write-set-")
 	if err != nil {
 		return nil, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/docker/docker/pkg/ioutils/temp_unix.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/docker/docker/pkg/ioutils/temp_unix.go
@@ -2,9 +2,9 @@
 
 package ioutils // import "github.com/docker/docker/pkg/ioutils"
 
-import "io/ioutil"
+import "os"
 
-// TempDir on Unix systems is equivalent to ioutil.TempDir.
+// TempDir on Unix systems is equivalent to os.MkdirTemp.
 func TempDir(dir, prefix string) (string, error) {
-	return ioutil.TempDir(dir, prefix)
+	return os.MkdirTemp(dir, prefix)
 }

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/docker/docker/pkg/ioutils/temp_windows.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/docker/docker/pkg/ioutils/temp_windows.go
@@ -1,14 +1,14 @@
 package ioutils // import "github.com/docker/docker/pkg/ioutils"
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/docker/docker/pkg/longpath"
 )
 
-// TempDir is the equivalent of ioutil.TempDir, except that the result is in Windows longpath format.
+// TempDir is the equivalent of os.MkdirTemp, except that the result is in Windows longpath format.
 func TempDir(dir, prefix string) (string, error) {
-	tempDir, err := ioutil.TempDir(dir, prefix)
+	tempDir, err := os.MkdirTemp(dir, prefix)
 	if err != nil {
 		return "", err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/docker/docker/pkg/system/filesys.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/docker/docker/pkg/system/filesys.go
@@ -3,7 +3,6 @@
 package system // import "github.com/docker/docker/pkg/system"
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -24,7 +23,7 @@ func IsAbs(path string) bool {
 	return filepath.IsAbs(path)
 }
 
-// The functions below here are wrappers for the equivalents in the os and ioutils packages.
+// The functions below here are wrappers for the equivalents in the os and io packages.
 // They are passthrough on Unix platforms, and only relevant on Windows.
 
 // CreateSequential creates the named file with mode 0666 (before umask), truncating
@@ -63,5 +62,5 @@ func OpenFileSequential(name string, flag int, perm os.FileMode) (*os.File, erro
 // to find the pathname of the file. It is the caller's responsibility
 // to remove the file when no longer needed.
 func TempFileSequential(dir, prefix string) (f *os.File, err error) {
-	return ioutil.TempFile(dir, prefix)
+	return os.CreateTemp(dir, prefix)
 }

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/docker/docker/pkg/system/filesys_windows.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/docker/docker/pkg/system/filesys_windows.go
@@ -262,7 +262,7 @@ func nextSuffix() string {
 	return strconv.Itoa(int(1e9 + r%1e9))[1:]
 }
 
-// TempFileSequential is a copy of ioutil.TempFile, modified to use sequential
+// TempFileSequential is a copy of os.CreateTemp, modified to use sequential
 // file access. Below is the original comment from golang:
 // TempFile creates a new temporary file in the directory dir
 // with a name beginning with prefix, opens the file for reading

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/docker/docker/pkg/term/windows/windows.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/docker/docker/pkg/term/windows/windows.go
@@ -5,7 +5,7 @@
 package windowsconsole // import "github.com/docker/docker/pkg/term/windows"
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"sync"
 
@@ -18,7 +18,7 @@ var initOnce sync.Once
 
 func initLogger() {
 	initOnce.Do(func() {
-		logFile := ioutil.Discard
+		logFile := io.Discard
 
 		if isDebugEnv := os.Getenv(ansiterm.LogEnv); isDebugEnv == "1" {
 			logFile, _ = os.Create("ansiReaderWriter.log")

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/fsouza/go-dockerclient/auth.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/fsouza/go-dockerclient/auth.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -198,7 +197,7 @@ func (c *Client) AuthCheck(conf *AuthConfiguration) (AuthStatus, error) {
 		return authStatus, err
 	}
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return authStatus, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/fsouza/go-dockerclient/client.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/fsouza/go-dockerclient/client.go
@@ -17,7 +17,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -242,19 +241,19 @@ func NewVersionedTLSClient(endpoint string, cert, key, ca, apiVersionString stri
 	var keyPEMBlock []byte
 	var caPEMCert []byte
 	if _, err := os.Stat(cert); !os.IsNotExist(err) {
-		certPEMBlock, err = ioutil.ReadFile(cert)
+		certPEMBlock, err = os.ReadFile(cert)
 		if err != nil {
 			return nil, err
 		}
 	}
 	if _, err := os.Stat(key); !os.IsNotExist(err) {
-		keyPEMBlock, err = ioutil.ReadFile(key)
+		keyPEMBlock, err = os.ReadFile(key)
 		if err != nil {
 			return nil, err
 		}
 	}
 	if _, err := os.Stat(ca); !os.IsNotExist(err) {
-		caPEMCert, err = ioutil.ReadFile(ca)
+		caPEMCert, err = os.ReadFile(ca)
 		if err != nil {
 			return nil, err
 		}
@@ -543,10 +542,10 @@ func (c *Client) stream(method, path string, streamOptions streamOptions) error 
 	protocol := c.endpointURL.Scheme
 	address := c.endpointURL.Path
 	if streamOptions.stdout == nil {
-		streamOptions.stdout = ioutil.Discard
+		streamOptions.stdout = io.Discard
 	}
 	if streamOptions.stderr == nil {
-		streamOptions.stderr = ioutil.Discard
+		streamOptions.stderr = io.Discard
 	}
 
 	// make a sub-context so that our active cancellation does not affect parent
@@ -780,10 +779,10 @@ func (c *Client) hijack(method, path string, hijackOptions hijackOptions) (Close
 			// will "hang" until the container terminates, even though you're not reading
 			// stdout/stderr
 			if hijackOptions.stdout == nil {
-				hijackOptions.stdout = ioutil.Discard
+				hijackOptions.stdout = io.Discard
 			}
 			if hijackOptions.stderr == nil {
-				hijackOptions.stderr = ioutil.Discard
+				hijackOptions.stderr = io.Discard
 			}
 
 			go func() {
@@ -962,7 +961,7 @@ func newError(resp *http.Response) *Error {
 		Message string `json:"message"`
 	}
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return &Error{Status: resp.StatusCode, Message: fmt.Sprintf("cannot read body, err: %v", err)}
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/fsouza/go-dockerclient/plugin.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/fsouza/go-dockerclient/plugin.go
@@ -7,7 +7,7 @@ package docker
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -344,7 +344,7 @@ func (c *Client) CreatePlugin(opts CreatePluginOptions) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	containerNameBytes, err := ioutil.ReadAll(resp.Body)
+	containerNameBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/fsouza/go-dockerclient/tar.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/fsouza/go-dockerclient/tar.go
@@ -7,7 +7,6 @@ package docker
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -112,7 +111,7 @@ func validateContextDirectory(srcPath string, excludes []string) error {
 
 func parseDockerignore(root string) ([]string, error) {
 	var excludes []string
-	ignore, err := ioutil.ReadFile(path.Join(root, ".dockerignore"))
+	ignore, err := os.ReadFile(path.Join(root, ".dockerignore"))
 	if err != nil && !os.IsNotExist(err) {
 		return excludes, fmt.Errorf("error reading .dockerignore: '%s'", err)
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/gogo/protobuf/protoc-gen-gogo/descriptor/descriptor.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/gogo/protobuf/protoc-gen-gogo/descriptor/descriptor.go
@@ -40,7 +40,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"github.com/gogo/protobuf/proto"
 )
@@ -53,7 +53,7 @@ func extractFile(gz []byte) (*FileDescriptorProto, error) {
 	}
 	defer r.Close()
 
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return nil, fmt.Errorf("failed to uncompress descriptor: %v", err)
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/googleapis/gnostic/compiler/reader.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/googleapis/gnostic/compiler/reader.go
@@ -18,10 +18,11 @@ import (
 	"errors"
 	"fmt"
 	"gopkg.in/yaml.v2"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -65,7 +66,7 @@ func FetchFile(fileurl string) ([]byte, error) {
 		return nil, errors.New(fmt.Sprintf("Error downloading %s: %s", fileurl, response.Status))
 	}
 	defer response.Body.Close()
-	bytes, err = ioutil.ReadAll(response.Body)
+	bytes, err = io.ReadAll(response.Body)
 	if err == nil {
 		fileCache[fileurl] = bytes
 	}
@@ -85,7 +86,7 @@ func ReadBytesForFile(filename string) ([]byte, error) {
 		return bytes, nil
 	}
 	// no, it's a local filename
-	bytes, err := ioutil.ReadFile(filename)
+	bytes, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/googleapis/gnostic/extensions/extensions.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/googleapis/gnostic/extensions/extensions.go
@@ -16,7 +16,7 @@ package openapiextension_v1
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/golang/protobuf/proto"
@@ -27,7 +27,7 @@ type documentHandler func(version string, extensionName string, document string)
 type extensionHandler func(name string, yamlInput string) (bool, proto.Message, error)
 
 func forInputYamlFromOpenapic(handler documentHandler) {
-	data, err := ioutil.ReadAll(os.Stdin)
+	data, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		fmt.Println("File error:", err.Error())
 		os.Exit(1)

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/gorilla/websocket/client.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/gorilla/websocket/client.go
@@ -11,7 +11,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -337,11 +336,11 @@ func (d *Dialer) Dial(urlStr string, requestHeader http.Header) (*Conn, *http.Re
 		// debugging.
 		buf := make([]byte, 1024)
 		n, _ := io.ReadFull(resp.Body, buf)
-		resp.Body = ioutil.NopCloser(bytes.NewReader(buf[:n]))
+		resp.Body = io.NopCloser(bytes.NewReader(buf[:n]))
 		return nil, resp, ErrBadHandshake
 	}
 
-	resp.Body = ioutil.NopCloser(bytes.NewReader([]byte{}))
+	resp.Body = io.NopCloser(bytes.NewReader([]byte{}))
 	conn.subprotocol = resp.Header.Get("Sec-Websocket-Protocol")
 
 	netConn.SetDeadline(time.Time{})

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/gorilla/websocket/conn.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/gorilla/websocket/conn.go
@@ -9,7 +9,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"strconv"
@@ -630,7 +629,7 @@ func (c *Conn) advanceFrame() (int, error) {
 	// 1. Skip remainder of previous frame.
 
 	if c.readRemaining > 0 {
-		if _, err := io.CopyN(ioutil.Discard, c.br, c.readRemaining); err != nil {
+		if _, err := io.CopyN(io.Discard, c.br, c.readRemaining); err != nil {
 			return noFrame, err
 		}
 	}
@@ -853,7 +852,7 @@ func (c *Conn) ReadMessage() (messageType int, p []byte, err error) {
 	if err != nil {
 		return messageType, nil, err
 	}
-	p, err = ioutil.ReadAll(r)
+	p, err = io.ReadAll(r)
 	return messageType, p, err
 }
 

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/gregjones/httpcache/httpcache.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/gregjones/httpcache/httpcache.go
@@ -11,7 +11,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"strings"
@@ -234,7 +233,7 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 				R: resp.Body,
 				OnEOF: func(r io.Reader) {
 					resp := *resp
-					resp.Body = ioutil.NopCloser(r)
+					resp.Body = io.NopCloser(r)
 					respBytes, err := httputil.DumpResponse(&resp, true)
 					if err == nil {
 						t.Cache.Set(cacheKey, respBytes)

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/iovisor/gobpf/elf/kernel_version.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/iovisor/gobpf/elf/kernel_version.go
@@ -18,7 +18,7 @@ package elf
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -63,7 +63,7 @@ func currentVersionUname() (uint32, error) {
 }
 
 func currentVersionUbuntu() (uint32, error) {
-	procVersion, err := ioutil.ReadFile("/proc/version_signature")
+	procVersion, err := os.ReadFile("/proc/version_signature")
 	if err != nil {
 		return 0, err
 	}
@@ -78,7 +78,7 @@ func currentVersionUbuntu() (uint32, error) {
 var debianVersionRegex = regexp.MustCompile(`.* SMP Debian (\d+\.\d+.\d+-\d+) .*`)
 
 func currentVersionDebian() (uint32, error) {
-	procVersion, err := ioutil.ReadFile("/proc/version")
+	procVersion, err := os.ReadFile("/proc/version")
 	if err != nil {
 		return 0, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/iovisor/gobpf/elf/module.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/iovisor/gobpf/elf/module.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -189,7 +188,7 @@ func writeKprobeEvent(probeType, eventName, funcName, maxactiveStr string) (int,
 	}
 
 	kprobeIdFile := fmt.Sprintf("/sys/kernel/debug/tracing/events/kprobes/%s/id", eventName)
-	kprobeIdBytes, err := ioutil.ReadFile(kprobeIdFile)
+	kprobeIdBytes, err := os.ReadFile(kprobeIdFile)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return -1, kprobeIDNotExist
@@ -268,7 +267,7 @@ func (b *Module) EnableKprobe(secName string, maxactive int) error {
 
 func writeTracepointEvent(category, name string) (int, error) {
 	tracepointIdFile := fmt.Sprintf("/sys/kernel/debug/tracing/events/%s/%s/id", category, name)
-	tracepointIdBytes, err := ioutil.ReadFile(tracepointIdFile)
+	tracepointIdBytes, err := os.ReadFile(tracepointIdFile)
 	if err != nil {
 		return -1, fmt.Errorf("cannot read tracepoint id %q: %v", tracepointIdFile, err)
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/iovisor/gobpf/pkg/cpuonline/cpu_range.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/iovisor/gobpf/pkg/cpuonline/cpu_range.go
@@ -1,7 +1,7 @@
 package cpuonline
 
 import (
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 )
@@ -35,7 +35,7 @@ func readCPURange(cpuRangeStr string) ([]uint, error) {
 
 // Get returns a slice with the online CPUs, for example `[0, 2, 3]`
 func Get() ([]uint, error) {
-	buf, err := ioutil.ReadFile(cpuOnline)
+	buf, err := os.ReadFile(cpuOnline)
 	if err != nil {
 		return nil, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/mailru/easyjson/benchmark/data.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/mailru/easyjson/benchmark/data.go
@@ -3,10 +3,10 @@
 package benchmark
 
 import (
-	"io/ioutil"
+	"os"
 )
 
-var largeStructText, _ = ioutil.ReadFile("example.json")
+var largeStructText, _ = os.ReadFile("example.json")
 var xlStructData XLStruct
 
 func init() {

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/mailru/easyjson/bootstrap/bootstrap.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/mailru/easyjson/bootstrap/bootstrap.go
@@ -8,7 +8,6 @@ package bootstrap
 import (
 	"fmt"
 	"go/format"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -87,7 +86,7 @@ func (g *Generator) writeStub() error {
 
 // writeMain creates a .go file that launches the generator if 'go run'.
 func (g *Generator) writeMain() (path string, err error) {
-	f, err := ioutil.TempFile(filepath.Dir(g.OutName), "easyjson-bootstrap")
+	f, err := os.CreateTemp(filepath.Dir(g.OutName), "easyjson-bootstrap")
 	if err != nil {
 		return "", err
 	}
@@ -204,7 +203,7 @@ func (g *Generator) Run() error {
 	}
 
 	// format file and write to out path
-	in, err := ioutil.ReadFile(f.Name())
+	in, err := os.ReadFile(f.Name())
 	if err != nil {
 		return err
 	}
@@ -212,5 +211,5 @@ func (g *Generator) Run() error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(g.OutName, out, 0644)
+	return os.WriteFile(g.OutName, out, 0644)
 }

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/mailru/easyjson/helpers.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/mailru/easyjson/helpers.go
@@ -3,7 +3,6 @@ package easyjson
 
 import (
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"unsafe"
@@ -104,7 +103,7 @@ func Unmarshal(data []byte, v Unmarshaler) error {
 
 // UnmarshalFromReader reads all the data in the reader and decodes as JSON into the object.
 func UnmarshalFromReader(r io.Reader, v Unmarshaler) error {
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/mailru/easyjson/parser/pkgpath.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/mailru/easyjson/parser/pkgpath.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"go/build"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -111,7 +110,7 @@ func getModulePath(goModPath string) string {
 		pkgPathFromGoModCache.Unlock()
 	}()
 
-	data, err := ioutil.ReadFile(goModPath)
+	data, err := os.ReadFile(goModPath)
 	if err != nil {
 		return ""
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/mjibson/esc/embed/embed.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/mjibson/esc/embed/embed.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -152,7 +151,7 @@ func Run(conf *Config, out io.Writer) error {
 				sort.Strings(dir.ChildFileNames)
 				directories = append(directories, dir)
 			} else if includeRegexp == nil || includeRegexp.MatchString(fname) {
-				b, err := ioutil.ReadAll(f)
+				b, err := io.ReadAll(f)
 				if err != nil {
 					return errors.Wrap(err, "readAll return err")
 				}
@@ -253,7 +252,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/base64"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path"
@@ -311,7 +310,7 @@ func (_escStaticFS) prepare(name string) (*_escFile, error) {
 		if err != nil {
 			return
 		}
-		f.data, err = ioutil.ReadAll(gr)
+		f.data, err = io.ReadAll(gr)
 	})
 	if err != nil {
 		return nil, err
@@ -422,7 +421,7 @@ func {{.FunctionPrefix}}FSByte(useLocal bool, name string) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		b, err := ioutil.ReadAll(f)
+		b, err := io.ReadAll(f)
 		_ = f.Close()
 		return b, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/modern-go/concurrent/log.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/modern-go/concurrent/log.go
@@ -3,11 +3,11 @@ package concurrent
 import (
 	"os"
 	"log"
-	"io/ioutil"
+	"io"
 )
 
 // ErrorLogger is used to print out error, can be set to writer other than stderr
 var ErrorLogger = log.New(os.Stderr, "", 0)
 
 // InfoLogger is used to print informational message, default to off
-var InfoLogger = log.New(ioutil.Discard, "", 0)
+var InfoLogger = log.New(io.Discard, "", 0)

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/nats-io/nats/nats.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/nats-io/nats/nats.go
@@ -11,10 +11,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"net/url"
+	"os"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -331,7 +331,7 @@ func RootCAs(file ...string) Option {
 	return func(o *Options) error {
 		pool := x509.NewCertPool()
 		for _, f := range file {
-			rootPEM, err := ioutil.ReadFile(f)
+			rootPEM, err := os.ReadFile(f)
 			if err != nil || rootPEM == nil {
 				return fmt.Errorf("nats: error loading or parsing rootCA file: %v", err)
 			}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/olivere/elastic/v7/errors.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/olivere/elastic/v7/errors.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -45,7 +45,7 @@ func createResponseError(res *http.Response) error {
 	if res.Body == nil {
 		return &Error{Status: res.StatusCode}
 	}
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
 		return &Error{Status: res.StatusCode}
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/olivere/elastic/v7/request.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/olivere/elastic/v7/request.go
@@ -9,7 +9,6 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 )
@@ -106,7 +105,7 @@ func (r *Request) setBodyGzip(body interface{}) error {
 func (r *Request) setBodyReader(body io.Reader) error {
 	rc, ok := body.(io.ReadCloser)
 	if !ok && body != nil {
-		rc = ioutil.NopCloser(body)
+		rc = io.NopCloser(body)
 	}
 	r.Body = rc
 	if body != nil {

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/olivere/elastic/v7/response.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/olivere/elastic/v7/response.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 )
 
@@ -50,7 +49,7 @@ func (c *Client) newResponse(res *http.Response, maxBodySize int64, stream bool)
 			}
 			body = io.LimitReader(body, maxBodySize+1)
 		}
-		slurp, err := ioutil.ReadAll(body)
+		slurp, err := io.ReadAll(body)
 		if err != nil {
 			return nil, err
 		}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/paypal/ionet/ionet.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/paypal/ionet/ionet.go
@@ -15,7 +15,6 @@ package ionet
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"sync"
 	"time"
@@ -23,7 +22,7 @@ import (
 
 // Conn is a net.Conn backed by an io.Reader and an io.Writer.
 // The zero value for Conn uses a reader that always returns EOF
-// and ioutil.Discard as a writer.
+// and io.Discard as a writer.
 //
 // "Reader" and "Writer" are relative to which half of
 // the connection you are on. R and W in Conn are named from
@@ -118,7 +117,7 @@ func (c *Conn) Read(b []byte) (int, error) {
 func (c *Conn) Write(b []byte) (int, error) {
 	if c.W == nil {
 		// all writes to Discard succeed, so there's no need to wrap errors
-		return ioutil.Discard.Write(b)
+		return io.Discard.Write(b)
 	}
 
 	c.initClosing()

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/peterbourgon/diskv/diskv.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/peterbourgon/diskv/diskv.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -133,7 +132,7 @@ func (d *Diskv) createKeyFileWithLock(key string) (*os.File, error) {
 		if err := os.MkdirAll(d.TempDir, d.PathPerm); err != nil {
 			return nil, fmt.Errorf("temp mkdir: %s", err)
 		}
-		f, err := ioutil.TempFile(d.TempDir, "")
+		f, err := os.CreateTemp(d.TempDir, "")
 		if err != nil {
 			return nil, fmt.Errorf("temp file: %s", err)
 		}
@@ -268,7 +267,7 @@ func (d *Diskv) Read(key string) ([]byte, error) {
 		return []byte{}, err
 	}
 	defer rc.Close()
-	return ioutil.ReadAll(rc)
+	return io.ReadAll(rc)
 }
 
 // ReadStream reads the key and returns the value (data) as an io.ReadCloser.
@@ -291,7 +290,7 @@ func (d *Diskv) ReadStream(key string, direct bool) (io.ReadCloser, error) {
 			if d.Compression != nil {
 				return d.Compression.Reader(buf)
 			}
-			return ioutil.NopCloser(buf), nil
+			return io.NopCloser(buf), nil
 		}
 
 		go func() {
@@ -331,7 +330,7 @@ func (d *Diskv) readWithRLock(key string) (io.ReadCloser, error) {
 		r = &closingReader{f}
 	}
 
-	var rc = io.ReadCloser(ioutil.NopCloser(r))
+	var rc = io.ReadCloser(io.NopCloser(r))
 	if d.Compression != nil {
 		rc, err = d.Compression.Reader(r)
 		if err != nil {

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/pkg/errors/README.md
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/pkg/errors/README.md
@@ -16,7 +16,7 @@ which applied recursively up the call stack results in error reports without con
 
 The errors.Wrap function returns a new error that adds context to the original error. For example
 ```go
-_, err := ioutil.ReadAll(r)
+_, err := io.ReadAll(r)
 if err != nil {
         return errors.Wrap(err, "read failed")
 }

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/pkg/errors/errors.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/pkg/errors/errors.go
@@ -17,7 +17,7 @@
 // original error by recording a stack trace at the point Wrap is called,
 // together with the supplied message. For example
 //
-//     _, err := ioutil.ReadAll(r)
+//     _, err := io.ReadAll(r)
 //     if err != nil {
 //             return errors.Wrap(err, "read failed")
 //     }

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/prometheus/client_golang/prometheus/registry.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/prometheus/client_golang/prometheus/registry.go
@@ -16,7 +16,6 @@ package prometheus
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -553,7 +552,7 @@ func (r *Registry) Gather() ([]*dto.MetricFamily, error) {
 // This is intended for use with the textfile collector of the node exporter.
 // Note that the node exporter expects the filename to be suffixed with ".prom".
 func WriteToTextfile(filename string, g Gatherer) error {
-	tmp, err := ioutil.TempFile(filepath.Dir(filename), filepath.Base(filename))
+	tmp, err := os.CreateTemp(filepath.Dir(filename), filepath.Base(filename))
 	if err != nil {
 		return err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/prometheus/common/expfmt/text_create.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/prometheus/common/expfmt/text_create.go
@@ -17,7 +17,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"strconv"
 	"strings"
@@ -44,7 +43,7 @@ const (
 var (
 	bufPool = sync.Pool{
 		New: func() interface{} {
-			return bufio.NewWriter(ioutil.Discard)
+			return bufio.NewWriter(io.Discard)
 		},
 	}
 	numBufPool = sync.Pool{

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/prometheus/procfs/CONTRIBUTING.md
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/prometheus/procfs/CONTRIBUTING.md
@@ -97,7 +97,7 @@ Many of the files are changing continuously and the data being read can in some 
 reads in the same file.  Also, most of the files are relatively small (less than a few KBs), and system calls
 to the `stat` function will often return the wrong size.  Therefore, for most files it's recommended to read the 
 full file in a single operation using an internal utility function called `util.ReadFileNoStat`.
-This function is similar to `ioutil.ReadFile`, but it avoids the system call to `stat` to get the current size of
+This function is similar to `os.ReadFile`, but it avoids the system call to `stat` to get the current size of
 the file.
 
 Note that parsing the file's contents can still be performed one line at a time.  This is done by first reading 
@@ -113,7 +113,7 @@ the full file, and then using a scanner on the `[]byte` or `string` containing t
 ```
 
 The `/sys` filesystem contains many very small files which contain only a single numeric or text value.  These files
-can be read using an internal function called `util.SysReadFile` which is similar to `ioutil.ReadFile` but does
+can be read using an internal function called `util.SysReadFile` which is similar to `os.ReadFile` but does
 not bother to check the size of the file before reading.
 ```
     data, err := util.SysReadFile("/sys/class/power_supply/BAT0/capacity")

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/prometheus/procfs/arp.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/prometheus/procfs/arp.go
@@ -15,7 +15,7 @@ package procfs
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"net"
 	"strings"
 )
@@ -34,7 +34,7 @@ type ARPEntry struct {
 // GatherARPEntries retrieves all the ARP entries, parse the relevant columns,
 // and then return a slice of ARPEntry's.
 func (fs FS) GatherARPEntries() ([]ARPEntry, error) {
-	data, err := ioutil.ReadFile(fs.proc.Path("net/arp"))
+	data, err := os.ReadFile(fs.proc.Path("net/arp"))
 	if err != nil {
 		return nil, fmt.Errorf("error reading arp %s: %s", fs.proc.Path("net/arp"), err)
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/prometheus/procfs/crypto.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/prometheus/procfs/crypto.go
@@ -16,7 +16,7 @@ package procfs
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -52,7 +52,7 @@ type Crypto struct {
 // structs containing the relevant info.  More information available here:
 // https://kernel.readthedocs.io/en/sphinx-samples/crypto-API.html
 func (fs FS) Crypto() ([]Crypto, error) {
-	data, err := ioutil.ReadFile(fs.proc.Path("crypto"))
+	data, err := os.ReadFile(fs.proc.Path("crypto"))
 	if err != nil {
 		return nil, fmt.Errorf("error parsing crypto %s: %s", fs.proc.Path("crypto"), err)
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/prometheus/procfs/internal/util/parse.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/prometheus/procfs/internal/util/parse.go
@@ -14,7 +14,7 @@
 package util
 
 import (
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 )
@@ -66,7 +66,7 @@ func ParsePInt64s(ss []string) ([]*int64, error) {
 
 // ReadUintFromFile reads a file and attempts to parse a uint64 from it.
 func ReadUintFromFile(path string) (uint64, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return 0, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/prometheus/procfs/internal/util/readfile.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/prometheus/procfs/internal/util/readfile.go
@@ -15,12 +15,11 @@ package util
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 )
 
-// ReadFileNoStat uses ioutil.ReadAll to read contents of entire file.
-// This is similar to ioutil.ReadFile but without the call to os.Stat, because
+// ReadFileNoStat uses io.ReadAll to read contents of entire file.
+// This is similar to os.ReadFile but without the call to os.Stat, because
 // many files in /proc and /sys report incorrect file sizes (either 0 or 4096).
 // Reads a max file size of 512kB.  For files larger than this, a scanner
 // should be used.
@@ -34,5 +33,5 @@ func ReadFileNoStat(filename string) ([]byte, error) {
 	defer f.Close()
 
 	reader := io.LimitReader(f, maxBufferSize)
-	return ioutil.ReadAll(reader)
+	return io.ReadAll(reader)
 }

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/prometheus/procfs/internal/util/sysreadfile.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/prometheus/procfs/internal/util/sysreadfile.go
@@ -21,7 +21,7 @@ import (
 	"syscall"
 )
 
-// SysReadFile is a simplified ioutil.ReadFile that invokes syscall.Read directly.
+// SysReadFile is a simplified os.ReadFile that invokes syscall.Read directly.
 // https://github.com/prometheus/node_exporter/pull/728/files
 //
 // Note that this function will not read files larger than 128 bytes.
@@ -33,7 +33,7 @@ func SysReadFile(file string) (string, error) {
 	defer f.Close()
 
 	// On some machines, hwmon drivers are broken and return EAGAIN.  This causes
-	// Go's ioutil.ReadFile implementation to poll forever.
+	// Go's os.ReadFile implementation to poll forever.
 	//
 	// Since we either want to read data or bail immediately, do the simplest
 	// possible read using syscall directly.

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/prometheus/procfs/ipvs.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/prometheus/procfs/ipvs.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"strconv"
@@ -84,7 +83,7 @@ func parseIPVSStats(r io.Reader) (IPVSStats, error) {
 		stats       IPVSStats
 	)
 
-	statContent, err := ioutil.ReadAll(r)
+	statContent, err := io.ReadAll(r)
 	if err != nil {
 		return IPVSStats{}, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/prometheus/procfs/mdstat.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/prometheus/procfs/mdstat.go
@@ -15,7 +15,7 @@ package procfs
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -50,7 +50,7 @@ type MDStat struct {
 // structs containing the relevant info.  More information available here:
 // https://raid.wiki.kernel.org/index.php/Mdstat
 func (fs FS) MDStat() ([]MDStat, error) {
-	data, err := ioutil.ReadFile(fs.proc.Path("mdstat"))
+	data, err := os.ReadFile(fs.proc.Path("mdstat"))
 	if err != nil {
 		return nil, fmt.Errorf("error parsing mdstat %s: %s", fs.proc.Path("mdstat"), err)
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/prometheus/procfs/net_softnet.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/prometheus/procfs/net_softnet.go
@@ -15,7 +15,7 @@ package procfs
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 )
@@ -37,7 +37,7 @@ type SoftnetEntry struct {
 // GatherSoftnetStats reads /proc/net/softnet_stat, parse the relevant columns,
 // and then return a slice of SoftnetEntry's.
 func (fs FS) GatherSoftnetStats() ([]SoftnetEntry, error) {
-	data, err := ioutil.ReadFile(fs.proc.Path("net/softnet_stat"))
+	data, err := os.ReadFile(fs.proc.Path("net/softnet_stat"))
 	if err != nil {
 		return nil, fmt.Errorf("error reading softnet %s: %s", fs.proc.Path("net/softnet_stat"), err)
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/prometheus/procfs/proc.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/prometheus/procfs/proc.go
@@ -16,7 +16,6 @@ package procfs
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -290,7 +289,7 @@ func (p Proc) FileDescriptorsInfo() (ProcFDInfos, error) {
 
 // Schedstat returns task scheduling information for the process.
 func (p Proc) Schedstat() (ProcSchedstat, error) {
-	contents, err := ioutil.ReadFile(p.path("schedstat"))
+	contents, err := os.ReadFile(p.path("schedstat"))
 	if err != nil {
 		return ProcSchedstat{}, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/prometheus/procfs/vm.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/prometheus/procfs/vm.go
@@ -17,7 +17,6 @@ package procfs
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -87,7 +86,7 @@ func (fs FS) VM() (*VM, error) {
 		return nil, fmt.Errorf("%s is not a directory", path)
 	}
 
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		return nil, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/prometheus/procfs/zoneinfo.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/prometheus/procfs/zoneinfo.go
@@ -18,7 +18,7 @@ package procfs
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 
@@ -72,7 +72,7 @@ var nodeZoneRE = regexp.MustCompile(`(\d+), zone\s+(\w+)`)
 // structs containing the relevant info.  More information available here:
 // https://www.kernel.org/doc/Documentation/sysctl/vm.txt
 func (fs FS) Zoneinfo() ([]Zoneinfo, error) {
-	data, err := ioutil.ReadFile(fs.proc.Path("zoneinfo"))
+	data, err := os.ReadFile(fs.proc.Path("zoneinfo"))
 	if err != nil {
 		return nil, fmt.Errorf("error reading zoneinfo %s: %s", fs.proc.Path("zoneinfo"), err)
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/richo/GOSHOUT/SHOUT.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/richo/GOSHOUT/SHOUT.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 )
@@ -39,7 +39,7 @@ func UPCASE(THING_TO_YELL string) (string, error) {
 
 	defer RESP.Body.Close()
 
-	BODYBYTES, ERR := ioutil.ReadAll(RESP.Body)
+	BODYBYTES, ERR := io.ReadAll(RESP.Body)
 	if ERR != nil {
 		return "", errors.New("COULDN'T READ BODY HALP")
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/romana/ipset/handle.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/romana/ipset/handle.go
@@ -19,7 +19,7 @@ import (
 	"context"
 	"encoding/xml"
 	"io"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -498,7 +498,7 @@ func Load(ctx context.Context, options ...OptFunc) (*Ipset, error) {
 func LoadFromFile(filename string) (*Ipset, error) {
 	rlog.Tracef(3, "loading ipset configuration form file %s", filename)
 
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load ipset config from file")
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/romana/ipset/internal/cmd/main.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/romana/ipset/internal/cmd/main.go
@@ -5,7 +5,6 @@ import (
 	"encoding/xml"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -26,7 +25,7 @@ func main() {
 	flag.Parse()
 
 	if *flagFile != "" {
-		data, err := ioutil.ReadFile(*flagFile)
+		data, err := os.ReadFile(*flagFile)
 		if err != nil {
 			panic(err)
 		}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/cpu/cpu_solaris_test.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/cpu/cpu_solaris_test.go
@@ -1,7 +1,7 @@
 package cpu
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -36,7 +36,7 @@ func TestParseISAInfo(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		content, err := ioutil.ReadFile(filepath.Join("testdata", "solaris", tc.filename))
+		content, err := os.ReadFile(filepath.Join("testdata", "solaris", tc.filename))
 		if err != nil {
 			t.Errorf("cannot read test case: %s", err)
 		}
@@ -96,7 +96,7 @@ func TestParseProcessorInfo(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		content, err := ioutil.ReadFile(filepath.Join("testdata", "solaris", tc.filename))
+		content, err := os.ReadFile(filepath.Join("testdata", "solaris", tc.filename))
 		if err != nil {
 			t.Errorf("cannot read test case: %s", err)
 		}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/disk/disk_linux.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/disk/disk_linux.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -460,7 +459,7 @@ func GetDiskSerialNumberWithContext(ctx context.Context, name string) string {
 
 	// Try to get the serial from udev data
 	udevDataPath := common.HostRun(fmt.Sprintf("udev/data/b%d:%d", major, minor))
-	if udevdata, err := ioutil.ReadFile(udevDataPath); err == nil {
+	if udevdata, err := os.ReadFile(udevDataPath); err == nil {
 		scanner := bufio.NewScanner(bytes.NewReader(udevdata))
 		for scanner.Scan() {
 			values := strings.Split(scanner.Text(), "=")
@@ -473,8 +472,8 @@ func GetDiskSerialNumberWithContext(ctx context.Context, name string) string {
 	// Try to get the serial from sysfs, look at the disk device (minor 0) directly
 	// because if it is a partition it is not going to contain any device information
 	devicePath := common.HostSys(fmt.Sprintf("dev/block/%d:0/device", major))
-	model, _ := ioutil.ReadFile(filepath.Join(devicePath, "model"))
-	serial, _ := ioutil.ReadFile(filepath.Join(devicePath, "serial"))
+	model, _ := os.ReadFile(filepath.Join(devicePath, "model"))
+	serial, _ := os.ReadFile(filepath.Join(devicePath, "serial"))
 	if len(model) > 0 && len(serial) > 0 {
 		return fmt.Sprintf("%s_%s", string(model), string(serial))
 	}
@@ -493,7 +492,7 @@ func GetLabel(name string) string {
 		return ""
 	}
 
-	dmname, err := ioutil.ReadFile(dmname_filename)
+	dmname, err := os.ReadFile(dmname_filename)
 	if err != nil {
 		return ""
 	} else {

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/host/host_darwin.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/host/host_darwin.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -46,7 +46,7 @@ func UsersWithContext(ctx context.Context) ([]UserStat, error) {
 	}
 	defer file.Close()
 
-	buf, err := ioutil.ReadAll(file)
+	buf, err := io.ReadAll(file)
 	if err != nil {
 		return ret, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/host/host_freebsd.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/host/host_freebsd.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-	"io/ioutil"
+	"io"
 	"math"
 	"os"
 	"strings"
@@ -53,7 +53,7 @@ func UsersWithContext(ctx context.Context) ([]UserStat, error) {
 	}
 	defer file.Close()
 
-	buf, err := ioutil.ReadAll(file)
+	buf, err := io.ReadAll(file)
 	if err != nil {
 		return ret, err
 	}
@@ -111,7 +111,7 @@ func getUsersFromUtmp(utmpfile string) ([]UserStat, error) {
 	}
 	defer file.Close()
 
-	buf, err := ioutil.ReadAll(file)
+	buf, err := io.ReadAll(file)
 	if err != nil {
 		return ret, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/host/host_linux.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/host/host_linux.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -86,7 +86,7 @@ func UsersWithContext(ctx context.Context) ([]UserStat, error) {
 	}
 	defer file.Close()
 
-	buf, err := ioutil.ReadAll(file)
+	buf, err := io.ReadAll(file)
 	if err != nil {
 		return nil, err
 	}
@@ -388,13 +388,13 @@ func SensorsTemperaturesWithContext(ctx context.Context) ([]TemperatureStat, err
 		}
 		for _, file := range files {
 			// Get the name of the temperature you are reading
-			name, err := ioutil.ReadFile(filepath.Join(file, "type"))
+			name, err := os.ReadFile(filepath.Join(file, "type"))
 			if err != nil {
 				warns.Add(err)
 				continue
 			}
 			// Get the temperature reading
-			current, err := ioutil.ReadFile(filepath.Join(file, "temp"))
+			current, err := os.ReadFile(filepath.Join(file, "temp"))
 			if err != nil {
 				warns.Add(err)
 				continue
@@ -428,21 +428,21 @@ func SensorsTemperaturesWithContext(ctx context.Context) ([]TemperatureStat, err
 
 		// Get the label of the temperature you are reading
 		var label string
-		c, _ := ioutil.ReadFile(filepath.Join(filepath.Dir(file), filename[0]+"_label"))
+		c, _ := os.ReadFile(filepath.Join(filepath.Dir(file), filename[0]+"_label"))
 		if c != nil {
 			//format the label from "Core 0" to "core0_"
 			label = fmt.Sprintf("%s_", strings.Join(strings.Split(strings.TrimSpace(strings.ToLower(string(c))), " "), ""))
 		}
 
 		// Get the name of the temperature you are reading
-		name, err := ioutil.ReadFile(filepath.Join(filepath.Dir(file), "name"))
+		name, err := os.ReadFile(filepath.Join(filepath.Dir(file), "name"))
 		if err != nil {
 			warns.Add(err)
 			continue
 		}
 
 		// Get the temperature reading
-		current, err := ioutil.ReadFile(file)
+		current, err := os.ReadFile(file)
 		if err != nil {
 			warns.Add(err)
 			continue

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/host/host_openbsd.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/host/host_openbsd.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"unsafe"
@@ -64,7 +64,7 @@ func UsersWithContext(ctx context.Context) ([]UserStat, error) {
 	}
 	defer file.Close()
 
-	buf, err := ioutil.ReadAll(file)
+	buf, err := io.ReadAll(file)
 	if err != nil {
 		return ret, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/host/host_solaris.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/host/host_solaris.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"regexp"
@@ -65,7 +64,7 @@ func HostIDWithContext(ctx context.Context) (string, error) {
 
 // Count number of processes based on the number of entries in /proc
 func numProcs(ctx context.Context) (uint64, error) {
-	dirs, err := ioutil.ReadDir("/proc")
+	dirs, err := os.ReadDir("/proc")
 	if err != nil {
 		return 0, err
 	}
@@ -115,7 +114,7 @@ func VirtualizationWithContext(ctx context.Context) (string, string, error) {
 
 // Find distribution name from /etc/release
 func parseReleaseFile() (string, error) {
-	b, err := ioutil.ReadFile("/etc/release")
+	b, err := os.ReadFile("/etc/release")
 	if err != nil {
 		return "", err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/internal/common/common.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/internal/common/common.go
@@ -12,7 +12,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"os/exec"
@@ -83,7 +82,7 @@ func (i FakeInvoke) Command(name string, arg ...string) ([]byte, error) {
 		fpath += "_" + i.Suffix
 	}
 	if PathExists(fpath) {
-		return ioutil.ReadFile(fpath)
+		return os.ReadFile(fpath)
 	}
 	return []byte{}, fmt.Errorf("could not find testdata: %s", fpath)
 }
@@ -96,7 +95,7 @@ var ErrNotImplementedError = errors.New("not implemented yet")
 
 // ReadFile reads contents from a file
 func ReadFile(filename string) (string, error) {
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 
 	if err != nil {
 		return "", err

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/load/load_linux.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/load/load_linux.go
@@ -4,7 +4,7 @@ package load
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 	"syscall"
@@ -75,7 +75,7 @@ func Misc() (*MiscStat, error) {
 
 func MiscWithContext(ctx context.Context) (*MiscStat, error) {
 	filename := common.HostProc("stat")
-	out, err := ioutil.ReadFile(filename)
+	out, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +125,7 @@ func getProcsTotal() (int64, error) {
 
 func readLoadAvgFromFile() ([]string, error) {
 	loadavgFilename := common.HostProc("loadavg")
-	line, err := ioutil.ReadFile(loadavgFilename)
+	line, err := os.ReadFile(loadavgFilename)
 	if err != nil {
 		return nil, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/net/net_linux.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/net/net_linux.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"strconv"
@@ -635,7 +634,7 @@ func (p *process) getUids() ([]int32, error) {
 func (p *process) fillFromStatus() error {
 	pid := p.Pid
 	statPath := common.HostProc(strconv.Itoa(int(pid)), "status")
-	contents, err := ioutil.ReadFile(statPath)
+	contents, err := os.ReadFile(statPath)
 	if err != nil {
 		return err
 	}
@@ -757,7 +756,7 @@ func processInet(file string, kind netConnectionKindType, inodes map[string][]in
 	// This minimizes duplicates in the returned connections
 	// For more info:
 	// https://github.com/shirou/gopsutil/pull/361
-	contents, err := ioutil.ReadFile(file)
+	contents, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}
@@ -818,7 +817,7 @@ func processUnix(file string, kind netConnectionKindType, inodes map[string][]in
 	// This minimizes duplicates in the returned connections
 	// For more info:
 	// https://github.com/shirou/gopsutil/pull/361
-	contents, err := ioutil.ReadFile(file)
+	contents, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/net/net_linux_test.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/net/net_linux_test.go
@@ -2,7 +2,6 @@ package net
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"strings"
@@ -15,7 +14,7 @@ import (
 
 func TestIOCountersByFileParsing(t *testing.T) {
 	// Prpare a temporary file, which will be read during the test
-	tmpfile, err := ioutil.TempFile("", "proc_dev_net")
+	tmpfile, err := os.CreateTemp("", "proc_dev_net")
 	defer os.Remove(tmpfile.Name()) // clean up
 
 	assert.Nil(t, err, "Temporary file creation failed: ", err)
@@ -182,7 +181,7 @@ func TestReverse(t *testing.T) {
 }
 
 func TestConntrackStatFileParsing(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "proc_net_stat_conntrack")
+	tmpfile, err := os.CreateTemp("", "proc_net_stat_conntrack")
 	defer os.Remove(tmpfile.Name())
 	assert.Nil(t, err, "Temporary file creation failed: ", err)
 

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/process/process_linux.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/process/process_linux.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -137,7 +136,7 @@ func (p *Process) ForegroundWithContext(ctx context.Context) (bool, error) {
 	// see https://github.com/shirou/gopsutil/issues/596#issuecomment-432707831 for implementation details
 	pid := p.Pid
 	statPath := common.HostProc(strconv.Itoa(int(pid)), "stat")
-	contents, err := ioutil.ReadFile(statPath)
+	contents, err := os.ReadFile(statPath)
 	if err != nil {
 		return false, err
 	}
@@ -392,7 +391,7 @@ func (p *Process) MemoryMapsWithContext(ctx context.Context, grouped bool) (*[]M
 		ret = make([]MemoryMapsStat, 1)
 	}
 	smapsPath := common.HostProc(strconv.Itoa(int(pid)), "smaps")
-	contents, err := ioutil.ReadFile(smapsPath)
+	contents, err := os.ReadFile(smapsPath)
 	if err != nil {
 		return nil, err
 	}
@@ -659,7 +658,7 @@ func (p *Process) fillFromExeWithContext(ctx context.Context) (string, error) {
 func (p *Process) fillFromCmdlineWithContext(ctx context.Context) (string, error) {
 	pid := p.Pid
 	cmdPath := common.HostProc(strconv.Itoa(int(pid)), "cmdline")
-	cmdline, err := ioutil.ReadFile(cmdPath)
+	cmdline, err := os.ReadFile(cmdPath)
 	if err != nil {
 		return "", err
 	}
@@ -676,7 +675,7 @@ func (p *Process) fillFromCmdlineWithContext(ctx context.Context) (string, error
 func (p *Process) fillSliceFromCmdlineWithContext(ctx context.Context) ([]string, error) {
 	pid := p.Pid
 	cmdPath := common.HostProc(strconv.Itoa(int(pid)), "cmdline")
-	cmdline, err := ioutil.ReadFile(cmdPath)
+	cmdline, err := os.ReadFile(cmdPath)
 	if err != nil {
 		return nil, err
 	}
@@ -699,7 +698,7 @@ func (p *Process) fillSliceFromCmdlineWithContext(ctx context.Context) ([]string
 func (p *Process) fillFromIOWithContext(ctx context.Context) (*IOCountersStat, error) {
 	pid := p.Pid
 	ioPath := common.HostProc(strconv.Itoa(int(pid)), "io")
-	ioline, err := ioutil.ReadFile(ioPath)
+	ioline, err := os.ReadFile(ioPath)
 	if err != nil {
 		return nil, err
 	}
@@ -738,7 +737,7 @@ func (p *Process) fillFromIOWithContext(ctx context.Context) (*IOCountersStat, e
 func (p *Process) fillFromStatmWithContext(ctx context.Context) (*MemoryInfoStat, *MemoryInfoExStat, error) {
 	pid := p.Pid
 	memPath := common.HostProc(strconv.Itoa(int(pid)), "statm")
-	contents, err := ioutil.ReadFile(memPath)
+	contents, err := os.ReadFile(memPath)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -790,7 +789,7 @@ func (p *Process) fillFromStatmWithContext(ctx context.Context) (*MemoryInfoStat
 func (p *Process) fillFromStatusWithContext(ctx context.Context) error {
 	pid := p.Pid
 	statPath := common.HostProc(strconv.Itoa(int(pid)), "status")
-	contents, err := ioutil.ReadFile(statPath)
+	contents, err := os.ReadFile(statPath)
 	if err != nil {
 		return err
 	}
@@ -980,7 +979,7 @@ func (p *Process) fillFromTIDStatWithContext(ctx context.Context, tid int32) (ui
 		statPath = common.HostProc(strconv.Itoa(int(pid)), "task", strconv.Itoa(int(tid)), "stat")
 	}
 
-	contents, err := ioutil.ReadFile(statPath)
+	contents, err := os.ReadFile(statPath)
 	if err != nil {
 		return 0, 0, nil, 0, 0, 0, nil, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/process/process_test.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/process/process_test.go
@@ -2,7 +2,6 @@ package process
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -313,7 +312,7 @@ func Test_Process_Name(t *testing.T) {
 	}
 }
 func Test_Process_Long_Name(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("unable to create temp dir %v", err)
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/v3/cpu/cpu_solaris_test.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/v3/cpu/cpu_solaris_test.go
@@ -1,7 +1,7 @@
 package cpu
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -36,7 +36,7 @@ func TestParseISAInfo(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		content, err := ioutil.ReadFile(filepath.Join("testdata", "solaris", tc.filename))
+		content, err := os.ReadFile(filepath.Join("testdata", "solaris", tc.filename))
 		if err != nil {
 			t.Errorf("cannot read test case: %s", err)
 		}
@@ -96,7 +96,7 @@ func TestParseProcessorInfo(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		content, err := ioutil.ReadFile(filepath.Join("testdata", "solaris", tc.filename))
+		content, err := os.ReadFile(filepath.Join("testdata", "solaris", tc.filename))
 		if err != nil {
 			t.Errorf("cannot read test case: %s", err)
 		}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/v3/disk/disk_linux.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/v3/disk/disk_linux.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -450,7 +449,7 @@ func SerialNumberWithContext(ctx context.Context, name string) (string, error) {
 
 	// Try to get the serial from udev data
 	udevDataPath := common.HostRun(fmt.Sprintf("udev/data/b%d:%d", major, minor))
-	if udevdata, err := ioutil.ReadFile(udevDataPath); err == nil {
+	if udevdata, err := os.ReadFile(udevDataPath); err == nil {
 		scanner := bufio.NewScanner(bytes.NewReader(udevdata))
 		for scanner.Scan() {
 			values := strings.Split(scanner.Text(), "=")
@@ -463,8 +462,8 @@ func SerialNumberWithContext(ctx context.Context, name string) (string, error) {
 	// Try to get the serial from sysfs, look at the disk device (minor 0) directly
 	// because if it is a partition it is not going to contain any device information
 	devicePath := common.HostSys(fmt.Sprintf("dev/block/%d:0/device", major))
-	model, _ := ioutil.ReadFile(filepath.Join(devicePath, "model"))
-	serial, _ := ioutil.ReadFile(filepath.Join(devicePath, "serial"))
+	model, _ := os.ReadFile(filepath.Join(devicePath, "model"))
+	serial, _ := os.ReadFile(filepath.Join(devicePath, "serial"))
 	if len(model) > 0 && len(serial) > 0 {
 		return fmt.Sprintf("%s_%s", string(model), string(serial)), nil
 	}
@@ -479,7 +478,7 @@ func LabelWithContext(ctx context.Context, name string) (string, error) {
 		return "", nil
 	}
 
-	dmname, err := ioutil.ReadFile(dmname_filename)
+	dmname, err := os.ReadFile(dmname_filename)
 	if err != nil {
 		return "", err
 	} else {

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/v3/host/host_darwin.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/v3/host/host_darwin.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -46,7 +46,7 @@ func UsersWithContext(ctx context.Context) ([]UserStat, error) {
 	}
 	defer file.Close()
 
-	buf, err := ioutil.ReadAll(file)
+	buf, err := io.ReadAll(file)
 	if err != nil {
 		return ret, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/v3/host/host_freebsd.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/v3/host/host_freebsd.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-	"io/ioutil"
+	"io"
 	"math"
 	"os"
 	"strings"
@@ -53,7 +53,7 @@ func UsersWithContext(ctx context.Context) ([]UserStat, error) {
 	}
 	defer file.Close()
 
-	buf, err := ioutil.ReadAll(file)
+	buf, err := io.ReadAll(file)
 	if err != nil {
 		return ret, err
 	}
@@ -111,7 +111,7 @@ func getUsersFromUtmp(utmpfile string) ([]UserStat, error) {
 	}
 	defer file.Close()
 
-	buf, err := ioutil.ReadAll(file)
+	buf, err := io.ReadAll(file)
 	if err != nil {
 		return ret, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/v3/host/host_linux.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/v3/host/host_linux.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -90,7 +90,7 @@ func UsersWithContext(ctx context.Context) ([]UserStat, error) {
 	}
 	defer file.Close()
 
-	buf, err := ioutil.ReadAll(file)
+	buf, err := io.ReadAll(file)
 	if err != nil {
 		return nil, err
 	}
@@ -400,13 +400,13 @@ func SensorsTemperaturesWithContext(ctx context.Context) ([]TemperatureStat, err
 		}
 		for _, file := range files {
 			// Get the name of the temperature you are reading
-			name, err := ioutil.ReadFile(filepath.Join(file, "type"))
+			name, err := os.ReadFile(filepath.Join(file, "type"))
 			if err != nil {
 				warns.Add(err)
 				continue
 			}
 			// Get the temperature reading
-			current, err := ioutil.ReadFile(filepath.Join(file, "temp"))
+			current, err := os.ReadFile(filepath.Join(file, "temp"))
 			if err != nil {
 				warns.Add(err)
 				continue
@@ -450,13 +450,13 @@ func SensorsTemperaturesWithContext(ctx context.Context) ([]TemperatureStat, err
 		// Get the label of the temperature you are reading
 		label := ""
 
-		if raw, _ = ioutil.ReadFile(basepath + "_label"); len(raw) != 0 {
+		if raw, _ = os.ReadFile(basepath + "_label"); len(raw) != 0 {
 			// Format the label from "Core 0" to "core_0"
 			label = strings.Join(strings.Split(strings.TrimSpace(strings.ToLower(string(raw))), " "), "_")
 		}
 
 		// Get the name of the temperature you are reading
-		if raw, err = ioutil.ReadFile(filepath.Join(directory, "name")); err != nil {
+		if raw, err = os.ReadFile(filepath.Join(directory, "name")); err != nil {
 			warns.Add(err)
 			continue
 		}
@@ -468,7 +468,7 @@ func SensorsTemperaturesWithContext(ctx context.Context) ([]TemperatureStat, err
 		}
 
 		// Get the temperature reading
-		if raw, err = ioutil.ReadFile(file); err != nil {
+		if raw, err = os.ReadFile(file); err != nil {
 			warns.Add(err)
 			continue
 		}
@@ -502,7 +502,7 @@ func optionalValueReadFromFile(filename string) float64 {
 		return 0
 	}
 
-	if raw, err = ioutil.ReadFile(filename); err != nil {
+	if raw, err = os.ReadFile(filename); err != nil {
 		return 0
 	}
 

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/v3/host/host_openbsd.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/v3/host/host_openbsd.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"unsafe"
@@ -64,7 +64,7 @@ func UsersWithContext(ctx context.Context) ([]UserStat, error) {
 	}
 	defer file.Close()
 
-	buf, err := ioutil.ReadAll(file)
+	buf, err := io.ReadAll(file)
 	if err != nil {
 		return ret, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/v3/host/host_solaris.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/v3/host/host_solaris.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"regexp"
@@ -65,7 +64,7 @@ func HostIDWithContext(ctx context.Context) (string, error) {
 
 // Count number of processes based on the number of entries in /proc
 func numProcs(ctx context.Context) (uint64, error) {
-	dirs, err := ioutil.ReadDir("/proc")
+	dirs, err := os.ReadDir("/proc")
 	if err != nil {
 		return 0, err
 	}
@@ -115,7 +114,7 @@ func VirtualizationWithContext(ctx context.Context) (string, string, error) {
 
 // Find distribution name from /etc/release
 func parseReleaseFile() (string, error) {
-	b, err := ioutil.ReadFile("/etc/release")
+	b, err := os.ReadFile("/etc/release")
 	if err != nil {
 		return "", err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/v3/internal/common/common.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/v3/internal/common/common.go
@@ -12,7 +12,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"os/exec"
@@ -83,7 +82,7 @@ func (i FakeInvoke) Command(name string, arg ...string) ([]byte, error) {
 		fpath += "_" + i.Suffix
 	}
 	if PathExists(fpath) {
-		return ioutil.ReadFile(fpath)
+		return os.ReadFile(fpath)
 	}
 	return []byte{}, fmt.Errorf("could not find testdata: %s", fpath)
 }
@@ -96,7 +95,7 @@ var ErrNotImplementedError = errors.New("not implemented yet")
 
 // ReadFile reads contents from a file
 func ReadFile(filename string) (string, error) {
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 
 	if err != nil {
 		return "", err

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/v3/load/load_linux.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/v3/load/load_linux.go
@@ -4,7 +4,7 @@ package load
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 	"syscall"
@@ -75,7 +75,7 @@ func Misc() (*MiscStat, error) {
 
 func MiscWithContext(ctx context.Context) (*MiscStat, error) {
 	filename := common.HostProc("stat")
-	out, err := ioutil.ReadFile(filename)
+	out, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +123,7 @@ func getProcsTotal() (int64, error) {
 
 func readLoadAvgFromFile() ([]string, error) {
 	loadavgFilename := common.HostProc("loadavg")
-	line, err := ioutil.ReadFile(loadavgFilename)
+	line, err := os.ReadFile(loadavgFilename)
 	if err != nil {
 		return nil, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/v3/net/net_linux.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/v3/net/net_linux.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"strconv"
@@ -635,7 +634,7 @@ func (p *process) getUids() ([]int32, error) {
 func (p *process) fillFromStatus() error {
 	pid := p.Pid
 	statPath := common.HostProc(strconv.Itoa(int(pid)), "status")
-	contents, err := ioutil.ReadFile(statPath)
+	contents, err := os.ReadFile(statPath)
 	if err != nil {
 		return err
 	}
@@ -757,7 +756,7 @@ func processInet(file string, kind netConnectionKindType, inodes map[string][]in
 	// This minimizes duplicates in the returned connections
 	// For more info:
 	// https://github.com/shirou/gopsutil/pull/361
-	contents, err := ioutil.ReadFile(file)
+	contents, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}
@@ -818,7 +817,7 @@ func processUnix(file string, kind netConnectionKindType, inodes map[string][]in
 	// This minimizes duplicates in the returned connections
 	// For more info:
 	// https://github.com/shirou/gopsutil/pull/361
-	contents, err := ioutil.ReadFile(file)
+	contents, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/v3/net/net_linux_test.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/v3/net/net_linux_test.go
@@ -2,7 +2,6 @@ package net
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"strings"
@@ -15,7 +14,7 @@ import (
 
 func TestIOCountersByFileParsing(t *testing.T) {
 	// Prpare a temporary file, which will be read during the test
-	tmpfile, err := ioutil.TempFile("", "proc_dev_net")
+	tmpfile, err := os.CreateTemp("", "proc_dev_net")
 	defer os.Remove(tmpfile.Name()) // clean up
 
 	assert.Nil(t, err, "Temporary file creation failed: ", err)
@@ -182,7 +181,7 @@ func TestReverse(t *testing.T) {
 }
 
 func TestConntrackStatFileParsing(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "proc_net_stat_conntrack")
+	tmpfile, err := os.CreateTemp("", "proc_net_stat_conntrack")
 	defer os.Remove(tmpfile.Name())
 	assert.Nil(t, err, "Temporary file creation failed: ", err)
 

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/v3/process/process_linux.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/v3/process/process_linux.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -137,7 +136,7 @@ func (p *Process) ForegroundWithContext(ctx context.Context) (bool, error) {
 	// see https://github.com/shirou/gopsutil/issues/596#issuecomment-432707831 for implementation details
 	pid := p.Pid
 	statPath := common.HostProc(strconv.Itoa(int(pid)), "stat")
-	contents, err := ioutil.ReadFile(statPath)
+	contents, err := os.ReadFile(statPath)
 	if err != nil {
 		return false, err
 	}
@@ -387,7 +386,7 @@ func (p *Process) MemoryMapsWithContext(ctx context.Context, grouped bool) (*[]M
 		ret = make([]MemoryMapsStat, 1)
 	}
 	smapsPath := common.HostProc(strconv.Itoa(int(pid)), "smaps")
-	contents, err := ioutil.ReadFile(smapsPath)
+	contents, err := os.ReadFile(smapsPath)
 	if err != nil {
 		return nil, err
 	}
@@ -654,7 +653,7 @@ func (p *Process) fillFromExeWithContext(ctx context.Context) (string, error) {
 func (p *Process) fillFromCmdlineWithContext(ctx context.Context) (string, error) {
 	pid := p.Pid
 	cmdPath := common.HostProc(strconv.Itoa(int(pid)), "cmdline")
-	cmdline, err := ioutil.ReadFile(cmdPath)
+	cmdline, err := os.ReadFile(cmdPath)
 	if err != nil {
 		return "", err
 	}
@@ -671,7 +670,7 @@ func (p *Process) fillFromCmdlineWithContext(ctx context.Context) (string, error
 func (p *Process) fillSliceFromCmdlineWithContext(ctx context.Context) ([]string, error) {
 	pid := p.Pid
 	cmdPath := common.HostProc(strconv.Itoa(int(pid)), "cmdline")
-	cmdline, err := ioutil.ReadFile(cmdPath)
+	cmdline, err := os.ReadFile(cmdPath)
 	if err != nil {
 		return nil, err
 	}
@@ -694,7 +693,7 @@ func (p *Process) fillSliceFromCmdlineWithContext(ctx context.Context) ([]string
 func (p *Process) fillFromIOWithContext(ctx context.Context) (*IOCountersStat, error) {
 	pid := p.Pid
 	ioPath := common.HostProc(strconv.Itoa(int(pid)), "io")
-	ioline, err := ioutil.ReadFile(ioPath)
+	ioline, err := os.ReadFile(ioPath)
 	if err != nil {
 		return nil, err
 	}
@@ -733,7 +732,7 @@ func (p *Process) fillFromIOWithContext(ctx context.Context) (*IOCountersStat, e
 func (p *Process) fillFromStatmWithContext(ctx context.Context) (*MemoryInfoStat, *MemoryInfoExStat, error) {
 	pid := p.Pid
 	memPath := common.HostProc(strconv.Itoa(int(pid)), "statm")
-	contents, err := ioutil.ReadFile(memPath)
+	contents, err := os.ReadFile(memPath)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -785,7 +784,7 @@ func (p *Process) fillFromStatmWithContext(ctx context.Context) (*MemoryInfoStat
 func (p *Process) fillFromStatusWithContext(ctx context.Context) error {
 	pid := p.Pid
 	statPath := common.HostProc(strconv.Itoa(int(pid)), "status")
-	contents, err := ioutil.ReadFile(statPath)
+	contents, err := os.ReadFile(statPath)
 	if err != nil {
 		return err
 	}
@@ -975,7 +974,7 @@ func (p *Process) fillFromTIDStatWithContext(ctx context.Context, tid int32) (ui
 		statPath = common.HostProc(strconv.Itoa(int(pid)), "task", strconv.Itoa(int(tid)), "stat")
 	}
 
-	contents, err := ioutil.ReadFile(statPath)
+	contents, err := os.ReadFile(statPath)
 	if err != nil {
 		return 0, 0, nil, 0, 0, 0, nil, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/v3/process/process_test.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/shirou/gopsutil/v3/process/process_test.go
@@ -2,7 +2,6 @@ package process
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -316,7 +315,7 @@ func Test_Process_Name(t *testing.T) {
 	}
 }
 func Test_Process_Long_Name(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("unable to create temp dir %v", err)
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/sirupsen/logrus/hooks/test/test.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/sirupsen/logrus/hooks/test/test.go
@@ -4,7 +4,7 @@
 package test
 
 import (
-	"io/ioutil"
+	"io"
 	"sync"
 
 	"github.com/sirupsen/logrus"
@@ -43,7 +43,7 @@ func NewLocal(logger *logrus.Logger) *Hook {
 func NewNullLogger() (*logrus.Logger, *Hook) {
 
 	logger := logrus.New()
-	logger.Out = ioutil.Discard
+	logger.Out = io.Discard
 
 	return logger, NewLocal(logger)
 

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/spf13/cobra/bash_completions.md
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/spf13/cobra/bash_completions.md
@@ -6,14 +6,14 @@ Generating bash completions from a cobra command is incredibly easy. An actual p
 package main
 
 import (
-        "io/ioutil"
+        "io"
         "os"
 
         "github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd"
 )
 
 func main() {
-        kubectl := cmd.NewFactory(nil).NewKubectlCommand(os.Stdin, ioutil.Discard, ioutil.Discard)
+        kubectl := cmd.NewFactory(nil).NewKubectlCommand(os.Stdin, io.Discard, io.Discard)
         kubectl.GenBashCompletionFile("out.sh")
 }
 ```

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/spf13/cobra/md_docs.md
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/spf13/cobra/md_docs.md
@@ -8,7 +8,7 @@ This program can actually generate docs for the kubectl command in the kubernete
 package main
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubectl/cmd"
@@ -16,7 +16,7 @@ import (
 )
 
 func main() {
-	kubectl := cmd.NewFactory(nil).NewKubectlCommand(os.Stdin, ioutil.Discard, ioutil.Discard)
+	kubectl := cmd.NewFactory(nil).NewKubectlCommand(os.Stdin, io.Discard, io.Discard)
 	cobra.GenMarkdownTree(kubectl, "./")
 }
 ```

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/tinylib/msgp/msgp/file_port.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/tinylib/msgp/msgp/file_port.go
@@ -3,7 +3,7 @@
 package msgp
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 )
 
@@ -20,7 +20,7 @@ func ReadFile(dst Unmarshaler, file *os.File) error {
 		return u.DecodeMsg(NewReader(file))
 	}
 
-	data, err := ioutil.ReadAll(file)
+	data, err := io.ReadAll(file)
 	if err != nil {
 		return err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/tklauser/go-sysconf/mksysconf.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/tklauser/go-sysconf/mksysconf.go
@@ -9,7 +9,6 @@ package main
 import (
 	"fmt"
 	"go/format"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"runtime"
@@ -35,7 +34,7 @@ func gensysconf(in, out string) error {
 	if err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(out, b, 0644); err != nil {
+	if err := os.WriteFile(out, b, 0644); err != nil {
 		return err
 	}
 	return nil

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/tklauser/go-sysconf/sysconf_linux.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/tklauser/go-sysconf/sysconf_linux.go
@@ -6,7 +6,6 @@ package sysconf
 
 import (
 	"bufio"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"strconv"
@@ -24,7 +23,7 @@ const (
 )
 
 func readProcFsInt64(path string, fallback int64) int64 {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return fallback
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/tklauser/numcpus/numcpus_linux.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/tklauser/numcpus/numcpus_linux.go
@@ -15,7 +15,7 @@
 package numcpus
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -24,7 +24,7 @@ import (
 const sysfsCPUBasePath = "/sys/devices/system/cpu"
 
 func readCPURange(file string) (int, error) {
-	buf, err := ioutil.ReadFile(filepath.Join(sysfsCPUBasePath, file))
+	buf, err := os.ReadFile(filepath.Join(sysfsCPUBasePath, file))
 	if err != nil {
 		return 0, err
 	}
@@ -56,7 +56,7 @@ func parseCPURange(cpus string) (int, error) {
 }
 
 func getKernelMax() (int, error) {
-	buf, err := ioutil.ReadFile(filepath.Join(sysfsCPUBasePath, "kernel_max"))
+	buf, err := os.ReadFile(filepath.Join(sysfsCPUBasePath, "kernel_max"))
 	if err != nil {
 		return 0, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/uber/jaeger-client-go/sampler_remote.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/uber/jaeger-client-go/sampler_remote.go
@@ -17,7 +17,7 @@ package jaeger
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"sync"
@@ -310,7 +310,7 @@ func (f *httpSamplingStrategyFetcher) Fetch(serviceName string) ([]byte, error) 
 		}
 	}()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/uber/jaeger-client-go/transport/http.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/uber/jaeger-client-go/transport/http.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -156,7 +155,7 @@ func (c *HTTPTransport) send(spans []*j.Span) error {
 	if err != nil {
 		return err
 	}
-	io.Copy(ioutil.Discard, resp.Body)
+	io.Copy(io.Discard, resp.Body)
 	resp.Body.Close()
 	if resp.StatusCode >= http.StatusBadRequest {
 		return fmt.Errorf("error from collector: %d", resp.StatusCode)

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/uber/jaeger-client-go/utils/http_json.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/uber/jaeger-client-go/utils/http_json.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 )
 
@@ -36,7 +35,7 @@ func ReadJSON(resp *http.Response, out interface{}) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}
@@ -45,7 +44,7 @@ func ReadJSON(resp *http.Response, out interface{}) error {
 	}
 
 	if out == nil {
-		io.Copy(ioutil.Discard, resp.Body)
+		io.Copy(io.Discard, resp.Body)
 		return nil
 	}
 

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/ugorji/go/codec/codecgen/gen.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/ugorji/go/codec/codecgen/gen.go
@@ -228,12 +228,12 @@ func Generate(outfile, buildTag, codecPkgPath string, uid int64, goRunTag string
 		return
 	}
 
-	// we cannot use ioutil.TempFile, because we cannot guarantee the file suffix (.go).
+	// we cannot use os.CreateTemp, because we cannot guarantee the file suffix (.go).
 	// Also, we cannot create file in temp directory,
 	// because go run will not work (as it needs to see the types here).
 	// Consequently, create the temp file in the current directory, and remove when done.
 
-	// frun, err = ioutil.TempFile("", "codecgen-")
+	// frun, err = os.CreateTemp("", "codecgen-")
 	// frunName := filepath.Join(os.TempDir(), "codecgen-"+strconv.FormatInt(time.Now().UnixNano(), 10)+".go")
 
 	frunMainName := "codecgen-main-" + tv.RandString + ".generated.go"

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/ugorji/go/codec/gen.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/ugorji/go/codec/gen.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"go/format"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"reflect"
 	"regexp"
@@ -1969,7 +1968,7 @@ func genInternalGoFile(r io.Reader, w io.Writer) (err error) {
 
 	t := template.New("").Funcs(genInternalTmplFuncs)
 
-	tmplstr, err := ioutil.ReadAll(r)
+	tmplstr, err := io.ReadAll(r)
 	if err != nil {
 		return
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/ugorji/go/codec/helper_unsafe.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/ugorji/go/codec/helper_unsafe.go
@@ -396,7 +396,7 @@ func (f *decFnInfo) kUint64(rv reflect.Value) {
 // 		[4]uint64{1, 2, 3, 4},
 // 		(chan<- int)(nil), // chan,
 // 		rv2i,              // func
-// 		io.Writer(ioutil.Discard),
+// 		io.Writer(io.Discard),
 // 		make(map[string]uint),
 // 		(map[string]uint)(nil),
 // 		staticM0,

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/vishvananda/netlink/link_linux.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/vishvananda/netlink/link_linux.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"strconv"
@@ -1706,7 +1705,7 @@ func LinkDeserialize(hdr *unix.NlMsghdr, m []byte) (Link, error) {
 
 func readSysPropAsInt64(ifname, prop string) (int64, error) {
 	fname := fmt.Sprintf("/sys/class/net/%s/%s", ifname, prop)
-	contents, err := ioutil.ReadFile(fname)
+	contents, err := os.ReadFile(fname)
 	if err != nil {
 		return 0, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/vishvananda/netlink/qdisc_linux.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/vishvananda/netlink/qdisc_linux.go
@@ -2,7 +2,7 @@ package netlink
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 	"syscall"
@@ -593,7 +593,7 @@ var (
 )
 
 func initClock() {
-	data, err := ioutil.ReadFile("/proc/net/psched")
+	data, err := os.ReadFile("/proc/net/psched")
 	if err != nil {
 		return
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/vishvananda/netns/netns_linux.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/vishvananda/netns/netns_linux.go
@@ -4,7 +4,6 @@ package netns
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -104,7 +103,7 @@ func GetFromDocker(id string) (NsHandle, error) {
 
 // borrowed from docker/utils/utils.go
 func findCgroupMountpoint(cgroupType string) (string, error) {
-	output, err := ioutil.ReadFile("/proc/mounts")
+	output, err := os.ReadFile("/proc/mounts")
 	if err != nil {
 		return "", err
 	}
@@ -129,7 +128,7 @@ func findCgroupMountpoint(cgroupType string) (string, error) {
 // borrowed from docker/utils/utils.go
 // modified to get the docker pid instead of using /proc/self
 func getThisCgroup(cgroupType string) (string, error) {
-	dockerpid, err := ioutil.ReadFile("/var/run/docker.pid")
+	dockerpid, err := os.ReadFile("/var/run/docker.pid")
 	if err != nil {
 		return "", err
 	}
@@ -141,7 +140,7 @@ func getThisCgroup(cgroupType string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	output, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/cgroup", pid))
+	output, err := os.ReadFile(fmt.Sprintf("/proc/%d/cgroup", pid))
 	if err != nil {
 		return "", err
 	}
@@ -211,7 +210,7 @@ func getPidForContainer(id string) (int, error) {
 		return pid, fmt.Errorf("Unable to find container: %v", id[:len(id)-1])
 	}
 
-	output, err := ioutil.ReadFile(filename)
+	output, err := os.ReadFile(filename)
 	if err != nil {
 		return pid, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/weaveworks/common/fs/fs.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/weaveworks/common/fs/fs.go
@@ -2,7 +2,6 @@ package fs
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"syscall"
 )
@@ -24,7 +23,19 @@ type realFS struct{}
 var fs Interface = realFS{}
 
 func (realFS) ReadDir(path string) ([]os.FileInfo, error) {
-	return ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
+	if err != nil {
+		return []os.FileInfo{}, err
+	}
+	fileInfos := make([]os.FileInfo, len(files), len(files))
+	for _, file := range files {
+		fileInfo, _ := file.Info()
+		if err != nil {
+			continue
+		}
+		fileInfos = append(fileInfos, fileInfo)
+	}
+	return fileInfos, nil
 }
 
 func (realFS) ReadDirNames(path string) ([]string, error) {
@@ -37,7 +48,7 @@ func (realFS) ReadDirNames(path string) ([]string, error) {
 }
 
 func (realFS) ReadFile(path string) ([]byte, error) {
-	return ioutil.ReadFile(path)
+	return os.ReadFile(path)
 }
 
 func (realFS) Lstat(path string, stat *syscall.Stat_t) error {
@@ -54,7 +65,7 @@ func (realFS) Open(path string) (io.ReadWriteCloser, error) {
 
 // trampolines here to allow users to do fs.ReadDir etc
 
-// ReadDir see ioutil.ReadDir
+// ReadDir see os.ReadDir
 func ReadDir(path string) ([]os.FileInfo, error) {
 	return fs.ReadDir(path)
 }
@@ -69,7 +80,7 @@ func ReadDirCount(path string) (int, error) {
 	return fs.ReadDirCount(path)
 }
 
-// ReadFile see ioutil.ReadFile
+// ReadFile see os.ReadFile
 func ReadFile(path string) ([]byte, error) {
 	return fs.ReadFile(path)
 }

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/weaveworks/common/test/exec/exec.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/weaveworks/common/test/exec/exec.go
@@ -3,7 +3,6 @@ package exec
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 
 	"github.com/weaveworks/common/exec"
 )
@@ -20,7 +19,7 @@ func NewMockCmdString(s string) exec.Cmd {
 			io.Closer
 		}{
 			bytes.NewBufferString(s),
-			ioutil.NopCloser(nil),
+			io.NopCloser(nil),
 		},
 	}
 }
@@ -45,7 +44,7 @@ func (c *mockCmd) StdoutPipe() (io.ReadCloser, error) {
 }
 
 func (c *mockCmd) StderrPipe() (io.ReadCloser, error) {
-	return ioutil.NopCloser(bytes.NewReader(nil)), nil
+	return io.NopCloser(bytes.NewReader(nil)), nil
 }
 
 func (c *mockCmd) Kill() error {
@@ -53,7 +52,7 @@ func (c *mockCmd) Kill() error {
 }
 
 func (c *mockCmd) Output() ([]byte, error) {
-	return ioutil.ReadAll(c.ReadCloser)
+	return io.ReadAll(c.ReadCloser)
 }
 
 func (c *mockCmd) Run() error {

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/weaveworks/common/test/fs/fs.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/weaveworks/common/test/fs/fs.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"syscall"
@@ -232,7 +231,7 @@ func (p File) ReadFile(path string) ([]byte, error) {
 		return nil, fmt.Errorf("I'm a file")
 	}
 	if p.FReader != nil {
-		return ioutil.ReadAll(p.FReader)
+		return io.ReadAll(p.FReader)
 	}
 	return []byte(p.FContents), nil
 }
@@ -266,7 +265,7 @@ func (p File) Open(path string) (io.ReadWriteCloser, error) {
 		io.Writer
 		io.Closer
 	}{
-		buf, buf, ioutil.NopCloser(nil),
+		buf, buf, io.NopCloser(nil),
 	}
 	if p.FReader != nil {
 		s.Reader = p.FReader

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/weaveworks/go-checkpoint/checkpoint.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/weaveworks/go-checkpoint/checkpoint.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"golang.org/x/crypto/scrypt"
 	"io"
-	"io/ioutil"
 	mrand "math/rand"
 	"net/http"
 	"net/url"
@@ -340,9 +339,9 @@ func checkResult(r io.Reader) (*CheckResponse, error) {
 // /sys/class/dmi/id/product_uuid, or, if that is not available,
 // sys/hypervisor/uuid.
 func getSystemUUID() (string, error) {
-	uuid, err := ioutil.ReadFile("/sys/class/dmi/id/product_uuid")
+	uuid, err := os.ReadFile("/sys/class/dmi/id/product_uuid")
 	if os.IsNotExist(err) {
-		uuid, err = ioutil.ReadFile("/sys/hypervisor/uuid")
+		uuid, err = os.ReadFile("/sys/hypervisor/uuid")
 	}
 	if err != nil {
 		return "", err
@@ -361,7 +360,7 @@ func checkSignature(path string) (string, error) {
 	_, err := os.Stat(path)
 	if err == nil {
 		// The file exists, read it out
-		sigBytes, err := ioutil.ReadFile(path)
+		sigBytes, err := os.ReadFile(path)
 		if err != nil {
 			return "", err
 		}
@@ -398,7 +397,7 @@ func checkSignature(path string) (string, error) {
 	}
 
 	// Write the signature
-	if err := ioutil.WriteFile(path, []byte(signature+"\n\n"+userMessage+"\n"), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(signature+"\n\n"+userMessage+"\n"), 0644); err != nil {
 		return "", err
 	}
 

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/weaveworks/tcptracer-bpf/pkg/tracer/tcptracer-ebpf.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/weaveworks/tcptracer-bpf/pkg/tracer/tcptracer-ebpf.go
@@ -10,7 +10,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -200,7 +199,7 @@ func RestoreAsset(dir, name string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(_filePath(dir, name), data, info.Mode())
+	err = os.WriteFile(_filePath(dir, name), data, info.Mode())
 	if err != nil {
 		return err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/golang.org/x/net/http2/transport.go
+++ b/deepfence_agent/tools/apache/scope/vendor/golang.org/x/net/http2/transport.go
@@ -16,7 +16,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"math"
 	mathrand "math/rand"
@@ -2391,7 +2390,7 @@ func (t *Transport) logf(format string, args ...interface{}) {
 	log.Printf(format, args...)
 }
 
-var noBody io.ReadCloser = ioutil.NopCloser(bytes.NewReader(nil))
+var noBody io.ReadCloser = io.NopCloser(bytes.NewReader(nil))
 
 func strSliceContains(ss []string, s string) bool {
 	for _, v := range ss {

--- a/deepfence_agent/tools/apache/scope/vendor/golang.org/x/oauth2/internal/token.go
+++ b/deepfence_agent/tools/apache/scope/vendor/golang.org/x/oauth2/internal/token.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"net/http"
 	"net/url"
@@ -201,7 +200,7 @@ func RetrieveToken(ctx context.Context, clientID, clientSecret, tokenURL string,
 		return nil, err
 	}
 	defer r.Body.Close()
-	body, err := ioutil.ReadAll(io.LimitReader(r.Body, 1<<20))
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 	if err != nil {
 		return nil, fmt.Errorf("oauth2: cannot fetch token: %v", err)
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/golang.org/x/tools/go/gcexportdata/gcexportdata.go
+++ b/deepfence_agent/tools/apache/scope/vendor/golang.org/x/tools/go/gcexportdata/gcexportdata.go
@@ -27,7 +27,6 @@ import (
 	"go/token"
 	"go/types"
 	"io"
-	"io/ioutil"
 
 	"golang.org/x/tools/go/internal/gcimporter"
 )
@@ -70,7 +69,7 @@ func NewReader(r io.Reader) (io.Reader, error) {
 //
 // On return, the state of the reader is undefined.
 func Read(in io.Reader, fset *token.FileSet, imports map[string]*types.Package, path string) (*types.Package, error) {
-	data, err := ioutil.ReadAll(in)
+	data, err := io.ReadAll(in)
 	if err != nil {
 		return nil, fmt.Errorf("reading export data for %q: %v", path, err)
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/golang.org/x/tools/go/internal/gcimporter/gcimporter.go
+++ b/deepfence_agent/tools/apache/scope/vendor/golang.org/x/tools/go/internal/gcimporter/gcimporter.go
@@ -20,7 +20,6 @@ import (
 	"go/token"
 	"go/types"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -195,7 +194,7 @@ func Import(packages map[string]*types.Package, path, srcDir string, lookup func
 
 	case "$$B\n":
 		var data []byte
-		data, err = ioutil.ReadAll(buf)
+		data, err = io.ReadAll(buf)
 		if err != nil {
 			break
 		}

--- a/deepfence_agent/tools/apache/scope/vendor/golang.org/x/tools/go/packages/golist.go
+++ b/deepfence_agent/tools/apache/scope/vendor/golang.org/x/tools/go/packages/golist.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"go/types"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -308,7 +307,7 @@ func runNamedQueries(cfg *Config, driver driver, response *responseDeduper, quer
 			panic(err) // See above.
 		}
 
-		files, err := ioutil.ReadDir(modRoot)
+		files, err := os.ReadDir(modRoot)
 		for _, f := range files {
 			if strings.HasSuffix(f.Name(), ".go") {
 				simpleMatches = append(simpleMatches, rel)
@@ -379,13 +378,13 @@ func runNamedQueries(cfg *Config, driver driver, response *responseDeduper, quer
 		tmpCfg.Env = append(append([]string{"GOPROXY=off"}, cfg.Env...))
 
 		var err error
-		tmpCfg.Dir, err = ioutil.TempDir("", "gopackages-modquery")
+		tmpCfg.Dir, err = os.MkdirTemp("", "gopackages-modquery")
 		if err != nil {
 			return err
 		}
 		defer os.RemoveAll(tmpCfg.Dir)
 
-		if err := ioutil.WriteFile(filepath.Join(tmpCfg.Dir, "go.mod"), gomod.Bytes(), 0777); err != nil {
+		if err := os.WriteFile(filepath.Join(tmpCfg.Dir, "go.mod"), gomod.Bytes(), 0777); err != nil {
 			return fmt.Errorf("writing go.mod for module cache query: %v", err)
 		}
 

--- a/deepfence_agent/tools/apache/scope/vendor/golang.org/x/tools/go/packages/packages.go
+++ b/deepfence_agent/tools/apache/scope/vendor/golang.org/x/tools/go/packages/packages.go
@@ -15,7 +15,6 @@ import (
 	"go/scanner"
 	"go/token"
 	"go/types"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -892,7 +891,7 @@ func (ld *loader) parseFile(filename string) (*ast.File, error) {
 		var err error
 		if src == nil {
 			ioLimit <- true // wait
-			src, err = ioutil.ReadFile(filename)
+			src, err = os.ReadFile(filename)
 			<-ioLimit // signal
 		}
 		if err != nil {

--- a/deepfence_agent/tools/apache/scope/vendor/golang.org/x/tools/imports/fix.go
+++ b/deepfence_agent/tools/apache/scope/vendor/golang.org/x/tools/imports/fix.go
@@ -12,7 +12,6 @@ import (
 	"go/build"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -100,7 +99,7 @@ func parseOtherFiles(fset *token.FileSet, srcDir, filename string) []*ast.File {
 	considerTests := strings.HasSuffix(filename, "_test.go")
 
 	fileBase := filepath.Base(filename)
-	packageFileInfos, err := ioutil.ReadDir(srcDir)
+	packageFileInfos, err := os.ReadDir(srcDir)
 	if err != nil {
 		return nil
 	}
@@ -970,11 +969,11 @@ func loadExports(ctx context.Context, env *fixEnv, expectPackage string, pkg *pk
 	exports := make(map[string]bool)
 
 	// Look for non-test, buildable .go files which could provide exports.
-	all, err := ioutil.ReadDir(pkg.dir)
+	all, err := os.ReadDir(pkg.dir)
 	if err != nil {
 		return nil, err
 	}
-	var files []os.FileInfo
+	var files []os.DirEntry
 	for _, fi := range all {
 		name := fi.Name()
 		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {

--- a/deepfence_agent/tools/apache/scope/vendor/golang.org/x/tools/imports/imports.go
+++ b/deepfence_agent/tools/apache/scope/vendor/golang.org/x/tools/imports/imports.go
@@ -19,7 +19,7 @@ import (
 	"go/printer"
 	"go/token"
 	"io"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -55,7 +55,7 @@ func process(filename string, src []byte, opt *Options, env *fixEnv) ([]byte, er
 		opt = &Options{Comments: true, TabIndent: true, TabWidth: 8}
 	}
 	if src == nil {
-		b, err := ioutil.ReadFile(filename)
+		b, err := os.ReadFile(filename)
 		if err != nil {
 			return nil, err
 		}

--- a/deepfence_agent/tools/apache/scope/vendor/golang.org/x/tools/imports/mod.go
+++ b/deepfence_agent/tools/apache/scope/vendor/golang.org/x/tools/imports/mod.go
@@ -3,7 +3,6 @@ package imports
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -105,7 +104,7 @@ func (r *moduleResolver) findPackage(importPath string) (*moduleJSON, string) {
 			continue
 		}
 
-		pkgFiles, err := ioutil.ReadDir(pkgDir)
+		pkgFiles, err := os.ReadDir(pkgDir)
 		if err != nil {
 			continue
 		}
@@ -285,7 +284,7 @@ func (r *moduleResolver) scan(_ references) ([]*pkg, error) {
 				modFile = findModFile(dir)
 			}
 
-			modBytes, err := ioutil.ReadFile(modFile)
+			modBytes, err := os.ReadFile(modFile)
 			if err == nil && !strings.HasPrefix(importPath, modulePath(modBytes)) {
 				// The module's declared path does not match
 				// its expected path. It probably needs a

--- a/deepfence_agent/tools/apache/scope/vendor/golang.org/x/tools/internal/fastwalk/fastwalk_portable.go
+++ b/deepfence_agent/tools/apache/scope/vendor/golang.org/x/tools/internal/fastwalk/fastwalk_portable.go
@@ -7,7 +7,6 @@
 package fastwalk
 
 import (
-	"io/ioutil"
 	"os"
 )
 
@@ -16,16 +15,17 @@ import (
 // If fn returns a non-nil error, readDir returns with that error
 // immediately.
 func readDir(dirName string, fn func(dirName, entName string, typ os.FileMode) error) error {
-	fis, err := ioutil.ReadDir(dirName)
+	fis, err := os.ReadDir(dirName)
 	if err != nil {
 		return err
 	}
 	skipFiles := false
 	for _, fi := range fis {
-		if fi.Mode().IsRegular() && skipFiles {
+		fInfo, _ := fi.Info()
+		if fInfo.Mode().IsRegular() && skipFiles {
 			continue
 		}
-		if err := fn(dirName, fi.Name(), fi.Mode()&os.ModeType); err != nil {
+		if err := fn(dirName, fi.Name(), fInfo.Mode()&os.ModeType); err != nil {
 			if err == SkipFiles {
 				skipFiles = true
 				continue

--- a/deepfence_agent/tools/apache/scope/vendor/golang.org/x/tools/internal/gopathwalk/walk.go
+++ b/deepfence_agent/tools/apache/scope/vendor/golang.org/x/tools/internal/gopathwalk/walk.go
@@ -11,7 +11,6 @@ import (
 	"bytes"
 	"fmt"
 	"go/build"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -127,7 +126,7 @@ func (w *walker) init() {
 // The provided path is one of the $GOPATH entries with "src" appended.
 func (w *walker) getIgnoredDirs(path string) []string {
 	file := filepath.Join(path, ".goimportsignore")
-	slurp, err := ioutil.ReadFile(file)
+	slurp, err := os.ReadFile(file)
 	if w.opts.Debug {
 		if err != nil {
 			log.Print(err)

--- a/deepfence_agent/tools/apache/scope/vendor/google.golang.org/appengine/internal/api.go
+++ b/deepfence_agent/tools/apache/scope/vendor/google.golang.org/appengine/internal/api.go
@@ -10,7 +10,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -390,7 +390,7 @@ func (c *context) post(body []byte, timeout time.Duration) (b []byte, err error)
 			apiContentType:    apiContentTypeValue,
 			apiDeadlineHeader: []string{strconv.FormatFloat(timeout.Seconds(), 'f', -1, 64)},
 		},
-		Body:          ioutil.NopCloser(bytes.NewReader(body)),
+		Body:          io.NopCloser(bytes.NewReader(body)),
 		ContentLength: int64(len(body)),
 		Host:          c.apiURL.Host,
 	}
@@ -424,7 +424,7 @@ func (c *context) post(body []byte, timeout time.Duration) (b []byte, err error)
 		}
 	}
 	defer hresp.Body.Close()
-	hrespBody, err := ioutil.ReadAll(hresp.Body)
+	hrespBody, err := io.ReadAll(hresp.Body)
 	if hresp.StatusCode != 200 {
 		return nil, &CallError{
 			Detail: fmt.Sprintf("service bridge returned HTTP %d (%q)", hresp.StatusCode, hrespBody),

--- a/deepfence_agent/tools/apache/scope/vendor/google.golang.org/appengine/internal/metadata.go
+++ b/deepfence_agent/tools/apache/scope/vendor/google.golang.org/appengine/internal/metadata.go
@@ -11,7 +11,7 @@ package internal
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 )
@@ -56,5 +56,5 @@ func getMetadata(key string) ([]byte, error) {
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("metadata server returned HTTP %d", resp.StatusCode)
 	}
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }

--- a/deepfence_agent/tools/apache/scope/vendor/google.golang.org/appengine/urlfetch/urlfetch.go
+++ b/deepfence_agent/tools/apache/scope/vendor/google.golang.org/appengine/urlfetch/urlfetch.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -158,7 +157,7 @@ func (t *Transport) RoundTrip(req *http.Request) (res *http.Response, err error)
 		}:
 			freq.Payload = b.Bytes()
 		default:
-			freq.Payload, err = ioutil.ReadAll(req.Body)
+			freq.Payload, err = io.ReadAll(req.Body)
 			if err != nil {
 				return nil, err
 			}

--- a/deepfence_agent/tools/apache/scope/vendor/google.golang.org/grpc/credentials/credentials.go
+++ b/deepfence_agent/tools/apache/scope/vendor/google.golang.org/grpc/credentials/credentials.go
@@ -28,8 +28,8 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"strings"
 
 	"github.com/golang/protobuf/proto"
@@ -226,7 +226,7 @@ func NewClientTLSFromCert(cp *x509.CertPool, serverNameOverride string) Transpor
 // serverNameOverride is for testing only. If set to a non empty string,
 // it will override the virtual host name of authority (e.g. :authority header field) in requests.
 func NewClientTLSFromFile(certFile, serverNameOverride string) (TransportCredentials, error) {
-	b, err := ioutil.ReadFile(certFile)
+	b, err := os.ReadFile(certFile)
 	if err != nil {
 		return nil, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/google.golang.org/grpc/grpclog/loggerv2.go
+++ b/deepfence_agent/tools/apache/scope/vendor/google.golang.org/grpc/grpclog/loggerv2.go
@@ -20,7 +20,6 @@ package grpclog
 
 import (
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"strconv"
@@ -117,9 +116,9 @@ func NewLoggerV2WithVerbosity(infoW, warningW, errorW io.Writer, v int) LoggerV2
 // newLoggerV2 creates a loggerV2 to be used as default logger.
 // All logs are written to stderr.
 func newLoggerV2() LoggerV2 {
-	errorW := ioutil.Discard
-	warningW := ioutil.Discard
-	infoW := ioutil.Discard
+	errorW := io.Discard
+	warningW := io.Discard
+	infoW := io.Discard
 
 	logLevel := os.Getenv("GRPC_GO_LOG_SEVERITY_LEVEL")
 	switch logLevel {

--- a/deepfence_agent/tools/apache/scope/vendor/google.golang.org/grpc/internal/binarylog/sink.go
+++ b/deepfence_agent/tools/apache/scope/vendor/google.golang.org/grpc/internal/binarylog/sink.go
@@ -23,7 +23,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"sync"
 	"time"
 
@@ -154,7 +154,7 @@ func newBufWriteCloserSink(o io.WriteCloser) Sink {
 // NewTempFileSink creates a temp file and returns a Sink that writes to this
 // file.
 func NewTempFileSink() (Sink, error) {
-	tempFile, err := ioutil.TempFile("/tmp", "grpcgo_binarylog_*.txt")
+	tempFile, err := os.CreateTemp("/tmp", "grpcgo_binarylog_*.txt")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp file: %v", err)
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/google.golang.org/grpc/rpc_util.go
+++ b/deepfence_agent/tools/apache/scope/vendor/google.golang.org/grpc/rpc_util.go
@@ -25,7 +25,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/url"
 	"strings"
@@ -78,7 +77,7 @@ func NewGZIPCompressorWithLevel(level int) (Compressor, error) {
 	return &gzipCompressor{
 		pool: sync.Pool{
 			New: func() interface{} {
-				w, err := gzip.NewWriterLevel(ioutil.Discard, level)
+				w, err := gzip.NewWriterLevel(io.Discard, level)
 				if err != nil {
 					panic(err)
 				}
@@ -144,7 +143,7 @@ func (d *gzipDecompressor) Do(r io.Reader) ([]byte, error) {
 		z.Close()
 		d.pool.Put(z)
 	}()
-	return ioutil.ReadAll(z)
+	return io.ReadAll(z)
 }
 
 func (d *gzipDecompressor) Type() string {
@@ -663,7 +662,7 @@ func recvAndDecompress(p *parser, s *transport.Stream, dc Decompressor, maxRecei
 			}
 			// Read from LimitReader with limit max+1. So if the underlying
 			// reader is over limit, the result will be bigger than max.
-			d, err = ioutil.ReadAll(io.LimitReader(dcReader, int64(maxReceiveMessageSize)+1))
+			d, err = io.ReadAll(io.LimitReader(dcReader, int64(maxReceiveMessageSize)+1))
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "grpc: failed to decompress the received message %v", err)
 			}

--- a/deepfence_agent/tools/apache/scope/vendor/k8s.io/apimachinery/pkg/util/yaml/decoder.go
+++ b/deepfence_agent/tools/apache/scope/vendor/k8s.io/apimachinery/pkg/util/yaml/decoder.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"unicode"
 
@@ -228,7 +227,7 @@ func (d *YAMLOrJSONDecoder) Decode(into interface{}) error {
 	err := d.decoder.Decode(into)
 	if jsonDecoder, ok := d.decoder.(*json.Decoder); ok {
 		if syntax, ok := err.(*json.SyntaxError); ok {
-			data, readErr := ioutil.ReadAll(jsonDecoder.Buffered())
+			data, readErr := io.ReadAll(jsonDecoder.Buffered())
 			if readErr != nil {
 				klog.V(4).Infof("reading stream failed: %v", readErr)
 			}

--- a/deepfence_agent/tools/apache/scope/vendor/k8s.io/cli-runtime/pkg/genericclioptions/io_options.go
+++ b/deepfence_agent/tools/apache/scope/vendor/k8s.io/cli-runtime/pkg/genericclioptions/io_options.go
@@ -19,7 +19,6 @@ package genericclioptions
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 )
 
 // IOStreams provides the standard names for iostreams.  This is useful for embedding and for unit testing.
@@ -51,7 +50,7 @@ func NewTestIOStreamsDiscard() IOStreams {
 	in := &bytes.Buffer{}
 	return IOStreams{
 		In:     in,
-		Out:    ioutil.Discard,
-		ErrOut: ioutil.Discard,
+		Out:    io.Discard,
+		ErrOut: io.Discard,
 	}
 }

--- a/deepfence_agent/tools/apache/scope/vendor/k8s.io/cli-runtime/pkg/genericclioptions/jsonpath_flags.go
+++ b/deepfence_agent/tools/apache/scope/vendor/k8s.io/cli-runtime/pkg/genericclioptions/jsonpath_flags.go
@@ -18,7 +18,7 @@ package genericclioptions
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sort"
 	"strings"
 
@@ -86,7 +86,7 @@ func (f *JSONPathPrintFlags) ToPrinter(templateFormat string) (printers.Resource
 	}
 
 	if templateFormat == "jsonpath-file" {
-		data, err := ioutil.ReadFile(templateValue)
+		data, err := os.ReadFile(templateValue)
 		if err != nil {
 			return nil, fmt.Errorf("error reading --template %s, %v\n", templateValue, err)
 		}

--- a/deepfence_agent/tools/apache/scope/vendor/k8s.io/cli-runtime/pkg/genericclioptions/template_flags.go
+++ b/deepfence_agent/tools/apache/scope/vendor/k8s.io/cli-runtime/pkg/genericclioptions/template_flags.go
@@ -18,7 +18,7 @@ package genericclioptions
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sort"
 	"strings"
 
@@ -88,7 +88,7 @@ func (f *GoTemplatePrintFlags) ToPrinter(templateFormat string) (printers.Resour
 	}
 
 	if templateFormat == "templatefile" || templateFormat == "go-template-file" {
-		data, err := ioutil.ReadFile(templateValue)
+		data, err := os.ReadFile(templateValue)
 		if err != nil {
 			return nil, fmt.Errorf("error reading --template %s, %v\n", templateValue, err)
 		}

--- a/deepfence_agent/tools/apache/scope/vendor/k8s.io/client-go/discovery/cached_discovery.go
+++ b/deepfence_agent/tools/apache/scope/vendor/k8s.io/client-go/discovery/cached_discovery.go
@@ -18,7 +18,7 @@ package discovery
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -151,7 +151,7 @@ func (d *CachedDiscoveryClient) getCachedFile(filename string) ([]byte, error) {
 	}
 
 	// the cache is present and its valid.  Try to read and use it.
-	cachedBytes, err := ioutil.ReadAll(file)
+	cachedBytes, err := io.ReadAll(file)
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +173,7 @@ func (d *CachedDiscoveryClient) writeCachedFile(filename string, obj runtime.Obj
 		return err
 	}
 
-	f, err := ioutil.TempFile(filepath.Dir(filename), filepath.Base(filename)+".")
+	f, err := os.CreateTemp(filepath.Dir(filename), filepath.Base(filename)+".")
 	if err != nil {
 		return err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/k8s.io/client-go/rest/config.go
+++ b/deepfence_agent/tools/apache/scope/vendor/k8s.io/client-go/rest/config.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -388,7 +387,7 @@ func dataFromSliceOrFile(data []byte, file string) ([]byte, error) {
 		return data, nil
 	}
 	if len(file) > 0 {
-		fileData, err := ioutil.ReadFile(file)
+		fileData, err := os.ReadFile(file)
 		if err != nil {
 			return []byte{}, err
 		}

--- a/deepfence_agent/tools/apache/scope/vendor/k8s.io/client-go/rest/token_source.go
+++ b/deepfence_agent/tools/apache/scope/vendor/k8s.io/client-go/rest/token_source.go
@@ -18,8 +18,8 @@ package rest
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -80,7 +80,7 @@ type fileTokenSource struct {
 var _ = oauth2.TokenSource(&fileTokenSource{})
 
 func (ts *fileTokenSource) Token() (*oauth2.Token, error) {
-	tokb, err := ioutil.ReadFile(ts.path)
+	tokb, err := os.ReadFile(ts.path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read token file %q: %v", ts.path, err)
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/k8s.io/client-go/tools/auth/clientauth.go
+++ b/deepfence_agent/tools/apache/scope/vendor/k8s.io/client-go/tools/auth/clientauth.go
@@ -65,7 +65,6 @@ package auth
 // TODO: need a way to rotate Tokens.  Therefore, need a way for client object to be reset when the authcfg is updated.
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 
 	restclient "k8s.io/client-go/rest"
@@ -90,7 +89,7 @@ func LoadFromFile(path string) (*Info, error) {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		return nil, err
 	}
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/k8s.io/client-go/tools/clientcmd/api/helpers.go
+++ b/deepfence_agent/tools/apache/scope/vendor/k8s.io/client-go/tools/clientcmd/api/helpers.go
@@ -20,7 +20,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -149,7 +148,7 @@ func FlattenContent(path *string, contents *[]byte, baseDir string) error {
 
 		var err error
 		absPath := ResolvePath(*path, baseDir)
-		*contents, err = ioutil.ReadFile(absPath)
+		*contents, err = os.ReadFile(absPath)
 		if err != nil {
 			return err
 		}

--- a/deepfence_agent/tools/apache/scope/vendor/k8s.io/client-go/tools/clientcmd/auth_loaders.go
+++ b/deepfence_agent/tools/apache/scope/vendor/k8s.io/client-go/tools/clientcmd/auth_loaders.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"golang.org/x/crypto/ssh/terminal"
@@ -59,7 +58,7 @@ func (a *PromptingAuthLoader) LoadAuth(path string) (*clientauth.Info, error) {
 		if err != nil {
 			return &auth, err
 		}
-		err = ioutil.WriteFile(path, data, 0600)
+		err = os.WriteFile(path, data, 0600)
 		return &auth, err
 	}
 	authPtr, err := clientauth.LoadFromFile(path)

--- a/deepfence_agent/tools/apache/scope/vendor/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/deepfence_agent/tools/apache/scope/vendor/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -19,7 +19,6 @@ package clientcmd
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"strings"
@@ -517,7 +516,7 @@ func (config *inClusterClientConfig) Namespace() (string, bool, error) {
 	}
 
 	// Fall back to the namespace associated with the service account token, if available
-	if data, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+	if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
 		if ns := strings.TrimSpace(string(data)); len(ns) > 0 {
 			return ns, false, nil
 		}

--- a/deepfence_agent/tools/apache/scope/vendor/k8s.io/client-go/tools/clientcmd/loader.go
+++ b/deepfence_agent/tools/apache/scope/vendor/k8s.io/client-go/tools/clientcmd/loader.go
@@ -19,7 +19,6 @@ package clientcmd
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -348,7 +347,7 @@ func (rules *ClientConfigLoadingRules) IsDefaultConfig(config *restclient.Config
 
 // LoadFromFile takes a filename and deserializes the contents into Config object
 func LoadFromFile(filename string) (*clientcmdapi.Config, error) {
-	kubeconfigBytes, err := ioutil.ReadFile(filename)
+	kubeconfigBytes, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -414,7 +413,7 @@ func WriteToFile(config clientcmdapi.Config, filename string) error {
 		}
 	}
 
-	if err := ioutil.WriteFile(filename, content, 0600); err != nil {
+	if err := os.WriteFile(filename, content, 0600); err != nil {
 		return err
 	}
 	return nil

--- a/deepfence_agent/tools/apache/scope/vendor/k8s.io/client-go/transport/transport.go
+++ b/deepfence_agent/tools/apache/scope/vendor/k8s.io/client-go/transport/transport.go
@@ -20,7 +20,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"net/http"
 )
 
@@ -143,7 +143,7 @@ func dataFromSliceOrFile(data []byte, file string) ([]byte, error) {
 		return data, nil
 	}
 	if len(file) > 0 {
-		fileData, err := ioutil.ReadFile(file)
+		fileData, err := os.ReadFile(file)
 		if err != nil {
 			return []byte{}, err
 		}

--- a/deepfence_agent/tools/apache/scope/vendor/k8s.io/client-go/util/cert/cert.go
+++ b/deepfence_agent/tools/apache/scope/vendor/k8s.io/client-go/util/cert/cert.go
@@ -29,10 +29,10 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"math/big"
 	"net"
+	"os"
 	"path"
 	"strings"
 	"time"
@@ -162,9 +162,9 @@ func GenerateSelfSignedCertKeyWithFixtures(host string, alternateIPs []net.IP, a
 	certFixturePath := path.Join(fixtureDirectory, baseName+".crt")
 	keyFixturePath := path.Join(fixtureDirectory, baseName+".key")
 	if len(fixtureDirectory) > 0 {
-		cert, err := ioutil.ReadFile(certFixturePath)
+		cert, err := os.ReadFile(certFixturePath)
 		if err == nil {
-			key, err := ioutil.ReadFile(keyFixturePath)
+			key, err := os.ReadFile(keyFixturePath)
 			if err == nil {
 				return cert, key, nil
 			}
@@ -249,10 +249,10 @@ func GenerateSelfSignedCertKeyWithFixtures(host string, alternateIPs []net.IP, a
 	}
 
 	if len(fixtureDirectory) > 0 {
-		if err := ioutil.WriteFile(certFixturePath, certBuffer.Bytes(), 0644); err != nil {
+		if err := os.WriteFile(certFixturePath, certBuffer.Bytes(), 0644); err != nil {
 			return nil, nil, fmt.Errorf("failed to write cert fixture to %s: %v", certFixturePath, err)
 		}
-		if err := ioutil.WriteFile(keyFixturePath, keyBuffer.Bytes(), 0644); err != nil {
+		if err := os.WriteFile(keyFixturePath, keyBuffer.Bytes(), 0644); err != nil {
 			return nil, nil, fmt.Errorf("failed to write key fixture to %s: %v", certFixturePath, err)
 		}
 	}

--- a/deepfence_agent/tools/apache/scope/vendor/k8s.io/client-go/util/cert/io.go
+++ b/deepfence_agent/tools/apache/scope/vendor/k8s.io/client-go/util/cert/io.go
@@ -23,7 +23,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -70,7 +69,7 @@ func WriteCert(certPath string, data []byte) error {
 	if err := os.MkdirAll(filepath.Dir(certPath), os.FileMode(0755)); err != nil {
 		return err
 	}
-	return ioutil.WriteFile(certPath, data, os.FileMode(0644))
+	return os.WriteFile(certPath, data, os.FileMode(0644))
 }
 
 // WriteKey writes the pem-encoded key data to keyPath.
@@ -81,13 +80,13 @@ func WriteKey(keyPath string, data []byte) error {
 	if err := os.MkdirAll(filepath.Dir(keyPath), os.FileMode(0755)); err != nil {
 		return err
 	}
-	return ioutil.WriteFile(keyPath, data, os.FileMode(0600))
+	return os.WriteFile(keyPath, data, os.FileMode(0600))
 }
 
 // LoadOrGenerateKeyFile looks for a key in the file at the given path. If it
 // can't find one, it will generate a new key and store it there.
 func LoadOrGenerateKeyFile(keyPath string) (data []byte, wasGenerated bool, err error) {
-	loadedData, err := ioutil.ReadFile(keyPath)
+	loadedData, err := os.ReadFile(keyPath)
 	// Call verifyKeyData to ensure the file wasn't empty/corrupt.
 	if err == nil && verifyKeyData(loadedData) {
 		return loadedData, false, err
@@ -144,7 +143,7 @@ func NewPool(filename string) (*x509.CertPool, error) {
 // CertsFromFile returns the x509.Certificates contained in the given PEM-encoded file.
 // Returns an error if the file could not be read, a certificate could not be parsed, or if the file does not contain any certificates
 func CertsFromFile(file string) ([]*x509.Certificate, error) {
-	pemBlock, err := ioutil.ReadFile(file)
+	pemBlock, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +157,7 @@ func CertsFromFile(file string) ([]*x509.Certificate, error) {
 // PrivateKeyFromFile returns the private key in rsa.PrivateKey or ecdsa.PrivateKey format from a given PEM-encoded file.
 // Returns an error if the file could not be read or if the private key could not be parsed.
 func PrivateKeyFromFile(file string) (interface{}, error) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +171,7 @@ func PrivateKeyFromFile(file string) (interface{}, error) {
 // PublicKeysFromFile returns the public keys in rsa.PublicKey or ecdsa.PublicKey format from a given PEM-encoded file.
 // Reads public keys from both public and private key files.
 func PublicKeysFromFile(file string) ([]interface{}, error) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}

--- a/deepfence_backend/minica.go
+++ b/deepfence_backend/minica.go
@@ -13,7 +13,6 @@ import (
 	"encoding/pem"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math"
 	"math/big"
@@ -37,8 +36,8 @@ type issuer struct {
 }
 
 func getIssuer(keyFile, certFile string) (*issuer, error) {
-	keyContents, keyErr := ioutil.ReadFile(keyFile)
-	certContents, certErr := ioutil.ReadFile(certFile)
+	keyContents, keyErr := os.ReadFile(keyFile)
+	certContents, certErr := os.ReadFile(certFile)
 	if os.IsNotExist(keyErr) && os.IsNotExist(certErr) {
 		err := makeIssuer(keyFile, certFile)
 		if err != nil {

--- a/deepfence_backend/websocket_api/scope_websocket_client/main.go
+++ b/deepfence_backend/websocket_api/scope_websocket_client/main.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -300,7 +300,7 @@ func (wsCli *WebsocketClient) updateNodeCount() error {
 		return err
 	}
 	if resp.StatusCode == http.StatusOK {
-		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		bodyBytes, err := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		if err != nil {
 			return err

--- a/deepfence_console/clair/api/api.go
+++ b/deepfence_console/clair/api/api.go
@@ -17,9 +17,9 @@ package api
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
 	"strconv"
 	"time"
 
@@ -133,7 +133,7 @@ func tlsClientConfig(caPath string) (*tls.Config, error) {
 		return nil, nil
 	}
 
-	caCert, err := ioutil.ReadFile(caPath)
+	caCert, err := os.ReadFile(caPath)
 	if err != nil {
 		return nil, err
 	}

--- a/deepfence_console/clair/cmd/clair/config.go
+++ b/deepfence_console/clair/cmd/clair/config.go
@@ -16,7 +16,7 @@ package main
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"os"
 	"time"
 
@@ -84,7 +84,7 @@ func LoadConfig(path string) (config *Config, err error) {
 	}
 	defer f.Close()
 
-	d, err := ioutil.ReadAll(f)
+	d, err := io.ReadAll(f)
 	if err != nil {
 		return
 	}

--- a/deepfence_console/clair/cve_server/cve-server.go
+++ b/deepfence_console/clair/cve_server/cve-server.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -160,7 +159,7 @@ func handleDeleteDumpsMethod(respWrite http.ResponseWriter, req *http.Request) {
 	}
 
 	folderPath := "/data/core_dumps"
-	dirs, err := ioutil.ReadDir(folderPath)
+	dirs, err := os.ReadDir(folderPath)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -168,7 +167,7 @@ func handleDeleteDumpsMethod(respWrite http.ResponseWriter, req *http.Request) {
 
 	for _, f := range dirs {
 		if f.IsDir() {
-			files, err := ioutil.ReadDir(folderPath + "/" + f.Name())
+			files, err := os.ReadDir(folderPath + "/" + f.Name())
 			if err != nil {
 				fmt.Println(err)
 				return
@@ -308,7 +307,7 @@ func callRegistryCredentialApi(credentialId string) (string, error) {
 		return "", err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
@@ -643,7 +642,7 @@ func addToLogstash(respWrite http.ResponseWriter, req *http.Request) {
 		http.Error(respWrite, "invalid request", http.StatusInternalServerError)
 		return
 	}
-	body, err := ioutil.ReadAll(req.Body)
+	body, err := io.ReadAll(req.Body)
 	if err != nil {
 		http.Error(respWrite, "Error reading request body", http.StatusInternalServerError)
 		return

--- a/deepfence_console/clair/database/pgsql/pgsql.go
+++ b/deepfence_console/clair/database/pgsql/pgsql.go
@@ -18,8 +18,8 @@ package pgsql
 import (
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -170,7 +170,7 @@ func openDatabase(registrableComponentConfig database.RegistrableComponentConfig
 	if pg.config.FixturePath != "" {
 		log.Info("pgsql: loading fixtures")
 
-		d, err := ioutil.ReadFile(pg.config.FixturePath)
+		d, err := os.ReadFile(pg.config.FixturePath)
 		if err != nil {
 			pg.Close()
 			return nil, fmt.Errorf("pgsql: could not open fixture file: %v", err)

--- a/deepfence_console/clair/ext/featurefmt/driver.go
+++ b/deepfence_console/clair/ext/featurefmt/driver.go
@@ -17,7 +17,7 @@
 package featurefmt
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"runtime"
 	"sync"
@@ -108,7 +108,7 @@ type TestData struct {
 // that is meant to be used for test data.
 func LoadFileForTest(name string) []byte {
 	_, filename, _, _ := runtime.Caller(0)
-	d, _ := ioutil.ReadFile(filepath.Join(filepath.Dir(filename)) + "/" + name)
+	d, _ := os.ReadFile(filepath.Join(filepath.Dir(filename)) + "/" + name)
 	return d
 }
 

--- a/deepfence_console/clair/ext/featurefmt/rpm/rpm.go
+++ b/deepfence_console/clair/ext/featurefmt/rpm/rpm.go
@@ -17,7 +17,6 @@ package rpm
 
 import (
 	"bufio"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -48,14 +47,14 @@ func (l lister) ListFeatures(files tarutil.FilesMap) ([]database.FeatureVersion,
 	packagesMap := make(map[string]database.FeatureVersion)
 
 	// Write the required "Packages" file to disk
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "rpm")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "rpm")
 	defer os.RemoveAll(tmpDir)
 	if err != nil {
 		log.WithError(err).Error("could not create temporary folder for RPM detection")
 		return []database.FeatureVersion{}, commonerr.ErrFilesystem
 	}
 
-	err = ioutil.WriteFile(tmpDir+"/Packages", f, 0700)
+	err = os.WriteFile(tmpDir+"/Packages", f, 0700)
 	if err != nil {
 		log.WithError(err).Error("could not create temporary file for RPM detection")
 		return []database.FeatureVersion{}, commonerr.ErrFilesystem

--- a/deepfence_console/clair/ext/notification/webhook/webhook.go
+++ b/deepfence_console/clair/ext/notification/webhook/webhook.go
@@ -22,9 +22,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"time"
 
 	"gopkg.in/yaml.v2"
@@ -148,7 +148,7 @@ func loadTLSClientConfig(cfg *Config) (*tls.Config, error) {
 
 	var caCertPool *x509.CertPool
 	if cfg.CAFile != "" {
-		caCert, err := ioutil.ReadFile(cfg.CAFile)
+		caCert, err := os.ReadFile(cfg.CAFile)
 		if err != nil {
 			return nil, err
 		}

--- a/deepfence_console/clair/ext/vulnmdsrc/nvd/nvd.go
+++ b/deepfence_console/clair/ext/vulnmdsrc/nvd/nvd.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"io"
 
-	//"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"

--- a/deepfence_console/clair/ext/vulnsrc/alpine/alpine.go
+++ b/deepfence_console/clair/ext/vulnsrc/alpine/alpine.go
@@ -20,7 +20,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -81,7 +80,7 @@ func (u *updater) processFile(filename string) {
 
 	// find hash of file contents as part of checking for changes
 	file_hasher := sha256.New()
-	fileContents, err := ioutil.ReadAll(response.Body)
+	fileContents, err := io.ReadAll(response.Body)
 	file_hasher.Write([]byte(fileContents[:]))
 
 	// Must be a better way to achieve this...
@@ -148,7 +147,7 @@ func (u *updater) getVulnFiles(repoPath, tempDirPrefix string) (commit string, e
 
 	// Set up temporary location for downlaods
 	if repoPath == "" {
-		u.repositoryLocalPath, err = ioutil.TempDir(os.TempDir(), tempDirPrefix)
+		u.repositoryLocalPath, err = os.MkdirTemp(os.TempDir(), tempDirPrefix)
 		if err != nil {
 			return
 		}
@@ -328,7 +327,7 @@ type secDBFile struct {
 
 func parseYAML(r io.Reader) (vulns []database.Vulnerability, err error) {
 	var rBytes []byte
-	rBytes, err = ioutil.ReadAll(r)
+	rBytes, err = io.ReadAll(r)
 	if err != nil {
 		return
 	}

--- a/deepfence_console/clair/ext/vulnsrc/amzn/amzn_test.go
+++ b/deepfence_console/clair/ext/vulnsrc/amzn/amzn_test.go
@@ -18,7 +18,6 @@
 package amzn
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -41,10 +40,10 @@ func TestAmazonLinux1(t *testing.T) {
 	_, filename, _, _ := runtime.Caller(0)
 	path := filepath.Join(filepath.Dir(filename))
 
-	expectedDescription0Bytes, _ := ioutil.ReadFile(path + "/testdata/amazon_linux_1_description_0.txt")
+	expectedDescription0Bytes, _ := os.ReadFile(path + "/testdata/amazon_linux_1_description_0.txt")
 	expectedDescription0 := string(expectedDescription0Bytes)
 
-	expectedDescription1Bytes, _ := ioutil.ReadFile(path + "/testdata/amazon_linux_1_description_1.txt")
+	expectedDescription1Bytes, _ := os.ReadFile(path + "/testdata/amazon_linux_1_description_1.txt")
 	expectedDescription1 := string(expectedDescription1Bytes)
 
 	updateInfoXml, _ := os.Open(path + "/testdata/amazon_linux_1_updateinfo.xml")
@@ -134,10 +133,10 @@ func TestAmazonLinux2(t *testing.T) {
 	_, filename, _, _ := runtime.Caller(0)
 	path := filepath.Join(filepath.Dir(filename))
 
-	expectedDescription0Bytes, _ := ioutil.ReadFile(path + "/testdata/amazon_linux_2_description_0.txt")
+	expectedDescription0Bytes, _ := os.ReadFile(path + "/testdata/amazon_linux_2_description_0.txt")
 	expectedDescription0 := string(expectedDescription0Bytes)
 
-	expectedDescription1Bytes, _ := ioutil.ReadFile(path + "/testdata/amazon_linux_2_description_1.txt")
+	expectedDescription1Bytes, _ := os.ReadFile(path + "/testdata/amazon_linux_2_description_1.txt")
 	expectedDescription1 := string(expectedDescription1Bytes)
 
 	updateInfoXml, _ := os.Open(path + "/testdata/amazon_linux_2_updateinfo.xml")

--- a/deepfence_console/clair/pkg/tarutil/tarutil.go
+++ b/deepfence_console/clair/pkg/tarutil/tarutil.go
@@ -23,7 +23,6 @@ import (
 	"compress/gzip"
 	"errors"
 	"io"
-	"io/ioutil"
 	"os/exec"
 	"strings"
 )
@@ -92,7 +91,7 @@ func ExtractFiles(r io.Reader, filenames []string) (FilesMap, error) {
 
 			// Extract the element
 			if hdr.Typeflag == tar.TypeSymlink || hdr.Typeflag == tar.TypeLink || hdr.Typeflag == tar.TypeReg {
-				d, _ := ioutil.ReadAll(tr)
+				d, _ := io.ReadAll(tr)
 				data[filename] = d
 			}
 		}
@@ -174,7 +173,7 @@ func NewTarReadCloser(r io.Reader) (*TarReadCloser, error) {
 			}
 			return &TarReadCloser{tar.NewReader(gr), gr}, nil
 		case bytes.HasPrefix(header, bzip2Header):
-			bzip2r := ioutil.NopCloser(bzip2.NewReader(br))
+			bzip2r := io.NopCloser(bzip2.NewReader(br))
 			return &TarReadCloser{tar.NewReader(bzip2r), bzip2r}, nil
 		case bytes.HasPrefix(header, xzHeader):
 			xzr, err := NewXzReader(br)
@@ -185,6 +184,6 @@ func NewTarReadCloser(r io.Reader) (*TarReadCloser, error) {
 		}
 	}
 
-	dr := ioutil.NopCloser(br)
+	dr := io.NopCloser(br)
 	return &TarReadCloser{tar.NewReader(dr), dr}, nil
 }

--- a/deepfence_console/deepaudit/depcheck.go
+++ b/deepfence_console/deepaudit/depcheck.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -26,7 +25,7 @@ func untarHostFiles(sourceDir string, fileExtn string, language string) (string,
 	} else {
 		tmpExtn = "tmp" + "-" + fileExtn
 	}
-	resultDir, tmpErrVal = ioutil.TempDir("", tmpExtn)
+	resultDir, tmpErrVal = os.MkdirTemp("", tmpExtn)
 	if tmpErrVal != nil {
 		return "", tmpErrVal
 	}
@@ -86,12 +85,12 @@ func untarFiles(srcDir string, fileExtn string) (string, error) {
 		tmpExtn = "tmp" + "-" + fileExtn
 	}
 	if runtime.GOOS == "windows" {
-		resultDir, errVal = ioutil.TempDir("C:/ProgramData/Deepfence/temp", tmpExtn)
+		resultDir, errVal = os.MkdirTemp("C:/ProgramData/Deepfence/temp", tmpExtn)
 		if errVal != nil {
 			return "", errVal
 		}
 	} else {
-		resultDir, errVal = ioutil.TempDir("", tmpExtn)
+		resultDir, errVal = os.MkdirTemp("", tmpExtn)
 		if errVal != nil {
 			return "", errVal
 		}

--- a/deepfence_console/deepaudit/jsonParser.go
+++ b/deepfence_console/deepaudit/jsonParser.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -152,7 +151,7 @@ func decodeDepCheckJson(language string, extFileDirList []string, fileSet map[st
 	} else {
 		fileName = fmt.Sprintf("/root/output_" + start_time + ".json")
 	}
-	fileBuff, err := ioutil.ReadFile(fileName)
+	fileBuff, err := os.ReadFile(fileName)
 	if err != nil {
 		return err
 	}

--- a/deepfence_console/deepaudit/main.go
+++ b/deepfence_console/deepaudit/main.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"html"
 	"io"
-	"io/ioutil"
 	"log"
 	"mime/multipart"
 	"net"
@@ -379,7 +378,7 @@ func analyzeLayer(path, layerName, parentLayerName string) error {
 			break
 		} else {
 			if retryCount > 1 {
-				body, _ := ioutil.ReadAll(response.Body)
+				body, _ := io.ReadAll(response.Body)
 				statusCode := response.StatusCode
 				response.Body.Close()
 				return fmt.Errorf("got response %d with message %s", statusCode, string(body))
@@ -420,7 +419,7 @@ func getLayer(layerID string) (Layer, error) {
 			return *apiResponse.Layer, nil
 		} else {
 			if retryCount > 1 {
-				body, _ := ioutil.ReadAll(response.Body)
+				body, _ := io.ReadAll(response.Body)
 				statusCode := response.StatusCode
 				response.Body.Close()
 				err = fmt.Errorf("got response %d with message %s", statusCode, string(body))
@@ -546,7 +545,7 @@ func buildClient() (*http.Client, error) {
 	} else {
 		certPath = "/etc/filebeat/filebeat.crt"
 	}
-	pemData, err := ioutil.ReadFile(certPath)
+	pemData, err := os.ReadFile(certPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1107,7 +1106,7 @@ func getCurrentlyMaskedCveIds(nodeId, nodeType string) ([]string, error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == HTTP_OK {
-		maskedCveIdStr, err := ioutil.ReadAll(resp.Body)
+		maskedCveIdStr, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return currentlyMaskedCveIds, err
 		}

--- a/deepfence_diagnosis/service/diagnosis.go
+++ b/deepfence_diagnosis/service/diagnosis.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -154,7 +153,7 @@ func addVulnerabilityLogsDocker(container types.Container, tarWriter *tar.Writer
 		if err != nil {
 			break
 		}
-		logBytes, err := ioutil.ReadAll(tr)
+		logBytes, err := io.ReadAll(tr)
 		if err != nil {
 			break
 		}
@@ -199,7 +198,7 @@ func addSupervisorLogsDocker(container types.Container, tarWriter *tar.Writer) e
 		if err != nil {
 			break
 		}
-		logBytes, err := ioutil.ReadAll(tr)
+		logBytes, err := io.ReadAll(tr)
 		if err != nil {
 			break
 		}
@@ -275,7 +274,7 @@ func (t *diagnosisT) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				fmt.Println("error in opening stream", err)
 				continue
 			}
-			logBytes, err := ioutil.ReadAll(podLogs)
+			logBytes, err := io.ReadAll(podLogs)
 			if err != nil {
 				continue
 			}
@@ -334,7 +333,7 @@ func (t *diagnosisT) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				continue
 			}
-			logBytes, err := ioutil.ReadAll(logs)
+			logBytes, err := io.ReadAll(logs)
 			if err != nil {
 				continue
 			}

--- a/deepfence_diagnosis/service/docker_util.go
+++ b/deepfence_diagnosis/service/docker_util.go
@@ -89,7 +89,7 @@ func inspectMain() {
 //		if err != nil {
 //			panic(err)
 //		}
-//		logBytes, err := ioutil.ReadAll(logs)
+//		logBytes, err := io.ReadAll(logs)
 //		if err != nil {
 //			panic(err)
 //		}


### PR DESCRIPTION
Fixes #119.

Changes proposed in this pull request:
- As part of https://github.com/deepfence/ThreatMapper/pull/119, `io/ioutil` was removed, but the changes were rolled back due to usage of older golang version 1.13
- Golang version is now updated to golang 1.16 as part of https://github.com/deepfence/ThreatMapper/issues/136, and hence, `io/ioutil` package can be deprecated
- This PR attempts to deprecate `io/ioutil` package functions in favor of corresponding `io` and `os` package functions.

@deepfence/engineering
