### PR TITLE
added toltip for the cut off text

### DIFF
--- a/deepfence_ui/app/scripts/components/common/multi-select/app-searchable.js
+++ b/deepfence_ui/app/scripts/components/common/multi-select/app-searchable.js
@@ -1,10 +1,28 @@
 /* eslint-disable prefer-destructuring */
 /* eslint-disable react/destructuring-assignment */
 import React, { useRef } from 'react';
-import Select from 'react-select';
+import Select, { components } from 'react-select';
+import Tippy from '@tippyjs/react';
 import { List } from 'react-virtualized';
 import useClickAway from 'react-use/lib/useClickAway';
 import Portal from "@reach/portal";
+
+const Option = (props) => {
+  const ref = useRef()
+  const span = ref.current;
+  const parentWidth = span?.parentElement?.clientWidth ?? 0;
+
+  return (
+    <Tippy
+      disabled={((span?.firstChild?.scrollWidth) ?? 0) <= parentWidth}
+      content={props.children}
+      placement="top-start">
+      <span ref={ref}>
+        <components.Option {...props}>{props.children}</components.Option>
+      </span>
+    </Tippy>
+  );
+};
 
 const Menu = props => {
   const ref = useRef(null);
@@ -241,6 +259,7 @@ class DFSearchableSelect extends React.Component {
           components={{
             DropdownIndicator,
             IndicatorSeparator: null,
+            Option,
             // if there are more than 50 opitons, switch to Virtualized list
             ...(options && options.length > 50
               ? { MenuList: VirtualizedList }


### PR DESCRIPTION
Fixes # https://github.com/deepfence/enterprise-roadmap/issues/1666.

Changes proposed in this pull request:
- Enable tooltip to see full text

@deepfence/engineering
<img width="425" alt="Screenshot 2022-11-23 at 10 15 52 AM" src="https://user-images.githubusercontent.com/111341101/203471551-f74e29fd-66c1-4eb6-b108-14d7026581ec.png">

<img width="464" alt="Screenshot 2022-11-23 at 10 16 01 AM" src="https://user-images.githubusercontent.com/111341101/203471560-ef2e28b5-e697-4db7-92f1-47d673b41dee.png">
