### PR TITLE
add external-sources to enhance java results

### DIFF
--- a/vulnerability_mapper/grype.yaml
+++ b/vulnerability_mapper/grype.yaml
@@ -61,3 +61,9 @@ log:
   # location to write the log file (default is not to have a log file)
   # same as GRYPE_LOG_FILE env var
   file: ""
+
+external-sources:
+  enable: true
+  maven:
+    search-upstream-by-sha1: true
+    base-url: https://search.maven.org/solrsearch/select


### PR DESCRIPTION
upgrade grype and syft and enable `external-sources` that includes maven upstream sha1 query.
Enhances the vulnerability scan results by adding `digest` in SBOM that is used by Grype to get groupId from external sources like maven.
ref: https://github.com/anchore/grype/pull/714