### PR TITLE
Adding nodePort support for on premises deployments

### DIFF
--- a/deployment-scripts/helm-charts/deepfence-router/templates/service.yaml
+++ b/deployment-scripts/helm-charts/deepfence-router/templates/service.yaml
@@ -44,7 +44,9 @@ spec:
   loadBalancerSourceRanges:
 {{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
 {{- end }}
+  {{- if  eq "LoadBalancer" .Values.service.type   }}
   externalTrafficPolicy: "{{ .Values.service.externalTrafficPolicy }}"
+  {{- end }}
   type: {{ .Values.service.type }}
   selector:
     name: {{ .Values.service.name }}
@@ -52,11 +54,29 @@ spec:
     - name: https-port
       port: {{ required "managementConsolePort is required" .Values.managementConsolePort }}
       protocol: TCP
+      {{- if eq .Values.service.type "LoadBalancer" }}
       targetPort: 443
+      {{- end }}
+      {{- if eq .Values.service.type "NodePort"}}
+      {{- if .Values.service.nodePortHttps }}
+      nodePort: {{ .Values.service.nodePortHttps }}
+      {{- else }}
+      nodePort: 30007
+      {{- end }}
+      {{- end }}
     - name: http-port
       port: 80
       protocol: TCP
+      {{- if eq .Values.service.type "LoadBalancer" }}
       targetPort: 80
+      {{- end }}
+      {{- if eq .Values.service.type "NodePort" }}
+      {{- if .Values.service.nodePortHttp }}
+      nodePort: {{ .Values.service.nodePortHttp }}
+      {{- else }}
+      nodePort: 30008
+      {{- end }}
+      {{- end }}
 ---
 {{- if eq "true" .Values.createSeparateServiceForAgents }}
 apiVersion: v1

--- a/deployment-scripts/helm-charts/deepfence-router/values.yaml
+++ b/deployment-scripts/helm-charts/deepfence-router/values.yaml
@@ -11,7 +11,12 @@ managementConsolePort: "443"
 
 service:
   name: deepfence-router
-  type: LoadBalancer
+  # Select the type of service to be used. 
+  # When exposing the service in an on premisses Kubernetes cluster, select NodePort as type
+  type: LoadBalancer # NodePort 
+  # Nodeport configuration. Only used when selecting NodePort in the service type
+  nodePortHttps: ""
+  nodePortHttp: ""
   #  Using static ip address for load balancer
   # - Google Cloud: https://cloud.google.com/kubernetes-engine/docs/tutorials/configuring-domain-name-static-ip
   # loadBalancerIP: "1.2.3.4"


### PR DESCRIPTION
Feature Adding nodePort support to deepfence-router service for on premisses deployments .

Changes proposed in this pull request:

- New support for NodePort type for service
- New variables nodePortHttps and nodePortHttp to define the ports to be used (defaults to 30007 and 30008)

@deepfence/engineering
