### PR TITLE
now we can assign the issue to assignee deepfence/ThreatMapper#445

### DIFF
--- a/deepfence_backend/api/user_api.py
+++ b/deepfence_backend/api/user_api.py
@@ -1728,7 +1728,7 @@ class IntegrationView(MethodView):
         api_token = request_json.get("api_token")
         jira_project_key = request_json.get("jira_project_key")
         issue_type = request_json.get("issue_type", "Bug")
-        assignee = request_json.get("assignee", None)
+        assignee = request_json.get("assignee", "")
 
         if not jira_site_url:
             raise InvalidUsage("jira_site_url is required")

--- a/deepfence_backend/api/user_api.py
+++ b/deepfence_backend/api/user_api.py
@@ -1728,6 +1728,7 @@ class IntegrationView(MethodView):
         api_token = request_json.get("api_token")
         jira_project_key = request_json.get("jira_project_key")
         issue_type = request_json.get("issue_type", "Bug")
+        assignee = request_json.get("assignee", None)
 
         if not jira_site_url:
             raise InvalidUsage("jira_site_url is required")
@@ -1757,7 +1758,9 @@ class IntegrationView(MethodView):
             "api_token": api_token,
             "jira_project_key": jira_project_key,
             "issue_type": issue_type,
+            "assignee" : assignee
         })
+        
         integration = Integration.query.filter_by(integration_type=INTEGRATION_TYPE_JIRA, config=config).one_or_none()
         if not integration:
             integration = Integration(

--- a/deepfence_backend/tasks/notification.py
+++ b/deepfence_backend/tasks/notification.py
@@ -309,11 +309,16 @@ def send_jira_notification(self, config, payloads, notification_id, resource_typ
                         index += 1
                     else:
                         summary = "{0} {1} - Deepfence".format(ts, prefix)
-                jclient.create_issue(project=config.get('jira_project_key'),
+                issue_number = jclient.create_issue(project=config.get('jira_project_key'),
                                      summary=summary,
                                      description=payload,
                                      issuetype=config.get('issue_type')
                                      )
+                
+                if config.get('assignee'):
+                    issue_created = jclient.issue(issue_number)
+                    jclient.assign_issue(issue_created, config.get('assignee'))
+                
         except JIRAError as e:
             save_integrations_status(notification_id, resource_type, e)
         except Exception as exc:


### PR DESCRIPTION
Fixes # now we can assign the ticket in Jira while creating the ticket

Changes proposed in this pull request:
- in jira integration once configured all the issues appear with assigneed unassigned ; assignee should not be left unassigned and should be configurable while in jira integration

@deepfence/engineering
