### PR TITLE
Fix global filter not working and duplicate api calls

### DIFF
--- a/deepfence_ui/app/scripts/components/common/df-table-v2/index.js
+++ b/deepfence_ui/app/scripts/components/common/df-table-v2/index.js
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import React, { forwardRef, useEffect, useImperativeHandle, useMemo, useState } from 'react';
 import { useExpanded, useFlexLayout, usePagination, useResizeColumns, useSortBy, useTable, useRowSelect } from 'react-table';
 import { useDispatch } from 'react-redux';
+import usePrevious from 'react-use/lib/usePrevious';
 import Pagination from './pagination';
 import DFTriggerSelect from '../multi-select/app-trigger';
 import AppLoader from '../../loader';
@@ -339,8 +340,12 @@ const DfTableV2 = forwardRef(({
     }
   }, [defaultPageSize, data]);
 
+  const prevSortBy = usePrevious(sortBy);
   useEffect(() => {
-    if (manual && onSortChange) onSortChange(sortBy);
+    // for some reason sortBy is initially undefined and then it gets
+    // set to empty array causing callback in the parent to be called
+    // twice on initial render
+    if (manual && onSortChange && prevSortBy) onSortChange(sortBy);
   }, [sortBy]);
 
   useImperativeHandle(ref, () => {

--- a/deepfence_ui/app/scripts/components/secret-scan-view/secret-scan-table-view/secret-scan-table-v2-view.js
+++ b/deepfence_ui/app/scripts/components/secret-scan-view/secret-scan-table-view/secret-scan-table-v2-view.js
@@ -114,8 +114,9 @@ class SecretScanTableV2 extends React.Component {
   }
 
   componentDidMount() {
-    const { registerPolling } = this.props;
+    const { registerPolling, startPolling } = this.props;
     registerPolling(this.getSecrets);
+    startPolling();
   }
 
   /**
@@ -139,14 +140,14 @@ class SecretScanTableV2 extends React.Component {
       options.hideMasked = newProps.hideMasked;
     }
     if (Object.keys(options).length > 0) {
-      this.getSecrets(options);
+      this.props.updatePollParams(options);
     }
     // Filters and from bound changed will reset page to 1
     if (!isEqual(oldProps.resetPageIndexData, this.props.resetPageIndexData)) {
       /* eslint-disable */
       this.setState({
         page: 0
-      })
+      });
     }
 
   }
@@ -156,14 +157,12 @@ class SecretScanTableV2 extends React.Component {
       this.props;
 
     const hideMasked = params.hideMasked || this.props.hideMasked;
-
     const {
       page = 0,
       pageSize = 20,
-      globalSearchQuery,
+      globalSearchQuery = this.props.globalSearchQuery || [],
       alertPanelHistoryBound = this.props.alertPanelHistoryBound || {},
     } = params;
-
     const tableFilters = params.filters || filterValues;
     const nonEmptyFilters = Object.keys(tableFilters)
       .filter(key => tableFilters[key].length)
@@ -376,7 +375,7 @@ function mapStateToProps(state) {
     secretScanResults: state.getIn(['secretScanResults', 'data']),
     total: state.getIn(['secretScanResults', 'total']),
     filterValues: nodeFilterValueSelector(state),
-    hideMasked: maskFormSelector(state, 'hideMasked'),
+    hideMasked: maskFormSelector(state, 'hideMasked') ?? true,
     maskDocs: state.getIn([
       'form',
       'dialogConfirmation',

--- a/deepfence_ui/app/scripts/components/vulnerability-view/vulnerability-table-view/vulnerability-table-v2-view.js
+++ b/deepfence_ui/app/scripts/components/vulnerability-view/vulnerability-table-view/vulnerability-table-v2-view.js
@@ -184,10 +184,10 @@ class VulnerabilityTableV2 extends React.Component {
     } = this.props;
     // Mask and unmask will reset page to 1
     this.handlePageChange(0)
-    
+
     const payload = {
       docs: params,
-    }; 
+    };
     /**
      * there are 3 cases to send payload
      * i) only this node or image needs mask_across_nodes: false, node_type: host or container_image
@@ -221,8 +221,10 @@ class VulnerabilityTableV2 extends React.Component {
   componentDidMount() {
     const {
       registerPolling,
+      startPolling
     } = this.props;
     registerPolling(this.getVulnerabilities);
+    startPolling();
   }
 
   /**
@@ -506,7 +508,7 @@ function mapStateToProps(state) {
     alerts: state.getIn(['alertsView', 'data']),
     total: state.getIn(['alertsView', 'total']),
     filterValues: nodeFilterValueSelector(state),
-    hideMasked: maskFormSelector(state, 'hideMasked'),
+    hideMasked: maskFormSelector(state, 'hideMasked') ?? true,
     maskDocs: state.getIn(['form', 'dialogConfirmation', 'values', 'masking_docs']),
     resetPageIndexData: resetTablePageIndexSelector(state),
   };


### PR DESCRIPTION
Changes proposed in this pull request:
- Fixes search query from the previous page not applied to vulnerability/secret scan results page.
- Fixes duplicate api calls on initial render on vulnerability/secret scan results page.

@deepfence/engineering
