### PR TITLE
fix:controls button misalignment on details pop up

### DIFF
--- a/deepfence_ui/app/scripts/components/common/detail-modal/body.module.scss
+++ b/deepfence_ui/app/scripts/components/common/detail-modal/body.module.scss
@@ -36,7 +36,7 @@
   margin-top: 6px;
   color: $text-primary;
   font-weight: 600;
-  font-size: 18px;
+  font-size: 16px;
 
   overflow-wrap: break-word;
 

--- a/deepfence_ui/app/scripts/components/common/detail-modal/header.module.scss
+++ b/deepfence_ui/app/scripts/components/common/detail-modal/header.module.scss
@@ -12,18 +12,19 @@
 }
 
 .wrapper {
-  display: flex;
+  display: grid;
+  grid-template-columns: 75% 25%;
 }
 
 .controlsWrapper {
   display: flex;
   align-items: center;
-  padding: 13px;
-  justify-self: flex-end;
-  margin-left: auto;
+  gap: 2px;
+  flex-wrap: wrap;
+  position: relative;
+  justify-content: flex-end;
 
   :global(button) {
-    margin-left: 6px;
     border: none;
     border-radius: 4px;
     background-color: #2e2e2e;
@@ -37,17 +38,19 @@
 }
 .closeButton {
   cursor: pointer;
-  padding: 4px 12px;
-  display: flex;
-  align-items: center;
-  margin-right: -24px;
+  font-size: 20px;
+  top: 0;
+  right: -30px;
+  position: absolute;
 }
 
 .contentWrapper {
   display: flex;
   flex: 1;
-  gap: 80px;
-  max-width: 75%;
+  gap: 4em;
+  @media screen and (max-width: 1024px) {
+    gap: 1.5em;
+  }
 }
 
 .alertSummaryItem {
@@ -64,7 +67,7 @@
   .alertSummaryItemContent {
     color: $text-primary;
     font-weight: bold;
-    font-size: 28px;
+    font-size: 24px;
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
@@ -75,7 +78,7 @@
 .actionButton {
   padding: 6px 8px !important;
   font-size: 12px;
-  min-width: 80px;
+  min-width: 0;
   height: 32px;
 }
 


### PR DESCRIPTION
Fixes # 

<img width="1293" alt="old" src="https://user-images.githubusercontent.com/111341101/193101211-7fede607-35f0-4be3-9546-63e2a7f430ad.png">

<img width="1297" alt="new" src="https://user-images.githubusercontent.com/111341101/193101236-bc98369a-71b4-4da9-86ae-c7f908b8a823.png">



Changes proposed in this pull request:
- Fix controls button which text are misalign when appears on details view

@deepfence/engineering
