### PR TITLE
Fixed issue-462: Console not available

### DIFF
--- a/deepfence_console/init-container/entrypoint.sh
+++ b/deepfence_console/init-container/entrypoint.sh
@@ -11,3 +11,6 @@ sysctl -w net.ipv4.tcp_max_syn_backlog=1024
 sysctl -w net.ipv4.ip_local_port_range="1024 65534"
 sysctl -w fs.nr_open=1048576
 sysctl -w fs.file-max=1048576
+
+# Required for deepfence-es-master
+sysctl -w vm.max_map_count=262144


### PR DESCRIPTION
Description:
- Elastic container was getting restarted as value for vm.max_map_count
was less than 262144

Solution:
- Setting this value in entrypoint.sh of init container helped elastic
container to start all services

Fixes #462