### PR TITLE
Improve plugins build time

### DIFF
--- a/deepfence_agent/Dockerfile
+++ b/deepfence_agent/Dockerfile
@@ -39,12 +39,12 @@ COPY tools/apache/scope/docker/deepfence_exe /usr/local/discovery/deepfence-disc
 COPY tools/apache/compliance_check /usr/local/bin/compliance_check
 COPY plugins/compliance/scripts /usr/local/bin/compliance_check/scripts
 COPY plugins/compliance/config.json /usr/local/bin/compliance_check/config.json
-COPY plugins/docker_bin/compliance /usr/local/bin/compliance_check/compliance
+COPY plugins/bin/compliance /usr/local/bin/compliance_check/compliance
 COPY tools/apache/scope/docker/agent_check.sh /home/deepfence/
 COPY supervisord.conf /home/deepfence/supervisord-temp.conf
 COPY run_discovery.sh /home/deepfence/
 COPY create_cgroups.sh /home/deepfence/create-cgroups.sh
-COPY plugins/docker_bin /home/deepfence/bin
+COPY plugins/bin /home/deepfence/bin
 
 COPY --from=build /usr/local/bin/syft /usr/local/bin/syft
 

--- a/deepfence_agent/build.sh
+++ b/deepfence_agent/build.sh
@@ -37,7 +37,8 @@ building_image(){
     build_result=$?
     if [ $build_result -ne 0 ]
     then
-        echo "Scope plugins build failed, proceeding with build nonetheless"
+        echo "Scope plugins build failed, bailing out"
+        exit 1
     fi
 
     echo "Building Scope"

--- a/deepfence_agent/build/plugincode-build.sh
+++ b/deepfence_agent/build/plugincode-build.sh
@@ -1,14 +1,6 @@
 #!/bin/bash
 
-cp -R plugins /tmp
-cd /tmp/plugins
-make clean
-#make bin/open-tracer
-build_result=$?
-if [ $build_result -ne 0 ]
-then
-    exit 1
-fi
+cd plugins
 make bin/package-scanner
 build_result=$?
 if [ $build_result -ne 0 ]
@@ -27,7 +19,3 @@ if [ $build_result -ne 0 ]
 then
     exit 1
 fi
-cd /go/src/github.com/deepfence/deepfence_agent
-rm -rf ./plugins/docker_bin
-mkdir ./plugins/docker_bin 2>/dev/null
-cp -r /tmp/plugins/bin/* ./plugins/docker_bin

--- a/deepfence_agent/fargate/Dockerfile.scratch
+++ b/deepfence_agent/fargate/Dockerfile.scratch
@@ -16,7 +16,7 @@ WORKDIR /
 COPY tools/apache/scope/docker/deepfence_exe deepfence/usr/local/discovery/deepfence-discovery
 COPY fargate/bin/ deepfence/bin/
 COPY etc/certs/* deepfence/etc/filebeat/
-COPY plugins/docker_bin/ deepfence/bin/
+COPY plugins/bin/ deepfence/bin/
 COPY --from=build /go/syft/syftCli /deepfence/usr/local/bin/syft
 
 COPY run_discovery.sh /deepfence/home/deepfence/

--- a/deepfence_agent/plugins/Makefile
+++ b/deepfence_agent/plugins/Makefile
@@ -4,14 +4,9 @@ all: localinit proto bin/SecretScanner bin/package-scanner
 localinit:
 	$(PWD)/bootstrap.sh
 
-#bin/open-tracer: ./open-tracer/**/*.rs
-#	(cd open-tracer/open-tracer-ebpf && cargo build --release)
-#	(cd open-tracer/open-tracer-usr && OPEN_TRACER_EBPF_BIN_ABS_PATH=$(PWD)/open-tracer/target/bpfel-unknown-none/release/open-tracer-ebpf cargo build --release)
-#	cp $(PWD)/open-tracer/target/release/open-tracer $(PWD)/bin
-
 bin/SecretScanner: ./SecretScanner/**/*.go
 	(cd SecretScanner && make)
-	mkdir $(PWD)/bin/secret-scanner/
+	-mkdir $(PWD)/bin/secret-scanner/
 	cp $(PWD)/SecretScanner/SecretScanner $(PWD)/bin/secret-scanner/
 	cp $(PWD)/SecretScanner/config.yaml $(PWD)/bin/secret-scanner/
 
@@ -28,10 +23,8 @@ proto: ./agent-plugins-grpc/proto/*.proto
 	cp agent-plugins-grpc/proto/*.go $(PWD)/proto
 
 clean:
-	-#rm $(PWD)/bin/open-tracer
 	-rm -rf $(PWD)/bin/secret-scanner/
 	-rm $(PWD)/bin/package-scanner
-	#cargo clean --manifest-path=./open-tracer/Cargo.toml
 	(cd agent-plugins-grpc && make clean)
 
 .PHONY: clean localinit


### PR DESCRIPTION
Stop cleaning the plugins binaries for every run.
Let make deciding when to trigger a new build instead. Abort build if any of the plugins build is failing.

@deepfence/engineering
