### PR TITLE
registry scan, cancel registry scan, priortizing scan for host and im…

### DIFF
--- a/deepfence_backend/api/common_api.py
+++ b/deepfence_backend/api/common_api.py
@@ -1422,8 +1422,7 @@ def user_activity_log():
         raise InvalidUsage()
 
 @common_api.route("/registry_images_tags", methods=["POST"])
-@jwt_required
-@non_read_only_user
+@jwt_required()
 def registry_images_tags():
     if not request.is_json:
         raise InvalidUsage("Missing JSON post data in request")

--- a/deepfence_backend/api/common_api.py
+++ b/deepfence_backend/api/common_api.py
@@ -1421,6 +1421,23 @@ def user_activity_log():
         print(ex)
         raise InvalidUsage()
 
+@common_api.route("/registry_images_tags", methods=["POST"])
+@jwt_required
+@non_read_only_user
+def registry_images_tags():
+    if not request.is_json:
+        raise InvalidUsage("Missing JSON post data in request")
+    post_data = request.json
+    if not post_data.get("registry_id", None):
+        raise InvalidUsage("registry id is required")
+    image_list_details_str = redis.get("{0}:{1}".format(REGISTRY_IMAGES_CACHE_KEY_PREFIX, post_data.get("registry_id")))
+    if not image_list_details_str:
+        return set_response([])
+    image_dict = json.loads(image_list_details_str)
+    images_set = set()
+    for image in image_dict['image_list']:
+        images_set.add(image["image_tag"])
+    return set_response(list(images_set))
 
 class EmailConfigurationView(MethodView):
     @jwt_required()

--- a/deepfence_backend/api/resource_api.py
+++ b/deepfence_backend/api/resource_api.py
@@ -319,6 +319,7 @@ def start_cve(node_id):
         if request.is_json:
             post_data = request.json
         node = Node.get_node(node_id, request.args.get("scope_id", None), request.args.get("node_type", None))
+        priority = request.args.get("priority", False)
         if not node:
             raise InvalidUsage("Node not found")
         if node.type == constants.NODE_TYPE_HOST or node.type == constants.NODE_TYPE_CONTAINER or node.type == constants.NODE_TYPE_CONTAINER_IMAGE:
@@ -409,7 +410,7 @@ def start_cve(node_id):
                     if redis_resp[i] != 1:
                         continue
                     try:
-                        tmp_node.cve_scan_start(scan_types)
+                        tmp_node.cve_scan_start(scan_types, priority=priority)
                     except:
                         continue
                 time.sleep(1)
@@ -449,7 +450,7 @@ def start_cve(node_id):
                     if redis_resp[i] != 1:
                         continue
                     try:
-                        tmp_node.cve_scan_start(scan_types)
+                        tmp_node.cve_scan_start(scan_types, priority=priority)
                     except:
                         continue
                 time.sleep(1)
@@ -469,7 +470,7 @@ def start_cve(node_id):
                     raise DFError("CVE scan on this node is already in progress")
                 resp = False
                 try:
-                    resp = node.cve_scan_start(scan_types, ",".join(mask_cve_ids))
+                    resp = node.cve_scan_start(scan_types, priority=priority,mask_cve_ids=",".join(mask_cve_ids))
                 except Exception as ex:
                     redis.delete(lock_key)
                     raise ex
@@ -1210,8 +1211,6 @@ def node_action():
             raise InvalidUsage("registry_images is required for node_type registry_image")
         if not registry_images.get("registry_id") or type(registry_images["registry_id"]) != int:
             raise InvalidUsage("registry_id is required in registry_images key")
-        if not filters and not registry_images.get("image_name_with_tag_list"):
-            raise InvalidUsage("image_name_with_tag_list is required in registry_images key")
         if registry_images.get("image_name_with_tag_list") and type(
                 registry_images["image_name_with_tag_list"]) != list:
             raise InvalidUsage("image_name_with_tag_list must be a list")

--- a/deepfence_backend/dockerify/celery/entrypoint.sh
+++ b/deepfence_backend/dockerify/celery/entrypoint.sh
@@ -20,5 +20,10 @@ if [ -f /app/code/supervisor_conf_celery/celery-vulnerability-scan-worker.conf ]
     envsubst '${VULNERABILITY_SCAN_CONCURRENCY}' < /app/code/supervisor_conf_celery/celery-vulnerability-scan-worker.conf > /app/code/supervisor_conf_celery/celery-vulnerability-worker.conf
     rm -f /app/code/supervisor_conf_celery/celery-vulnerability-scan-worker.conf
 fi
