### PR TITLE
fix: empty response of search filter must update severity counts

### DIFF
--- a/deepfence_ui/app/scripts/components/common/alert-graph-view/search-box.js
+++ b/deepfence_ui/app/scripts/components/common/alert-graph-view/search-box.js
@@ -54,6 +54,9 @@ class SearchBox extends React.Component {
             this.props.dispatch(setSearchBarValue({searchQuery: searchBoxValue}));
 
             this.updateSearchQuery(`${searchBoxValue}`);
+            this.setState({
+              searchBarValue:''
+            })
           }
         }.bind(this));
 
@@ -70,7 +73,7 @@ class SearchBox extends React.Component {
   }
 
   updateSearchQuery(filter) {
-    this.setState({searchQuery :[...this.state.searchQuery, filter]}, function stateUpdateComplete() {
+    this.setState({searchQuery :[...this.props.searchQuery, filter]}, function stateUpdateComplete() {
       this.props.dispatch(setSearchQuery({searchQuery: this.state.searchQuery}));
 
       // Filters view

--- a/deepfence_ui/app/scripts/reducers/cve-reducer.js
+++ b/deepfence_ui/app/scripts/reducers/cve-reducer.js
@@ -37,6 +37,7 @@ function CVEImageReportReducer(state = Map(), action) {
     }
     case ActionTypes.CVE_IMAGE_REPORT_SUCCESS: {
       const response = action.payload.data || {};
+      const scanId = action.input.scan_id;
       const {total} = response;
       const imageList = response.data;
       const scanIndex = imageList.reduce((acc, image) => {
@@ -51,6 +52,10 @@ function CVEImageReportReducer(state = Map(), action) {
         };
         return acc;
       }, {});
+
+      if (scanId && imageList?.length === 0) {
+        Object.assign(scanIndex, {[scanId]: {}})
+      }
 
       const prevReport = state.getIn(['report']);
 


### PR DESCRIPTION
Fixes # 1. https://github.com/deepfence/enterprise-roadmap/issues/1579 2.https://github.com/deepfence/enterprise-roadmap/issues/1581

Changes proposed in this pull request:
- Do not reset existing filter
- Severity counts must be reset to 0

@deepfence/engineering
