### PR TITLE
Add ability to integrate with AWS Security Hub #686

### DIFF
--- a/deepfence_backend/api/resource_api.py
+++ b/deepfence_backend/api/resource_api.py
@@ -1152,6 +1152,17 @@ def enumerate_node_filters():
                 "required": True
             }
             response["filters"].append(item)
+        if "aws_account_id" in filters_needed:
+            cloudtrail_resources = CloudComplianceNode.query.filter_by(cloud_provider=CLOUD_AWS).all()
+            account_options = map(lambda x: x.node_name, cloudtrail_resources)
+            item = {
+                "label": "AWS Account",
+                "name": "aws_account_id",
+                "options": list(account_options),
+                "type": "string",
+                "required": True
+            }
+            response["filters"].append(item)
     if resource_filters and response.get('filters'):
         merged_filters = resource_filters + response.get('filters')
         # merged_filters = list(filter(lambda x: x.get('name') in [y.get('name') for y in response.get('filters')],

--- a/deepfence_backend/models/integration.py
+++ b/deepfence_backend/models/integration.py
@@ -5,7 +5,8 @@ import json
 from sys import getsizeof
 from utils.constants import INTEGRATION_TYPE_EMAIL, INTEGRATION_TYPE_ES, INTEGRATION_TYPE_HTTP, INTEGRATION_TYPE_JIRA, \
     INTEGRATION_TYPE_PAGERDUTY, INTEGRATION_TYPE_S3, INTEGRATION_TYPE_SLACK, INTEGRATION_TYPE_SPLUNK, \
-    INTEGRATION_TYPE_SUMO_LOGIC, INTEGRATION_TYPE_MICROSOFT_TEAMS, INTEGRATION_TYPE_GOOGLE_CHRONICLE
+    INTEGRATION_TYPE_SUMO_LOGIC, INTEGRATION_TYPE_MICROSOFT_TEAMS, INTEGRATION_TYPE_GOOGLE_CHRONICLE, \
+    INTEGRATION_TYPE_AWS_SECURITY_HUB
 
 
 class IntegrationTypes(object):
@@ -146,6 +147,8 @@ class IntegrationTypes(object):
             return SumoLogic(config)
         elif integration_type == INTEGRATION_TYPE_MICROSOFT_TEAMS:
             return MicrosoftTeams(config)
+        elif integration_type == INTEGRATION_TYPE_AWS_SECURITY_HUB:
+            return AwsSecurityHub(config)
         else:
             raise Exception("Integration type: {0} - not found".format(integration_type))
 
@@ -277,6 +280,20 @@ class GoogleChronicle(IntegrationTypes):
         resource_type = kwargs["resource_type"]
         from tasks.notification import send_google_chronicle_notification
         send_google_chronicle_notification(self.pretty_print(), content_json["contents"], notification_id,
+                                           resource_type)
+
+
+class AwsSecurityHub(IntegrationTypes):
+    integration_type = INTEGRATION_TYPE_AWS_SECURITY_HUB
+
+    def __init__(self, config):
+        super(AwsSecurityHub, self).__init__(config)
+
+    def send(self, content_json, **kwargs):
+        notification_id = kwargs["notification_id"]
+        resource_type = kwargs["resource_type"]
+        from tasks.notification import send_aws_security_hub_notification
+        send_aws_security_hub_notification(self.pretty_print(), content_json["contents"], notification_id,
                                            resource_type)
 
 

--- a/deepfence_backend/tasks/notification.py
+++ b/deepfence_backend/tasks/notification.py
@@ -12,8 +12,10 @@ from models.user import User
 from utils.common import get_epochtime
 from utils.constants import FILTER_TYPE_IMAGE_NAME_WITH_TAG, CVE_ES_TYPE, USER_DEFINED_TAGS, \
     NODE_TYPE_POD, FILTER_TYPE_HOST_NAME, FILTER_TYPE_IMAGE_NAME, FILTER_TYPE_KUBE_CLUSTER_NAME, \