+
+if [ -f /app/code/supervisor_conf_celery/celery-vulnerability-scan-worker-priority.conf ]; then
+    envsubst '${VULNERABILITY_SCAN_CONCURRENCY}' < /app/code/supervisor_conf_celery/celery-vulnerability-scan-worker-priority.conf > /app/code/supervisor_conf_celery/celery-vulnerability-worker-priority.conf
+    rm -f /app/code/supervisor_conf_celery/celery-vulnerability-scan-worker-priority.conf
+fi
 # Start supervisor
 /usr/local/bin/supervisord -c /etc/supervisor/supervisord_celery.conf -n

--- a/deepfence_backend/supervisor_conf_celery/celery-vulnerability-scan-worker-priority.conf
+++ b/deepfence_backend/supervisor_conf_celery/celery-vulnerability-scan-worker-priority.conf
@@ -1,0 +1,35 @@
+; the name of your supervisord program
+[program:celery-vulnerability-scan-worker-priority]
+
+command=/usr/local/bin/celery --app config.config.celery_app --config config.celeryworkerconfig worker --statedb /app/code/celery_vulnerability_worker_priority.state --loglevel ERROR --pool gevent -Q celery_vulnerability_scan_priority_queue -n vulnerability_scan_worker_priority --concurrency ${VULNERABILITY_SCAN_CONCURRENCY} -Ofair
+directory=/app/code
+
+; Supervisor will start as many instances of this program as named by numprocs
+numprocs=1
+
+; If true, this program will start automatically when supervisord is started
+autostart=true
+
+; May be one of false, unexpected, or true. If false, the process will never
+; be autorestarted. If unexpected, the process will be restart when the program
+; exits with an exit code that is not one of the exit codes associated with this
+; process’ configuration (see exitcodes). If true, the process will be
+; unconditionally restarted when it exits, without regard to its exit code.
+autorestart=true
+
+; The total number of seconds which the program needs to stay running after
+; a startup to consider the start successful.
+startsecs=0
+
+; Need to wait for currently executing tasks to finish at shutdown.
+; Increase this if you have very long running tasks.
+stopwaitsecs=30
+
+; When resorting to send SIGKILL to the program to terminate it
+; send SIGKILL to its whole process group instead,
+; taking care of its children as well.
+killasgroup=true
+
+; if your broker is supervised, set its priority higher
+; so it starts first
+priority=12

--- a/deepfence_backend/tasks/task_scheduler.py
+++ b/deepfence_backend/tasks/task_scheduler.py
@@ -17,7 +17,9 @@ from flask import make_response
 import json
 import uuid
 from copy import deepcopy
-from utils.helper import get_all_scanned_node
+from utils.helper import get_all_scanned_node,get_all_scanned_images
+import pandas as pd
+import re
 
 
 @celery_app.task
@@ -29,10 +31,10 @@ def task_scheduler():
             return
         for scheduled_task in scheduled_tasks:
             if croniter.match(scheduled_task.cron_expr, curr_time):
-                run_node_task(scheduled_task.action, scheduled_task.nodes, scheduled_task.id)
+                run_node_task(scheduled_task.action, scheduled_task.nodes, scheduled_task.id,scheduled_task.cron_expr)
 
 
-def run_node_task(action, node_action_details, scheduler_id=None):
+def run_node_task(action, node_action_details, scheduler_id=None,cron_expr=None):
     with app.app_context():
         curr_time = arrow.now(tz="+00:00").datetime
         if scheduler_id:
@@ -92,6 +94,46 @@ def run_node_task(action, node_action_details, scheduler_id=None):
                 from config.app import celery_app
                 redis_lock_keys = []
                 redis_pipe = redis.pipeline()
