### PR TITLE
Upgrade elasticsearch version

### DIFF
--- a/deepfence_console/elastic-Dockerfile
+++ b/deepfence_console/elastic-Dockerfile
@@ -2,12 +2,12 @@ FROM alpine:3.13.6
 MAINTAINER Deepfence Inc
 LABEL deepfence.role=system
 
-ENV VERSION=7.10.2 \
+ENV VERSION=7.17.5 \
     DOWNLOAD_URL="https://artifacts.elastic.co/downloads/elasticsearch"
-ENV ES_TARBAL="${DOWNLOAD_URL}/elasticsearch-oss-${VERSION}-linux-x86_64.tar.gz" \
-    ES_TARBALL_ASC="${DOWNLOAD_URL}/elasticsearch-oss-${VERSION}-linux-x86_64.tar.gz.asc" \
-    EXPECTED_SHA_URL="${DOWNLOAD_URL}/elasticsearch-oss-${VERSION}-linux-x86_64.tar.gz.sha512" \
-    ES_TARBALL_SHA="4933c8291e42bc11422176aeb8655a97727553ef6ec55f123c69bbee3c0dc7453f06ac8606a86efd0a6cd2b2c33f7f2615e793e4ad648c68718d71564cda6bbc" \
+ENV ES_TARBAL="${DOWNLOAD_URL}/elasticsearch-${VERSION}-linux-x86_64.tar.gz" \
+    ES_TARBALL_ASC="${DOWNLOAD_URL}/elasticsearch-${VERSION}-linux-x86_64.tar.gz.asc" \
+    EXPECTED_SHA_URL="${DOWNLOAD_URL}/elasticsearch-${VERSION}-linux-x86_64.tar.gz.sha512" \
+    ES_TARBALL_SHA="98791c40f7ce1ba2a463fddb0986bb6ab9f94ab6479d79f96cd9b772e5208a04c7552c56e9fea484248d2ff1dd46fa25ed7066a41160fb22eb1b8dc837448ccf" \
     GPG_KEY="46095ACC8548582C1A2699A9D27D666CD88E42B4" \
     PATH=/usr/share/elasticsearch/bin:$PATH \
     ES_TMPDIR=/usr/share/elasticsearch/tmp \
@@ -82,11 +82,13 @@ USER root
 #COPY --from=build /go/check-postgres /usr/local/bin/check-postgres
 RUN mkdir /data \
     && chmod 755 /usr/bin/startEs.sh \
-    && chown -R elasticsearch:elasticsearch /data \
-    && apk add --no-cache zip \
-    && zip -q -d /usr/share/elasticsearch/lib/log4j-core-2.11.1.jar org/apache/logging/log4j/core/lookup/JndiLookup.class \
-    && apk del --purge zip
-#&& chmod 755 /usr/local/bin/check-postgres
+    && chown -R elasticsearch:elasticsearch /data
+#    && apk add --no-cache zip \
+#    && apk del --purge zip \
+#    && chmod 755 /usr/local/bin/check-postgres \   
+#    && ls org/apache/logging/log4j/core/lookup/JndiLookup.class \
+#    && zip -q -d /usr/share/elasticsearch/lib/log4j-core-2.11.1.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
+
 EXPOSE 9200 9300
 ENTRYPOINT ["/usr/bin/startEs.sh"]
 CMD ["elasticsearch"]

--- a/deepfence_console/elastic-Dockerfile
+++ b/deepfence_console/elastic-Dockerfile
@@ -83,11 +83,6 @@ USER root
 RUN mkdir /data \
     && chmod 755 /usr/bin/startEs.sh \
     && chown -R elasticsearch:elasticsearch /data
-#    && apk add --no-cache zip \
-#    && apk del --purge zip \
-#    && chmod 755 /usr/local/bin/check-postgres \   
-#    && ls org/apache/logging/log4j/core/lookup/JndiLookup.class \
-#    && zip -q -d /usr/share/elasticsearch/lib/log4j-core-2.11.1.jar org/apache/logging/log4j/core/lookup/JndiLookup.class
 
 EXPOSE 9200 9300
 ENTRYPOINT ["/usr/bin/startEs.sh"]

--- a/deepfence_console/elastic-Dockerfile
+++ b/deepfence_console/elastic-Dockerfile
@@ -4,10 +4,10 @@ LABEL deepfence.role=system
 
 ENV VERSION=7.10.2 \
     DOWNLOAD_URL="https://artifacts.elastic.co/downloads/elasticsearch"
-ENV ES_TARBAL="${DOWNLOAD_URL}/elasticsearch-oss-${VERSION}-no-jdk-linux-x86_64.tar.gz" \
-    ES_TARBALL_ASC="${DOWNLOAD_URL}/elasticsearch-oss-${VERSION}-no-jdk-linux-x86_64.tar.gz.asc" \
-    EXPECTED_SHA_URL="${DOWNLOAD_URL}/elasticsearch-oss-${VERSION}-no-jdk-linux-x86_64.tar.gz.sha512" \
-    ES_TARBALL_SHA="7b63237996569ccdc7c9d9e7cc097fcb23865396eddac30e5f02543484220d2fc70a7285b430877e5e76a5d8716d9682de9fc40d5e57a08f331e82011fc59756" \
+ENV ES_TARBAL="${DOWNLOAD_URL}/elasticsearch-oss-${VERSION}-linux-x86_64.tar.gz" \
+    ES_TARBALL_ASC="${DOWNLOAD_URL}/elasticsearch-oss-${VERSION}-linux-x86_64.tar.gz.asc" \
+    EXPECTED_SHA_URL="${DOWNLOAD_URL}/elasticsearch-oss-${VERSION}-linux-x86_64.tar.gz.sha512" \
+    ES_TARBALL_SHA="4933c8291e42bc11422176aeb8655a97727553ef6ec55f123c69bbee3c0dc7453f06ac8606a86efd0a6cd2b2c33f7f2615e793e4ad648c68718d71564cda6bbc" \
     GPG_KEY="46095ACC8548582C1A2699A9D27D666CD88E42B4" \
     PATH=/usr/share/elasticsearch/bin:$PATH \
     ES_TMPDIR=/usr/share/elasticsearch/tmp \
@@ -18,7 +18,6 @@ ENV bootstrap.memory_lock true
 ENV cluster.name=df-es-cluster
 ENV path.data=/usr/share/elasticsearch/data
 ENV path.logs=/usr/share/elasticsearch/logs
-
 
 RUN apk update --no-cache && apk upgrade --no-cache \
     && apk add --no-cache openjdk11-jre-headless su-exec bash \


### PR DESCRIPTION
This branch is for https://github.com/deepfence/ThreatMapper/issues/450

Changes proposed in this pull request:
  - Moved from **elasticsearch-7.10.2-oss-no-jdk-linux-x86_64.tar.gz** to  **elasticsearch-7.10.2-oss-linux-x86_64.tar.gz** in **deepfence_console>elastic-Dockerfile**.

@deepfence/engineering
