### PR TITLE
UI: Reset page index on filter on registry image list

### DIFF
--- a/deepfence_ui/app/scripts/components/vulnerability-view/registry-scan/image-list.js
+++ b/deepfence_ui/app/scripts/components/vulnerability-view/registry-scan/image-list.js
@@ -62,6 +62,9 @@ class RegistryImageList extends React.PureComponent {
         enabled: true,
       },
     ];
+    this.state = {
+      page: 0
+    }
   }
 
   componentDidMount() {
@@ -93,8 +96,13 @@ class RegistryImageList extends React.PureComponent {
 
     if (newFilterValues && this.props.filterValues !== newFilterValues) {
       const { updatePollParams } = this.props;
-      updatePollParams({
-        filters: newFilterValues,
+      this.setState({
+        page: 0
+      }, () => {
+        updatePollParams({
+          filters: newFilterValues,
+          page: 0
+        });
       });
     }
   }
@@ -326,6 +334,9 @@ class RegistryImageList extends React.PureComponent {
   }
 
   handlePageChange(pageNumber) {
+    this.setState({
+      page: pageNumber
+    });
     this.tableChangeHandler({
       page: pageNumber,
     });
@@ -522,6 +533,7 @@ class RegistryImageList extends React.PureComponent {
           showPagination
           onPageChange={this.handlePageChange}
           manual
+          page={this.state.page}
           totalRows={total}
           defaultPageSize={20}
           LoadingComponent={


### PR DESCRIPTION
Changes proposed in this pull request:
- Fixes an issue where applying filter after navigating to page index > 1 shows empty results even if results are present.

@deepfence/engineering