-    FILTER_TYPE_KUBE_NAMESPACE, FILTER_TYPE_TAGS, CLOUDTRAIL_ALERT_ES_TYPE
+    FILTER_TYPE_KUBE_NAMESPACE, FILTER_TYPE_TAGS, CLOUDTRAIL_ALERT_ES_TYPE, NODE_TYPE_HOST, COMPLIANCE_ES_TYPE, \
+    COMPLIANCE_LINUX_HOST, COMPLIANCE_TYPE_ASFF_MAPPING, COMPLIANCE_STATUS_ASFF_MAPPING
 import datetime
+from utils.scope import fetch_topology_data
 
 
 @celery_app.task
@@ -366,6 +368,134 @@ def send_google_chronicle_notification(self, chronicle_endpoint_conf, payload, n
                 "HTTP Endpoint notification failed. url:[{}], error:[{}]".format(chronicle_endpoint_conf["api_url"],
                                                                                  exc))
             save_integrations_status(notification_id, resource_type, "Error in HTTP endpoint: {0}".format(exc))
+
+
+def map_payload_to_findings(payload, resource_type, region, account_id):
+    findings = []
+    if resource_type == CVE_ES_TYPE:
+        hosts = fetch_topology_data(node_type=NODE_TYPE_HOST, format="scope")
+        for cve in payload:
+            resources = []
+            if cve["node_type"] == NODE_TYPE_HOST:
+                scope_resource = hosts.get("{};<{}>".format(cve["host_name"], cve["node_type"]), None)
+                if scope_resource:
+                    cloud_metadata = list(filter(lambda x: x["id"] == "cloud_metadata",
+                                                 scope_resource.get("metadata", [])))
+                    if cloud_metadata:
+                        try:
+                            cloud_metadata_value = json.loads(cloud_metadata[0]["value"])
+                            resources.append({
+                                "Type": "AwsEc2Instance",
+                                "Id": "arn:aws:ec2:{}:{}:instance/{}".format(cloud_metadata_value["region"],
+                                                                             account_id,
+                                                                             cloud_metadata_value["instance_id"])
+                            })
+                        except ValueError:
+                            continue
+                    else:
+                        continue
+                else:
+                    continue
+            package_name = ""
+            package_version = ""
+            package_split = cve["cve_caused_by_package"].split(":", 1)
+            if package_split:
+                package_name = package_split[0]
+                package_version = package_split[1]
+
+            findings.append({
+                "ProductArn": "arn:aws:securityhub:{region}:{account_id}:product/{account_id}/default".format(
+                    region=region, account_id=account_id
+                ),
+                "AwsAccountId": account_id,
+                "CreatedAt": cve["@timestamp"],
+                "Description": cve["cve_description"],
+                "Title": cve["cve_id"],
+                "UpdatedAt": cve["@timestamp"],
+                "GeneratorId": "deepfence-vulnerability-mapper-v1-0",
+                "Id": "{}/{}/{}".format(region, account_id, cve["doc_id"]),
+                "Resources": resources,
+                "SchemaVersion": "2018-10-08",
+                "Severity": {"Label": cve["cve_severity"].upper(), "Original": str(cve["cve_cvss_score"])},
+                "Types": ["Software and Configuration Checks/Vulnerabilities/CVE"],
+                "Vulnerabilities": [{
+                    "Id": cve["cve_id"],
+                    "ReferenceUrls": [cve["cve_link"]],
+                    "VulnerablePackages": [{
+                        "Name": package_name,
+                        "Version": package_version,
+                    }]
+                }]
+            })
+        return findings
+    elif resource_type == COMPLIANCE_ES_TYPE:
+        hosts = fetch_topology_data(node_type=NODE_TYPE_HOST, format="scope")
+        for compliance in payload:
+            resources = []
+            if compliance.get("compliance_node_type", "") == COMPLIANCE_LINUX_HOST:
+                scope_resource = hosts.get(compliance["node_id"], None)
+                if scope_resource:
+                    cloud_metadata = list(filter(lambda x: x["id"] == "cloud_metadata",
+                                                 scope_resource.get("metadata", [])))
+                    if cloud_metadata:
+                        try:
+                            cloud_metadata_value = json.loads(cloud_metadata[0]["value"])
+                            resources.append({
+                                "Type": "AwsEc2Instance",
+                                "Id": "arn:aws:ec2:{}:{}:instance/{}".format(cloud_metadata_value["region"],
+                                                                             account_id,
+                                                                             cloud_metadata_value["instance_id"])
+                            })
+                        except ValueError:
+                            continue
+                    else:
+                        continue
+                else:
+                    continue
+            findings.append({
+                "ProductArn": "arn:aws:securityhub:{region}:{account_id}:product/{account_id}/default".format(
+                    region=region, account_id=account_id
+                ),
+                "AwsAccountId": account_id,
+                "CreatedAt": compliance["@timestamp"],
+                "Description": compliance["description"],
+                "Title": compliance["test_category"],
+                "UpdatedAt": compliance["@timestamp"],
+                "GeneratorId": "deepfence-compliance-v1-0",
+                "Id": "{}/{}/{}".format(region, account_id, compliance["doc_id"]),
+                "Resources": resources,
+                "SchemaVersion": "2018-10-08",
+                "Severity": {"Label": compliance["status"].upper(), "Original": str(compliance["test_severity"])},
+                "Types": [COMPLIANCE_TYPE_ASFF_MAPPING.get(compliance["compliance_check_type"])],
+                "Compliance": {
+                    "Status": COMPLIANCE_STATUS_ASFF_MAPPING.get(compliance["status"])
+                }
+            })
+        return findings
+    else:
+        return findings
+
+
+@celery_app.task(bind=True, default_retry_delay=1 * 60)
+def send_aws_security_hub_notification(self, security_hub_conf, payload, notification_id, resource_type):
+    with app.app_context():
+        try:
+            import boto3
+
+            def default(o):
+                if isinstance(o, (datetime.date, datetime.datetime)):
+                    return o.isoformat()
+
+            security_hub_client = boto3.client('securityhub', aws_access_key_id=security_hub_conf["aws_access_key"],
+                                               region_name=security_hub_conf["region_name"],
+                                               aws_secret_access_key=security_hub_conf["aws_secret_key"])
+            findings = map_payload_to_findings(payload, resource_type, security_hub_conf["region_name"],
+                                               security_hub_conf["aws_account_id"][0])
+            security_hub_client.batch_import_findings(Findings=findings)
+            save_integrations_status(notification_id, resource_type, "")
+        except Exception as exc:
+            app.logger.error("Security Hub notification failed, error:[{}]".format(exc))
+            save_integrations_status(notification_id, resource_type, "Error in Security Hub: {0}".format(exc))
 
 
 @celery_app.task(bind=True, default_retry_delay=1 * 60)

