### PR TITLE
fix:to have info icon for an error case

### DIFF
--- a/deepfence_ui/app/scripts/components/common/scan-status/index.js
+++ b/deepfence_ui/app/scripts/components/common/scan-status/index.js
@@ -16,7 +16,7 @@ export const ScanStatus = ({ status, tooltipText }) => {
         label = <span className="scan-status never-scanned ">{humanString}</span>;
         break;
       case 'error':
-        label = <span className="scan-status error">{humanString}</span>;
+        label = <span className="scan-status error">{humanString}<span className='fa fa-info-circle'/></span>;
         break;
       case 'complete':
         label = <span className="scan-status complete">{humanString}</span>;

--- a/deepfence_ui/app/scripts/components/multi-cloud-table/styles.scss
+++ b/deepfence_ui/app/scripts/components/multi-cloud-table/styles.scss
@@ -79,7 +79,7 @@
 
 .scan-status {
   color: $text-secondary;
-  display: inline-block !important;
+  display: inline-flex !important;
   @include vertical-align;
   text-transform: capitalize;
   padding: 0 20px 0 20px;
@@ -102,6 +102,10 @@
 }
 .error {
   color: $color-error-outline;
+  & .fa.fa-info-circle {
+    padding-left: 6px;
+    cursor: text;
+  }
 }
 .complete {
   color: $color-success-outline;


### PR DESCRIPTION
Fixes # https://github.com/deepfence/enterprise-roadmap/issues/1404

Changes proposed in this pull request:
- To display an info icon along with Error

@deepfence/engineering
