### PR TITLE
Fixed empty cve table when deleing all entries in the last page

### DIFF
--- a/deepfence_ui/app/scripts/components/vulnerability-view/vulnerability-table-view/vulnerability-table-v2-view.js
+++ b/deepfence_ui/app/scripts/components/vulnerability-view/vulnerability-table-view/vulnerability-table-v2-view.js
@@ -31,7 +31,8 @@ class VulnerabilityTableV2 extends React.Component {
     this.handleNotify = this.handleNotify.bind(this);
     this.state = {
       isVulnerabilityModalOpen: false,
-      cveData: null
+      cveData: null,
+      deletedValues: [],
     }
   }
 
@@ -86,6 +87,8 @@ class VulnerabilityTableV2 extends React.Component {
     const {
       deleteDocsByIdAction: action,
     } = this.props;
+    // eslint-disable-next-line react/no-access-state-in-setstate
+    this.setState({deletedValues: [...this.state.deletedValues, ...params.ids]});
     return action(params);
   }
 
@@ -212,10 +215,18 @@ class VulnerabilityTableV2 extends React.Component {
       scan_id: this.props.scanId,
     };
 
+    let from = page ? page * pageSize : page
+
+    if(this.state.deletedValues.length > 0) {
+      if(this.props.total - this.state.deletedValues.length < from + pageSize) {
+        from -= this.state.deletedValues.length;
+      }
+    }
+
     const apiParams = {
       type: 'cve',
       query: {
-        from: page ? page * pageSize : page,
+        from,
         size: pageSize,
         ...sortField,
         lucene_query: globalSearchQuery,


### PR DESCRIPTION
Fixes # .https://github.com/deepfence/enterprise-roadmap/issues/1640

Changes proposed in this pull request:
- Fixed empty cve results table when deleting all entries on the last page 

@deepfence/engineering