--- a/deepfence_backend/utils/constants.py
+++ b/deepfence_backend/utils/constants.py
@@ -96,10 +96,11 @@ INTEGRATION_TYPE_GOOGLE_CHRONICLE = "google_chronicle"
 INTEGRATION_TYPE_JIRA = "jira"
 INTEGRATION_TYPE_SUMO_LOGIC = "sumo_logic"
 INTEGRATION_TYPE_MICROSOFT_TEAMS = "microsoft_teams"
+INTEGRATION_TYPE_AWS_SECURITY_HUB = "aws_security_hub"
 INTEGRATION_TYPES = [
     INTEGRATION_TYPE_EMAIL, INTEGRATION_TYPE_SLACK, INTEGRATION_TYPE_PAGERDUTY, INTEGRATION_TYPE_SPLUNK,
     INTEGRATION_TYPE_ES, INTEGRATION_TYPE_S3, INTEGRATION_TYPE_HTTP, INTEGRATION_TYPE_JIRA, INTEGRATION_TYPE_SUMO_LOGIC,
-    INTEGRATION_TYPE_MICROSOFT_TEAMS, INTEGRATION_TYPE_GOOGLE_CHRONICLE]
+    INTEGRATION_TYPE_MICROSOFT_TEAMS, INTEGRATION_TYPE_GOOGLE_CHRONICLE, INTEGRATION_TYPE_AWS_SECURITY_HUB]
 
 NOTIFICATION_TYPE_VULNERABILITY = "vulnerability"
 NOTIFICATION_TYPE_COMPLIANCE = "compliance"
