### PR TITLE
Fix connections report

### DIFF
--- a/deepfence_agent/misc/deepfence/procspy/fixture.go
+++ b/deepfence_agent/misc/deepfence/procspy/fixture.go
@@ -19,7 +19,7 @@ func (f *fixedConnIter) Next() *Connection {
 
 // SetFixtures is used in test scenarios to have known output.
 func SetFixtures(c []Connection) {
-	cbConnections = func(bool) (ConnIter, error) {
+	cbConnections = func(bool, []uint, []string) (ConnIter, error) {
 		f := fixedConnIter(c)
 		return &f, nil
 	}

--- a/deepfence_agent/misc/deepfence/procspy/procnet.go
+++ b/deepfence_agent/misc/deepfence/procspy/procnet.go
@@ -14,15 +14,17 @@ type ProcNet struct {
 	wantedStates            []uint
 	bytesLocal, bytesRemote [16]byte
 	seen                    map[uint64]struct{}
+	localIps                []string
 }
 
 // NewProcNet gives a new ProcNet parser.
-func NewProcNet(b []byte, wantedState []uint) *ProcNet {
+func NewProcNet(b []byte, wantedState []uint, localIps []string) *ProcNet {
 	return &ProcNet{
 		b:            b,
 		c:            Connection{},
 		wantedStates: wantedState,
 		seen:         map[uint64]struct{}{},
+		localIps:     localIps,
 	}
 }
 
@@ -79,7 +81,7 @@ again:
 
 	p.c.LocalAddress, p.c.LocalPort = scanAddressNA(local, &p.bytesLocal)
 	p.c.RemoteAddress, p.c.RemotePort = scanAddressNA(remote, &p.bytesRemote)
-	remoteInLocal, _ := dfUtils.InArray(p.c.RemoteAddress.String(), localIps)
+	remoteInLocal, _ := dfUtils.InArray(p.c.RemoteAddress.String(), p.localIps)
 	if remoteInLocal {
 		p.c.InOutBoundType = "inbound"
 	} else {

--- a/deepfence_agent/misc/deepfence/procspy/procnet_test.go
+++ b/deepfence_agent/misc/deepfence/procspy/procnet_test.go
@@ -11,13 +11,13 @@ var (
 )
 
 func TestProcNet(t *testing.T) {
-	testString := `  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout Inode                                                     
-   0: 00000000:A6C0 00000000:0000 01 00000000:00000000 00:00000000 00000000   105        0 5107 1 ffff8800a6aaf040 100 0 0 10 0                      
-   1: 00000000:006F 00000000:0000 01 00000000:00000000 00:00000000 00000000     0        0 5084 1 ffff8800a6aaf740 100 0 0 10 0                      
-   2: 0100007F:0019 00000000:0000 01 00000000:00000000 00:00000000 00000000     0        0 10550 1 ffff8800a729b780 100 0 0 10 0                     
-   3: A12CF62E:E4D7 57FC1EC0:01BB 01 00000000:00000000 02:000006FA 00000000  1000        0 639474 2 ffff88007e75a740 48 4 26 10 -1                   
+	testString := `  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout Inode
+   0: 00000000:A6C0 00000000:0000 01 00000000:00000000 00:00000000 00000000   105        0 5107 1 ffff8800a6aaf040 100 0 0 10 0
+   1: 00000000:006F 00000000:0000 01 00000000:00000000 00:00000000 00000000     0        0 5084 1 ffff8800a6aaf740 100 0 0 10 0
+   2: 0100007F:0019 00000000:0000 01 00000000:00000000 00:00000000 00000000     0        0 10550 1 ffff8800a729b780 100 0 0 10 0
+   3: A12CF62E:E4D7 57FC1EC0:01BB 01 00000000:00000000 02:000006FA 00000000  1000        0 639474 2 ffff88007e75a740 48 4 26 10 -1
 `
-	p := NewProcNet([]byte(testString), tcpStatesTest)
+	p := NewProcNet([]byte(testString), tcpStatesTest, []string{})
 	expected := []Connection{
 		{
 			LocalAddress:  net.IP([]byte{0, 0, 0, 0}),
@@ -68,7 +68,7 @@ func TestTransport6(t *testing.T) {
    8: 4500032000BE692B8AE31EBD919D9D10:D61C 5014002A080805400000000015100000:01BB 01 00000000:00000000 02:00000045 00000000  1000        0 36856710 2 ffff88010b796080 22 4 30 8 7
 `
 
-	p := NewProcNet([]byte(testString), tcpStatesTest)
+	p := NewProcNet([]byte(testString), tcpStatesTest, []string{})
 	expected := []Connection{
 		{
 			// state:         10,
@@ -118,7 +118,7 @@ func TestTransportNonsense(t *testing.T) {
    0: 00000000:A6C0 00000000:0000 01 000000
 broken line
 `
-	p := NewProcNet([]byte(testString), tcpStatesTest)
+	p := NewProcNet([]byte(testString), tcpStatesTest, []string{})
 	expected := []Connection{
 		{
 			LocalAddress:  net.IP([]byte{0, 0, 0, 0}),
@@ -142,11 +142,11 @@ broken line
 }
 
 func TestProcNetFiltersDuplicates(t *testing.T) {
-	testString := `  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout Inode                                                     
-   0: 00000000:A6C0 00000000:0000 01 00000000:00000000 00:00000000 00000000   105        0 5107 1 ffff8800a6aaf040 100 0 0 10 0                      
-   1: 00000000:A6C0 00000000:0000 01 00000000:00000000 00:00000000 00000000   105        0 5107 1 ffff8800a6aaf040 100 0 0 10 0                      
+	testString := `  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout Inode
+   0: 00000000:A6C0 00000000:0000 01 00000000:00000000 00:00000000 00000000   105        0 5107 1 ffff8800a6aaf040 100 0 0 10 0
+   1: 00000000:A6C0 00000000:0000 01 00000000:00000000 00:00000000 00000000   105        0 5107 1 ffff8800a6aaf040 100 0 0 10 0
 `
-	p := NewProcNet([]byte(testString), tcpStatesTest)
+	p := NewProcNet([]byte(testString), tcpStatesTest, []string{})
 	expected := Connection{
 		LocalAddress:  net.IP([]byte{0, 0, 0, 0}),
 		LocalPort:     0xa6c0,

--- a/deepfence_agent/misc/deepfence/procspy/spy.go
+++ b/deepfence_agent/misc/deepfence/procspy/spy.go
@@ -7,27 +7,6 @@ import (
 	"net"
 )
 
-/*
-tcpStates
----------------------
-TCPF_ESTABLISHED = 1,
-TCPF_SYN_SENT	 = 2,
-TCPF_SYN_RECV	 = 3,
-TCPF_FIN_WAIT1	 = 4,
-TCPF_FIN_WAIT2	 = 5,
-TCPF_TIME_WAIT	 = 6,
-TCPF_CLOSE	     = 7,
-TCPF_CLOSE_WAIT	 = 8,
-TCPF_LAST_ACK	 = 9,
-TCPF_LISTEN	     = 10,
-TCPF_CLOSING	 = 11,
-TCPF_NEW_SYN_RECV = 12,
-*/
-var (
-	tcpStates []uint // according to /include/net/tcp_states.h
-	localIps  []string
-)
-
 // Connection is a (TCP) connection. The Proc struct might not be filled in.
 type Connection struct {
 	Transport      string
@@ -57,7 +36,5 @@ type ConnIter interface {
 // connection, filling in the Proc field. You will need to run this as root to
 // find all processes.
 func Connections(processes bool, tcpStatesSlice []uint, localIpList []string) (ConnIter, error) {
-	tcpStates = tcpStatesSlice
-	localIps = localIpList
-	return cbConnections(processes)
+	return cbConnections(processes, tcpStatesSlice, localIpList)
 }

--- a/deepfence_agent/misc/deepfence/procspy/spy_linux.go
+++ b/deepfence_agent/misc/deepfence/procspy/spy_linux.go
@@ -30,8 +30,25 @@ func (c *pnConnIter) Next() *Connection {
 	return n
 }
 
+/*
+tcpStates
+---------------------
+TCPF_ESTABLISHED = 1,
+TCPF_SYN_SENT	 = 2,
+TCPF_SYN_RECV	 = 3,
+TCPF_FIN_WAIT1	 = 4,
+TCPF_FIN_WAIT2	 = 5,
+TCPF_TIME_WAIT	 = 6,
+TCPF_CLOSE	     = 7,
+TCPF_CLOSE_WAIT	 = 8,
+TCPF_LAST_ACK	 = 9,
+TCPF_LISTEN	     = 10,
+TCPF_CLOSING	 = 11,
+TCPF_NEW_SYN_RECV = 12,
+*/
+
 // cbConnections sets Connections()
-var cbConnections = func(processes bool) (ConnIter, error) {
+var cbConnections = func(processes bool, tcpStates []uint, localIps []string) (ConnIter, error) {
 	// buffer for contents of /proc/<pid>/net/tcp
 	buf := bufPool.Get().(*bytes.Buffer)
 	buf.Reset()
@@ -50,7 +67,7 @@ var cbConnections = func(processes bool) (ConnIter, error) {
 	}
 
 	return &pnConnIter{
-		pn:    NewProcNet(buf.Bytes(), tcpStates),
+		pn:    NewProcNet(buf.Bytes(), tcpStates, localIps),
 		buf:   buf,
 		procs: procs,
 	}, nil

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/deepfence/procspy/spy.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/deepfence/procspy/spy.go
@@ -7,27 +7,6 @@ import (
 	"net"
 )
 
-/*
-tcpStates
----------------------
-TCPF_ESTABLISHED = 1,
-TCPF_SYN_SENT	 = 2,
-TCPF_SYN_RECV	 = 3,
-TCPF_FIN_WAIT1	 = 4,
-TCPF_FIN_WAIT2	 = 5,
-TCPF_TIME_WAIT	 = 6,
-TCPF_CLOSE	     = 7,
-TCPF_CLOSE_WAIT	 = 8,
-TCPF_LAST_ACK	 = 9,
-TCPF_LISTEN	     = 10,
-TCPF_CLOSING	 = 11,
-TCPF_NEW_SYN_RECV = 12,
-*/
-var (
-	tcpStates []uint // according to /include/net/tcp_states.h
-	localIps  []string
-)
-
 // Connection is a (TCP) connection. The Proc struct might not be filled in.
 type Connection struct {
 	Transport      string
@@ -56,8 +35,6 @@ type ConnIter interface {
 // If processes is true it'll additionally try to lookup the process owning the
 // connection, filling in the Proc field. You will need to run this as root to
 // find all processes.
-func Connections(processes bool, tcpStatesSlice []uint, localIpList []string) (ConnIter, error) {
-	tcpStates = tcpStatesSlice
-	localIps = localIpList
-	return cbConnections(processes)
+func Connections(processes bool, tcpStatesSlice []uint) (ConnIter, error) {
+	return cbConnections(processes, tcpStates)
 }

--- a/deepfence_agent/tools/apache/scope/vendor/github.com/deepfence/procspy/spy_linux.go
+++ b/deepfence_agent/tools/apache/scope/vendor/github.com/deepfence/procspy/spy_linux.go
@@ -30,8 +30,24 @@ func (c *pnConnIter) Next() *Connection {
 	return n
 }
 
+/*
+tcpStates
+---------------------
+TCPF_ESTABLISHED = 1,
+TCPF_SYN_SENT	 = 2,
+TCPF_SYN_RECV	 = 3,
+TCPF_FIN_WAIT1	 = 4,
+TCPF_FIN_WAIT2	 = 5,
+TCPF_TIME_WAIT	 = 6,
+TCPF_CLOSE	     = 7,
+TCPF_CLOSE_WAIT	 = 8,
+TCPF_LAST_ACK	 = 9,
+TCPF_LISTEN	     = 10,
+TCPF_CLOSING	 = 11,
+TCPF_NEW_SYN_RECV = 12,
+*/
 // cbConnections sets Connections()
-var cbConnections = func(processes bool) (ConnIter, error) {
+var cbConnections = func(processes bool, tcpStates []uint, localIpList []string) (ConnIter, error) {
 	// buffer for contents of /proc/<pid>/net/tcp
 	buf := bufPool.Get().(*bytes.Buffer)
 	buf.Reset()


### PR DESCRIPTION
Fixes missing connections report.

Changes proposed in this pull request:
- Avoid race condition on non-eBPF route by removing global variables
- Make sure kprobes are correctly cleaned up if loading them failed once 

@deepfence/engineering