+                image_list_details_str = redis.get("{0}:{1}".format(constants.REGISTRY_IMAGES_CACHE_KEY_PREFIX, node_action_details["registry_images"]["registry_id"]))
+                if image_list_details_str:
+                    if node_action_details["registry_images"].get("all_registry_images", False):
+                        image_dict = json.loads(image_list_details_str)
+                        image_df = pd.DataFrame(image_dict['image_list'])
+                        image_df['timestamp'] = pd.to_datetime(image_df.pushed_at)
+                        sorted_df = image_df.sort_values(by=['timestamp'], ascending=False)
+                        df_unique_list = sorted_df["image_tag"].unique()
+                        df_unique = pd.DataFrame(data = df_unique_list,columns = ["image_tag"])
+                        sorted_df_by_image_tag = image_df.sort_values("image_tag")
+                        images_by_tags = df_unique.merge(sorted_df_by_image_tag, on=["image_tag"] ,how="outer")["image_name_with_tag"]
+                        node_action_details["registry_images"]["image_name_with_tag_list"] = images_by_tags
+                    elif node_action_details["registry_images"].get("only_new_images", False):
+                        image_dict = json.loads(image_list_details_str)
+                        all_registry_images = set([ image["image_name_with_tag"] for image in image_dict['image_list']])
+                        if cron_expr:
+                            pattern = '^0.*?\*/(\d).*?$'
+                            match = re.search(pattern, cron_expr) 
+                            if match:
+                                days_interval = int(match.group(1))
+                            else:
+                                days_interval = 1
+                        images_need_to_be_scanned = all_registry_images - get_all_scanned_images(days_interval)
+                        node_action_details["registry_images"]["image_name_with_tag_list"] = list(images_need_to_be_scanned)
+                    elif node_action_details["registry_images"].get("registry_scan_type", None) == "latest_timestamp":
+                        image_dict = json.loads(image_list_details_str)
+                        image_df = pd.DataFrame(image_dict['image_list'])
+                        image_df['timestamp'] = pd.to_datetime(image_df.pushed_at)
+                        grouped = image_df.groupby(['image_name']).agg({"timestamp" : max}).reset_index()
+                        latest_images_by_tags = image_df.merge(grouped, on=["image_name", "timestamp"],how="inner")['image_name_with_tag']
+                        node_action_details["registry_images"]["image_name_with_tag_list"] = latest_images_by_tags
+                    elif node_action_details["registry_images"].get("registry_scan_type", None) == "image_tags":
+                        if node_action_details["registry_images"].get("image_tags", []):
+                            image_tags = node_action_details["registry_images"].get("image_tags", [])
+                            image_dict = json.loads(image_list_details_str)
+                            image_df = pd.DataFrame(image_dict['image_list'])
+                            images_by_tags = image_df[image_df["image_tag"].isin(image_tags)]["image_name_with_tag"]
+                            node_action_details["registry_images"]["image_name_with_tag_list"] = images_by_tags
+                else:
+                    node_action_details["registry_images"]["image_name_with_tag_list"] = []
                 for image_name_with_tag in node_action_details["registry_images"]["image_name_with_tag_list"]:
                     lock_key = "{0}:{1}".format(constants.NODE_ACTION_CVE_SCAN_START, image_name_with_tag)
                     redis_pipe.incr(lock_key)
@@ -166,7 +208,7 @@ def run_node_task(action, node_action_details, scheduler_id=None):
                     if redis_resp[i] != 1:
                         continue
                     try:
-                        node.cve_scan_start(node_action_details["scan_type"])
+                        node.cve_scan_start(node_action_details["scan_type"], priority=node_action_details.get("priority", False))
                     except Exception as ex:
                         save_scheduled_task_status("Error: " + str(ex))
                         app.logger.error(ex)
@@ -178,6 +220,10 @@ def run_node_task(action, node_action_details, scheduler_id=None):
         elif action == constants.NODE_ACTION_CVE_SCAN_STOP:
             if node_type == constants.NODE_TYPE_REGISTRY_IMAGE:
                 from config.app import celery_app
+                if node_action_details["registry_images"].get("all_registry_images", False):
+                    image_list_details_str = redis.get("{0}:{1}".format(constants.REGISTRY_IMAGES_CACHE_KEY_PREFIX, node_action_details["registry_images"]["registry_id"]))
+                    image_dict = json.loads(image_list_details_str)
+                    node_action_details["registry_images"]["image_name_with_tag_list"] = [ image["image_name_with_tag"] for image in image_dict['image_list']]
                 for image_name_with_tag in node_action_details["registry_images"]["image_name_with_tag_list"]:
                     try:
                         es_response = ESConn.search_by_and_clause(constants.CVE_SCAN_LOGS_INDEX,

--- a/deepfence_backend/utils/constants.py
+++ b/deepfence_backend/utils/constants.py
@@ -80,6 +80,7 @@ PASSWORD_RESET_CODE_EXPIRY = 3600
 MAX_TOTAL_SEVERITY_SCORE = 500.0  # match this value with deepfence_console/deepaudit/main.go constant
 MAX_TOP_EXPLOITABLE_VULNERABILITIES = 1000
 VULNERABILITY_SCAN_QUEUE = "celery_vulnerability_scan_queue"
+VULNERABILITY_SCAN_PRIORITY_QUEUE = "celery_vulnerability_scan_priority_queue"
 CELERY_NODE_ACTION_QUEUE = "celery_node_action_queue"
 
 INTEGRATION_TYPE_EMAIL = "email"


### PR DESCRIPTION
…age node is completed now deepfence/ThreatMapper#109

Fixes # registry scan, cancel registry scan, prioritizing scans for all nodes

Changes proposed in this pull request:
- entire registry can be scanned through UI
- registry scan now can be cancelled 
- we can now schedule the registry scan
- we can now prioritize the node scan
- If user scan entire registry then latest tags will be scanned first
- feature has been added to scan registry [ images tags and latest times stamp ] wise
- default registry scan will be considered as latest time stamp scan

@deepfence/engineering