@@ -209,6 +210,25 @@ COMPLIANCE_CHECK_TYPES = {
     COMPLIANCE_PROVIDER_AZURE: ["cis", "nist", "hipaa"],
     COMPLIANCE_LINUX_HOST: ["hipaa", "gdpr", "pci", "nist"],
     COMPLIANCE_KUBERNETES_HOST: ["nsa-cisa"]
+}
+COMPLIANCE_TYPE_ASFF_MAPPING = {
+    "hipaa": "Software and Configuration Checks/Industry and Regulatory Standards/HIPAA Controls (USA)",
+    "gdpr": "Software and Configuration Checks/Industry and Regulatory Standards/GDPR Controls (Europe)",
+    "pci": "Software and Configuration Checks/Industry and Regulatory Standards/PCI-DSS",
+    "nist": "Software and Configuration Checks/Industry and Regulatory Standards/NIST 800-53 Controls (USA)",
+    "aws-foundational-security": "Software and Configuration Checks/Industry and Regulatory Standards/" +
+                                 "AWS Foundational Security Best Practices",
+    "cis": "Software and Configuration Checks/Industry and Regulatory Standards/CIS Host Hardening Benchmarks",
+    "soc2": "Software and Configuration Checks/Industry and Regulatory Standards/SOC 2"
+}
+COMPLIANCE_STATUS_ASFF_MAPPING = {
+    "alarm": "FAILED",
+    "ok": "PASSED",
+    "info": "NOT_AVAILABLE",
+    "skip": "NOT_AVAILABLE",
+    "note": "NOT_AVAILABLE",
+    "pass": "PASSED",
+    "warn": "WARNING"
 }
 CSPM_RESOURCES = {
     "aws_s3_bucket": "aws_s3",
@@ -625,9 +645,10 @@ FILTER_TYPE_IMAGE_NAME = "image_name"
 FILTER_TYPE_IMAGE_NAME_WITH_TAG = "image_name_with_tag"
 FILTER_TYPE_TAGS = "user_defined_tags"
 FILTER_TYPE_CLOUDTRAIL_TRAIL = "cloudtrail_trail"
+FILTER_TYPE_AWS_ACCOUNT_ID = "aws_account_id"
 INTEGRATION_FILTER_TYPES = [FILTER_TYPE_KUBE_NAMESPACE, FILTER_TYPE_KUBE_CLUSTER_NAME, FILTER_TYPE_HOST_NAME,
                             FILTER_TYPE_IMAGE_NAME, FILTER_TYPE_TAGS, FILTER_TYPE_IMAGE_NAME_WITH_TAG,
-                            FILTER_TYPE_CLOUDTRAIL_TRAIL]
+                            FILTER_TYPE_CLOUDTRAIL_TRAIL, FILTER_TYPE_AWS_ACCOUNT_ID]
 DEEPFENCE_KEY = "deepfence-key"
 
 # all text fields needs .keyword in es query for sorting


### PR DESCRIPTION
As mentioned in deepfence/ThreatMapper#686, this PR adds the ability to push scans of your AWS related resources on ThreatMapper to AWS Security Hub.

Changes proposed in this pull request:
- Add ability to push findings(Vulnerabilities, etc) to AWS Security Hub

@deepfence/engineering
