### PR TITLE
extend TLD matching to match till 18 chars

### DIFF
--- a/deepfence_backend/utils/helper.py
+++ b/deepfence_backend/utils/helper.py
@@ -89,7 +89,7 @@ def validate_port(port):
 def validate_domain(domain):
     if not domain:
         return False
-    regex = "^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+[A-Za-z]{2,6}$"
+    regex = "^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+[A-Za-z]{2,18}$"
     if ":" in domain:
         domain_split = str(domain).split(":")
         domain = domain_split[0]


### PR DESCRIPTION
Fixes # https://github.com/deepfence/ThreatMapper/issues/752

this PR extends the regex to match the TLD till 18 chars.

reference: https://github.com/xtermjs/xterm.js/pull/3596

@deepfence/engineering
