### PR TITLE
UI: Show checkbox for only relevant node types on topology table

### DIFF
--- a/deepfence_ui/app/scripts/components/multi-cloud-table/table-columns.js
+++ b/deepfence_ui/app/scripts/components/multi-cloud-table/table-columns.js
@@ -153,13 +153,17 @@ export const addCheckbox = (cols, selections, Cb) => {
     accessor: 'checkbox',
     maxWidth: 40,
     resizable: false,
-    Cell: row => (
-      <input
-        type="checkbox"
-        defaultChecked={selections.includes(row.original.id)}
-        onChange={() => Cb(row)}
-      />
-    ),
+    Cell: row => {
+      const nodeType = row?.original?.node_type ?? '';
+      if (!['host', 'container', 'container_image'].includes(nodeType)) return '';
+      return (
+        <input
+          type="checkbox"
+          defaultChecked={selections.includes(row.original.id)}
+          onChange={() => Cb(row)}
+        />
+      );
+    }
   };
   return [...cols, checkbox];
 };


### PR DESCRIPTION
Changes proposed in this pull request:
- Show checkbox for selection for only relevant nodes. Hide it for nodes like cloud, regions etc where there are no actions available.

@deepfence/engineering
