### PR TITLE
(feat). API to upload vulnerability db in airgapped env

### DIFF
--- a/deepfence_console/fetcher/fetcher-server.go
+++ b/deepfence_console/fetcher/fetcher-server.go
@@ -502,7 +502,7 @@ func handleVulnerabilityFeedTarUpload(respWrite http.ResponseWriter, req *http.R
 		vulnerabilityDbUpdater.updateVulnerabilityDbListing()
 
 		// call mapper api to update grype db
-		updateVulnerabilityMapperDB(respWrite)
+		updateVulnerabilityMapperDB()
 	}()
 	_, err = fmt.Fprintf(respWrite, "vulnerability db updated")
 	if err != nil {
@@ -512,12 +512,12 @@ func handleVulnerabilityFeedTarUpload(respWrite http.ResponseWriter, req *http.R
 	respWrite.WriteHeader(http.StatusOK)
 }
 
-func updateVulnerabilityMapperDB(respWrite http.ResponseWriter) {
+func updateVulnerabilityMapperDB() {
 	response, err := http.Post("http://deepfence-vulnerability-mapper:8001/vulnerability-mapper-api/db-update", "text/plain", nil)
 	if err != nil {
 		errMsg := "Error while calling vulnerability mapper api. " + err.Error()
 		fmt.Println(errMsg)
-		respWrite.WriteHeader(http.StatusInternalServerError)
+		return
 	}
 
 	defer response.Body.Close()
@@ -525,8 +525,9 @@ func updateVulnerabilityMapperDB(respWrite http.ResponseWriter) {
 	if response.StatusCode != 200 {
 		errMsg := "Error while calling vulnerability mapper api. " + response.Status
 		fmt.Println(errMsg)
-		http.Error(respWrite, errMsg, http.StatusInternalServerError)
+		return
 	}
+	return
 }
 
 type registryCredentialRequest struct {

--- a/vulnerability_mapper/controller/vulnerability-db-update/types.go
+++ b/vulnerability_mapper/controller/vulnerability-db-update/types.go
@@ -1,0 +1,3 @@
+package vulnerability_db_update
+
+type VulnerabilityDBUpdate struct{}

--- a/vulnerability_mapper/controller/vulnerability-db-update/update.go
+++ b/vulnerability_mapper/controller/vulnerability-db-update/update.go
@@ -1,0 +1,23 @@
+package vulnerability_db_update
+
+import (
+	"os/exec"
+
+	"github.com/gin-gonic/gin"
+)
+
+func New() *VulnerabilityDBUpdate {
+	return &VulnerabilityDBUpdate{}
+}
+
+func (v *VulnerabilityDBUpdate) UpdateDB(gc *gin.Context) {
+	out, err := exec.Command("grype", "db", "update").Output()
+	if err != nil {
+		gc.JSON(500, gin.H{
+			"error": err.Error(),
+		})
+		return
+	}
+	gc.JSON(200, gin.H{"status": "success", "output": out})
+
+}

--- a/vulnerability_mapper/router/endpoints.go
+++ b/vulnerability_mapper/router/endpoints.go
@@ -1,12 +1,12 @@
 package router
 
 import (
-	"github.com/gin-gonic/gin"
 	"net/http"
+
+	"github.com/gin-gonic/gin"
 )
 
 // Simple ping-pong router for readiness and liveness checks
-
 func addPingRoutes(r *gin.Engine) {
 	ping := r.Group("/vulnerability-mapper-api/ping")
 
@@ -19,5 +19,9 @@ func addVulnerabilityService(r *gin.Engine) {
 	vulnerabilityScan := r.Group("/vulnerability-mapper-api/vulnerability-scan")
 
 	vulnerabilityScan.POST("", vulnerabilityScanController.Scan) // : probe
-	// vulnerabilityScan.POST("/registry", vulnerabilityScanController.RegistryScan) // :console
+}
+
+func addDBUpdateService(r *gin.Engine) {
+	vulnerabilityScan := r.Group("/vulnerability-mapper-api/db-update")
+	vulnerabilityScan.POST("", VulnerabilityDBUpdateController.UpdateDB)
 }

--- a/vulnerability_mapper/router/router.go
+++ b/vulnerability_mapper/router/router.go
@@ -1,12 +1,15 @@
 package router
 
 import (
-	"github.com/deepfence/vulnerability_mapper/controller/vulnerability-scan-service"
+	vuolnerability_db_update "github.com/deepfence/vulnerability_mapper/controller/vulnerability-db-update"
+	vulnerability_scan_service "github.com/deepfence/vulnerability_mapper/controller/vulnerability-scan-service"
+
 	"github.com/gin-gonic/gin"
 )
 
 var (
-	vulnerabilityScanController = vulnerability_scan_service.New()
+	vulnerabilityScanController     = vulnerability_scan_service.New()
+	VulnerabilityDBUpdateController = vuolnerability_db_update.New()
 )
 
 // New instantiates a new gin router to handle API requests
@@ -25,4 +28,5 @@ func registerAllEndpoints(r *gin.Engine) {
 	// registers the below endpoints
 	addPingRoutes(r)
 	addVulnerabilityService(r)
+	addDBUpdateService(r)
 }


### PR DESCRIPTION
API: `df-api/upload-vulnerability-db`

Usage:
```
curl --location --request POST 'https://my-console.df.io/df-api/upload-vulnerability-db' \
--header 'Content-Type: application/json' \
--header 'deepfence-key: xxxxxxxxxx-xxxx-xxxxxxxxxx-xxx' \
--form 'file=@"/Users/karn/Downloads/threatintel-vuln-1648219229250.tar.gz"'
```
Changes:
- add api in fetcher to receive `.tar.gz` size less than 150MB
- add api in vulnerability-mapper that updates vulnerability db

Related PR in UI: #411 
Issue: https://github.com/deepfence/ThreatMapper/issues/366