### PR TITLE
Tolerance of built grype db increased to 60 days.

### DIFF
--- a/deepfence_console/fetcher/grype.yaml
+++ b/deepfence_console/fetcher/grype.yaml
@@ -55,8 +55,8 @@ db:
   
   # Max allowed age for vulnerability database,
   # age being the time since it was built
-  # Default max age is 120h (or five days)
-  max-allowed-built-age: "120h"
+  # Default max age is 1440h (or 60 days)
+  max-allowed-built-age: "1440h"
 
 log:
   # use structured logging

--- a/vulnerability_mapper/grype.yaml
+++ b/vulnerability_mapper/grype.yaml
@@ -55,8 +55,8 @@ db:
 
   # Max allowed age for vulnerability database,
   # age being the time since it was built
-  # Default max age is 120h (or five days)
-  max-allowed-built-age: "120h"
+  # Default max age is 1440h (or 60 days)
+  max-allowed-built-age: "1440h"
 
 log:
   # use structured logging


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
-  In `deepfence-vulnerability-mapper`, we would see errors when build time of grype-db is more than 5 days from latest build. Scans of containers would fail consequently.

```
bash-5.1# grype db status
Location:  /root/.cache/grype/db/3
Built:     2022-06-15 00:24:52.202099955 +0000 UTC
Schema:    3
Checksum:  sha256:7ac6cfb1cd4ddb1598e65fea20b0a6b4be08080b9b9379e0b096d0ec9ed84b6d
Status:    invalid
the vulnerability database was built 1 week ago (max allowed age is 5 days)
```

- This change increases tolerance of build time of grype-db to 60 days.

@deepfence/engineering
