### PR TITLE
Add nginx ingress controller as type for router service installation

### DIFF
--- a/deployment-scripts/helm-charts/deepfence-router/ReadMe.md
+++ b/deployment-scripts/helm-charts/deepfence-router/ReadMe.md
@@ -82,3 +82,27 @@ helm delete --purge deepfence-router
 # helm 3
 helm delete deepfence-router
 ```
+
+### Using Nginx Ingress Controller
+If using the Nginx Ingress Controller instead, the service type can be specified as `Ingress`.
+```yaml
+service:
+  name: deepfence-router
+  type: Ingress
+...
+```
+
+Additionally, the Nginx Ingress Controller needs to be installed as specified [here](https://kubernetes.github.io/ingress-nginx/deploy/) based on the cloud provider.
+
+For example, you can use either `helm` or `kubectl` commands for installing on AWS:
+Helm Command:
+```
+helm upgrade --install ingress-nginx ingress-nginx \
+  --repo https://kubernetes.github.io/ingress-nginx \
+  --namespace ingress-nginx --create-namespace
+```
+Kubectl Command:
+```
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.2.0/deploy/static/provider/aws/deploy.yaml
+```
+

--- a/deployment-scripts/helm-charts/deepfence-router/ReadMe.md
+++ b/deployment-scripts/helm-charts/deepfence-router/ReadMe.md
@@ -94,7 +94,8 @@ service:
 
 Additionally, the Nginx Ingress Controller needs to be installed as specified [here](https://kubernetes.github.io/ingress-nginx/deploy/) based on the cloud provider.
 
-For example, you can use either `helm` or `kubectl` commands for installing on AWS:
+For example, you can use either `helm` or `kubectl` commands for installing on AWS.
+
 Helm Command:
 ```
 helm upgrade --install ingress-nginx ingress-nginx \

--- a/deployment-scripts/helm-charts/deepfence-router/templates/service.yaml
+++ b/deployment-scripts/helm-charts/deepfence-router/templates/service.yaml
@@ -54,7 +54,7 @@ spec:
     - name: https-port
       port: {{ required "managementConsolePort is required" .Values.managementConsolePort }}
       protocol: TCP
-      {{- if eq .Values.service.type "LoadBalancer" }}
+      {{- if or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "Ingress") }}
       targetPort: 443
       {{- end }}
       {{- if eq .Values.service.type "NodePort"}}
@@ -67,7 +67,7 @@ spec:
     - name: http-port
       port: 80
       protocol: TCP
-      {{- if eq .Values.service.type "LoadBalancer" }}
+      {{- if or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "Ingress") }}
       targetPort: 80
       {{- end }}
       {{- if eq .Values.service.type "NodePort" }}
@@ -77,6 +77,29 @@ spec:
       nodePort: 30008
       {{- end }}
       {{- end }}
+---
+{{- if eq .Values.service.type "Ingress" }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: deepfence-router-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: 200m
+spec:
+  ingressClassName: nginx
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Values.service.name }}
+                port:
+                  number: 443
+{{- end }}
 ---
 {{- if eq "true" .Values.createSeparateServiceForAgents }}
 apiVersion: v1

--- a/deployment-scripts/helm-charts/deepfence-router/values.yaml
+++ b/deployment-scripts/helm-charts/deepfence-router/values.yaml
@@ -13,7 +13,8 @@ service:
   name: deepfence-router
   # Select the type of service to be used. 
   # When exposing the service in an on premisses Kubernetes cluster, select NodePort as type
-  type: LoadBalancer # NodePort 
+  # Also, possible to use Ingress as type when ingress controller is installed
+  type: LoadBalancer # NodePort/Ingress
   # Nodeport configuration. Only used when selecting NodePort in the service type
   nodePortHttps: ""
   nodePortHttp: ""


### PR DESCRIPTION
Currently, there is only option to use either `LoadBalancer` or `NodePort` for router helm chart installation. This PR aims to add Nginx Ingress Controller as another type for router service installation.

Changes proposed in this pull request:
- Add support for Nginx Ingress Controller in router helm chart
- Add instructions for installing router helm chart with Nginx Ingress Controller .

@deepfence/engineering
