### PR TITLE
add missing internal port on api pod

### DIFF
--- a/deployment-scripts/helm-charts/deepfence-console/templates/api/deployment.yaml
+++ b/deployment-scripts/helm-charts/deepfence-console/templates/api/deployment.yaml
@@ -151,6 +151,9 @@ spec:
             - name: http
               containerPort: 9998
               protocol: TCP
+            - name: internal
+              containerPort: 9997
+              protocol: TCP
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}
       {{- with .Values.api.nodeSelector }}


### PR DESCRIPTION
Changes proposed in this pull request:
- internal port is exposed in service for api pod but not exposed on pod itself 
- this is required to implement https://github.com/deepfence/saas-portal/issues/491

@deepfence/engineering
