### PR TITLE
Fix mask host vs image

### DIFF
--- a/deepfence_ui/app/scripts/components/common/confirmation-box/index.js
+++ b/deepfence_ui/app/scripts/components/common/confirmation-box/index.js
@@ -20,6 +20,7 @@ const renderRadioInput = ({ name, label, value, id } = {}) => (
       justifyContent: 'flex-start',
       alignItems: 'center',
     }}
+    key={id}
   >
     <Field component="input" type="radio" name={name} value={value} id={id} />
     <span className="label">{label}</span>

--- a/deepfence_ui/app/scripts/components/vulnerability-view/vulnerability-table-view/vulnerability-table-v2-view.js
+++ b/deepfence_ui/app/scripts/components/vulnerability-view/vulnerability-table-view/vulnerability-table-v2-view.js
@@ -22,7 +22,7 @@ const maskOptionsMap = {
   host: [
     {
       type: 'radio',
-      id: 'mask_across_nodes',
+      id: 'mask_across_nodes_and_images',
       name: 'masking_docs',
       label: 'Mask across all hosts and images',
       value: 'mask_across_nodes',
@@ -32,15 +32,15 @@ const maskOptionsMap = {
       id: 'mask_across_nodes',
       name: 'masking_docs',
       label: 'Mask across all hosts',
-      value: 'host||mask_across_nodes', // node_type of host is required by backend
+      value: 'host||mask_across_nodes', // added host|| because node_type of host is required by backend and we retrieved it later
     },
     {
       type: 'radio',
-      id: 'mask_this_host',
+      id: 'mask_this_node',
       name: 'masking_docs',
       label: 'Mask only on this host',
-      value: 'host||mask_this_host', // node_type of host is required by backend
-      defaultValue: 'host||mask_this_host',
+      value: 'host||mask_this_node',
+      defaultValue: 'host||mask_this_node',
     },
   ],
   container_image: [
@@ -56,7 +56,7 @@ const maskOptionsMap = {
       id: 'mask_across_images',
       name: 'masking_docs',
       label: 'Mask across all images',
-      value: 'container_image||mask_across_images', // node_type of container_image is required by backend
+      value: 'container_image||mask_across_nodes', // added container_image || because node_type of container_image is required by backend and we retrieved it later
     },
     {
       type: 'radio',
@@ -64,7 +64,7 @@ const maskOptionsMap = {
       name: 'masking_docs',
       label: 'Mask only on this image',
       value: 'container_image||mask_this_image',
-      defaultValue: 'container_image||mask_this_image', // node_type of container_image is required by backend
+      defaultValue: 'container_image||mask_this_image',
     },
   ]
 }
@@ -188,12 +188,18 @@ class VulnerabilityTableV2 extends React.Component {
     const payload = {
       docs: params,
     }; 
+    /**
+     * there are 3 cases to send payload
+     * i) only this node or image needs mask_across_nodes: false, node_type: host or container_image
+     * ii) across nodes needs mask_across_nodes: true, node_type: host or container_image
+     * iii) across nodes and images needs mask_across_nodes: true
+     */
     const [node, value] = maskDocs.split('||');
     if (value !== undefined) {
-      payload[value] = true;
+      payload.mask_across_nodes = value === 'mask_across_nodes';
       payload.node_type = node;
     } else {
-      payload[node] = true;
+      payload.mask_across_nodes = node === 'mask_across_nodes'
     }
     return action(payload);
   }

--- a/deepfence_ui/app/scripts/components/vulnerability-view/vulnerability-table-view/vulnerability-table-v2-view.js
+++ b/deepfence_ui/app/scripts/components/vulnerability-view/vulnerability-table-view/vulnerability-table-v2-view.js
@@ -18,6 +18,56 @@ import {
 } from '../../../actions/app-actions';
 import { VulnerabilityModal } from '../vulnerability-modal';
 
+const maskOptionsMap = {
+  host: [
+    {
+      type: 'radio',
+      id: 'mask_all_hosts_and_images',
+      name: 'masking_docs',
+      label: 'Mask across all hosts and images',
+      value: 'mask_all_hosts_and_images',
+    },
+    {
+      type: 'radio',
+      id: 'mask_all_host',
+      name: 'masking_docs',
+      label: 'Mask across all hosts',
+      value: 'mask_all_host',
+    },
+    {
+      type: 'radio',
+      id: 'mask_this_host',
+      name: 'masking_docs',
+      label: 'Mask only on this host',
+      value: 'mask_this_host',
+      defaultValue: 'mask_this_host',
+    },
+  ],
+  container_image: [
+    {
+      type: 'radio',
+      id: 'mask_all_images',
+      name: 'masking_docs',
+      label: 'Mask across all images',
+      value: 'mask_all_images',
+    },
+    {
+      type: 'radio',
+      id: 'mask_this_image',
+      name: 'masking_docs',
+      label: 'Mask only on this image',
+      value: 'mask_this_image',
+      defaultValue: 'mask_this_image',
+    },
+  ]
+}
+const getMaskOptionsType = (nodeType) => {
+  if (!nodeType) {
+    throw new Error('No nodeType found!')
+  }
+  return maskOptionsMap[nodeType];
+}
+
 
 class VulnerabilityTableV2 extends React.Component {
   constructor(props) {
@@ -368,23 +418,7 @@ class VulnerabilityTableV2 extends React.Component {
                 confirmationDialogParams: {
                   dialogTitle: 'Mask these records?',
                   dialogBody: 'Are you sure you want to mask the selected records?',
-                  additionalInputs: [
-                    {
-                      type: 'radio',
-                      id: 'mask_all_images',
-                      name: 'masking_docs',
-                      label: 'Mask across all images',
-                      value: 'true',
-                    },
-                    {
-                      type: 'radio',
-                      id: 'mask_this_image',
-                      name: 'masking_docs',
-                      label: 'Mask only on this image',
-                      value: 'false',
-                      defaultValue: 'false',
-                    },
-                  ],
+                  additionalInputs: alerts[0]?.node_type ? getMaskOptionsType(alerts[0].node_type) : [],
                   confirmButtonText: 'Yes, mask',
                   cancelButtonText: 'No, Keep',
                 },

--- a/deepfence_ui/app/scripts/components/vulnerability-view/vulnerability-table-view/vulnerability-table-v2-view.js
+++ b/deepfence_ui/app/scripts/components/vulnerability-view/vulnerability-table-view/vulnerability-table-v2-view.js
@@ -22,42 +22,49 @@ const maskOptionsMap = {
   host: [
     {
       type: 'radio',
-      id: 'mask_all_hosts_and_images',
+      id: 'mask_across_nodes',
       name: 'masking_docs',
       label: 'Mask across all hosts and images',
-      value: 'mask_all_hosts_and_images',
+      value: 'mask_across_nodes',
     },
     {
       type: 'radio',
-      id: 'mask_all_host',
+      id: 'mask_across_nodes',
       name: 'masking_docs',
       label: 'Mask across all hosts',
-      value: 'mask_all_host',
+      value: 'host||mask_across_nodes', // node_type of host is required by backend
     },
     {
       type: 'radio',
       id: 'mask_this_host',
       name: 'masking_docs',
       label: 'Mask only on this host',
-      value: 'mask_this_host',
-      defaultValue: 'mask_this_host',
+      value: 'host||mask_this_host', // node_type of host is required by backend
+      defaultValue: 'host||mask_this_host',
     },
   ],
   container_image: [
     {
       type: 'radio',
-      id: 'mask_all_images',
+      id: 'mask_across_nodes',
+      name: 'masking_docs',
+      label: 'Mask across all hosts and images',
+      value: 'mask_across_nodes',
+    },
+    {
+      type: 'radio',
+      id: 'mask_across_images',
       name: 'masking_docs',
       label: 'Mask across all images',
-      value: 'mask_all_images',
+      value: 'container_image||mask_across_images', // node_type of container_image is required by backend
     },
     {
       type: 'radio',
       id: 'mask_this_image',
       name: 'masking_docs',
       label: 'Mask only on this image',
-      value: 'mask_this_image',
-      defaultValue: 'mask_this_image',
+      value: 'container_image||mask_this_image',
+      defaultValue: 'container_image||mask_this_image', // node_type of container_image is required by backend
     },
   ]
 }
@@ -177,10 +184,18 @@ class VulnerabilityTableV2 extends React.Component {
     } = this.props;
     // Mask and unmask will reset page to 1
     this.handlePageChange(0)
-    return action({
+    
+    const payload = {
       docs: params,
-      mask_across_images: maskDocs === 'true'
-    });
+    }; 
+    const [node, value] = maskDocs.split('||');
+    if (value !== undefined) {
+      payload[value] = true;
+      payload.node_type = node;
+    } else {
+      payload[node] = true;
+    }
+    return action(payload);
   }
 
   handleNotify(selectedDocIndex = {}) {
@@ -421,6 +436,9 @@ class VulnerabilityTableV2 extends React.Component {
                   additionalInputs: alerts[0]?.node_type ? getMaskOptionsType(alerts[0].node_type) : [],
                   confirmButtonText: 'Yes, mask',
                   cancelButtonText: 'No, Keep',
+                  contentStyles: {
+                    height: '300px',
+                  },
                 },
               },
               {


### PR DESCRIPTION
Fixes # https://github.com/deepfence/ThreatMapper/issues/655.

Changes proposed in this pull request:
- To have option mask across host and images

@deepfence/engineering
<img width="539" alt="Screenshot 2022-11-16 at 4 49 23 PM" src="https://user-images.githubusercontent.com/111341101/202167086-6a7c0894-d459-4b53-ac7c-a3ac13387814.png">

