### PR TITLE
agent: Handle both cgroup v1 and v2

### DIFF
--- a/deepfence_agent/create_cgroups.sh
+++ b/deepfence_agent/create_cgroups.sh
@@ -1,19 +1,45 @@
 #!/bin/bash
 
-# add hard-limits to cgroup created for container
+set -e
 
-echo 20000 > /sys/fs/cgroup/cpu/cpu.cfs_quota_us
+create_cgroups() {
+    # create three cgroups named high, medium-1, medium-2
+    cgcreate -a root -t $USER:$USER -g cpu:high
+    cgcreate -a root -t $USER:$USER -g cpu:medium_1
+    cgcreate -a root -t $USER:$USER -g cpu:medium_2
+}
 
-# create three cgroups named high, medium-1, medium-2
+manage_cgroups_v1() {
+    # add hard-limits to cgroup created for container
+    echo 50000 > /sys/fs/cgroup/cpu/cpu.cfs_quota_us
 
-cgcreate -a root -t $USER:$USER -g cpu:high
-cgcreate -a root -t $USER:$USER -g cpu:medium_1
-cgcreate -a root -t $USER:$USER -g cpu:medium_2
+    create_cgroups
 
-# add appropriate cpu-shares
+    # add appropriate cpu-shares
+    echo 512 > /sys/fs/cgroup/cpu/high/cpu.shares
+    echo 256 > /sys/fs/cgroup/cpu/medium_1/cpu.shares
+    echo 256 > /sys/fs/cgroup/cpu/medium_2/cpu.shares
+}
 
-echo 512 > /sys/fs/cgroup/cpu/high/cpu.shares
-echo 256 > /sys/fs/cgroup/cpu/medium_1/cpu.shares
-echo 256 > /sys/fs/cgroup/cpu/medium_2/cpu.shares
+manage_cgroups_v2() {
+    echo "50000 100000" > /sys/fs/cgroup/cpu.max
 
+    create_cgroups
 
+    # add appropriate cpu-shares
+    echo 512 > /sys/fs/cgroup/high/cpu.weight
+    echo 256 > /sys/fs/cgroup/medium_1/cpu.weight
+    echo 256 > /sys/fs/cgroup/medium_2/cpu.weight
+}
+
+# Check the cgroups version
+CGROUPV2=0
+if grep cgroup2 /proc/mounts; then
+    CGROUPV2=1
+fi
+
+if [ $CGROUPV2 -eq 1 ]; then
+    manage_cgroups_v2
+else
+    manage_cgroups_v1
+fi


### PR DESCRIPTION
Before this change, the `create_cgroups.sh` script was assuming that cgroup hierarchy (mounted in `/sys/fs/cgroup`) is v1. The script was also not exiting on error, so when running on a modern distro with cgroups v2 (like Ubuntu 22.04), it was silently failing and then the agent processes were running without cgroups at all.

This change fixes that by detecting the version of cgroup hierarchy and applying changes differently for each version.

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>

@deepfence/engineering
