### PR TITLE
Display image name in details page, sbom header instead of image id

### DIFF
--- a/deepfence_ui/app/scripts/components/app-deepfence.js
+++ b/deepfence_ui/app/scripts/components/app-deepfence.js
@@ -141,7 +141,7 @@ class DeepFenceApp extends React.Component {
 
             <PrivateRoute path="/topology" component={TopologyView} />
             <PrivateRoute
-              path="/vulnerability/details/:scanId"
+              path="/vulnerability/details/:scanId/:scanName"
               component={CVEDetailsView}
             />
             <PrivateRoute

--- a/deepfence_ui/app/scripts/components/common/detail-modal/header.jsx
+++ b/deepfence_ui/app/scripts/components/common/detail-modal/header.jsx
@@ -10,7 +10,7 @@ const HeaderKVPair = ({ dataKey, value, valueAsText }) => {
   return (
     <div className={styles.alertSummaryItem}>
       <div className={styles.alertSummaryItemTitle}>{dataKey}</div>
-      <div className={styles.alertSummaryItemContent} title={valueAsText}>{value}</div>
+      <div className={styles.alertSummaryItemContent} title={valueAsText}>{valueAsText}</div>
     </div>
   );
 }

--- a/deepfence_ui/app/scripts/components/vulnerability-view/cve-image-report-container.js
+++ b/deepfence_ui/app/scripts/components/vulnerability-view/cve-image-report-container.js
@@ -109,6 +109,7 @@ class CVEImageReportContainer extends React.PureComponent {
   async handleShowSBOM(params) {
     const {
       scanId,
+      scanName,
     } = params;
     const {
       toaster,
@@ -116,6 +117,8 @@ class CVEImageReportContainer extends React.PureComponent {
     } = this.props;
     const lastUnderscoreIndex = scanId.lastIndexOf('_');
     const unEscapedImageName = scanId.substring(0, lastUnderscoreIndex);
+
+    const unEscapedScanName = decodeURIComponent(scanName);
 
     toaster('Getting SBOM data...');
     const sbomResponse = await getSBOMByScanIdAction({ scanId });
@@ -131,7 +134,8 @@ class CVEImageReportContainer extends React.PureComponent {
         sbomData: {
           sbomJson,
           nodeId: unEscapedImageName,
-          scanId
+          scanId,
+          scanName: unEscapedScanName,
         }
       });
     } else {

--- a/deepfence_ui/app/scripts/components/vulnerability-view/cve-image-report-row-detail.js
+++ b/deepfence_ui/app/scripts/components/vulnerability-view/cve-image-report-row-detail.js
@@ -72,7 +72,7 @@ class CVEImageReportRowDetail extends React.PureComponent {
       <div>
         <DfTableV2
           data={data}
-          onRowClick={(row) => rowClickHandler(row.original.scan_id)}
+          onRowClick={(row) => rowClickHandler(row.original)}
           enableSorting
           columns={[
             {
@@ -202,7 +202,7 @@ class CVEImageReportRowDetail extends React.PureComponent {
                           </div>
                           <div className="row-action-dropdown-item" onClick={(e) => {
                             e.stopPropagation();
-                            handleShowSBOM(cell.value);
+                            handleShowSBOM(cell.row.original);
                           }}>
                             <div className="row-action-item-icon">
                               <i className="fa fa-eye" aria-hidden="true" />

--- a/deepfence_ui/app/scripts/components/vulnerability-view/cve-image-report.js
+++ b/deepfence_ui/app/scripts/components/vulnerability-view/cve-image-report.js
@@ -168,19 +168,38 @@ class CVEImageReport extends React.PureComponent {
     });
   }
 
-  handleShowSBOM(scanId) {
+  handleShowSBOM(row) {
+    let scanName = ''
+    if (row.node_type === "container_image") {
+      scanName = row.image_name;
+    } else if (row.node_type === "container") {
+      scanName = row.container_name;
+    } else if (row.node_type === "host") {
+      scanName = row.host_name;
+    }
     const {
       handleShowSBOM,
     } = this.props;
     return handleShowSBOM({
-      scanId,
+      scanId: row.scan_id,
+      scanName,
     });
   }
 
-  rowClickHandler(scanId) {
+  rowClickHandler(row) {
+    const scanId = row.scan_id;
+    let scanName = ''
+    if (row.node_type === "container_image") {
+      scanName = row.image_name;
+    } else if (row.node_type === "container") {
+      scanName = row.container_name;
+    } else if (row.node_type === "host") {
+      scanName = row.host_name;
+    }
+
     this.setState({
       redirect: true,
-      link: `/vulnerability/details/${encodeURIComponent(scanId)}`,
+      link: `/vulnerability/details/${encodeURIComponent(scanId)}/${encodeURIComponent(scanName)}`,
     });
   }
 

--- a/deepfence_ui/app/scripts/components/vulnerability-view/cve-stats-per-image.js
+++ b/deepfence_ui/app/scripts/components/vulnerability-view/cve-stats-per-image.js
@@ -117,12 +117,6 @@ class CVEStatsPerImage extends React.PureComponent {
                 <div className="name">low</div>
               </div>
             </div>
-            <div className="vulnerability-details">
-              <div className="vulnerability-details-container">
-                <div className="count">{activeContainers}</div>
-                <div className="name">Active containers</div>
-              </div>
-            </div>
           </div>
         </div>
       </div>

--- a/deepfence_ui/app/scripts/components/vulnerability-view/sbom-modal/index.jsx
+++ b/deepfence_ui/app/scripts/components/vulnerability-view/sbom-modal/index.jsx
@@ -17,7 +17,8 @@ export const SBOMModal = ({
   const {
     sbomJson,
     nodeId,
-    scanId
+    scanId,
+    scanName,
   } = data;
   const dispatch = useDispatch();
 
@@ -46,7 +47,7 @@ export const SBOMModal = ({
         data={[{
           key: <div>SBOM for</div>,
           value: nodeId,
-          valueAsText: nodeId
+          valueAsText: scanName,
         }]}
         actions={[
           {

--- a/deepfence_ui/app/scripts/components/vulnerability-view/vulnerability-view.js
+++ b/deepfence_ui/app/scripts/components/vulnerability-view/vulnerability-view.js
@@ -71,16 +71,13 @@ class VulnerabilityView extends React.Component {
     const {
       match: {
         params: {
-          scanId,
+          scanName,
         } = {},
       } = {},
     } = this.props;
-    const unEscapedScanId = decodeURIComponent(scanId);
-    const lastUnderscoreIndex = unEscapedScanId.lastIndexOf('_');
-    const unEscapedImageName = unEscapedScanId.substring(0, lastUnderscoreIndex);
-    let changedImageName = unEscapedImageName;
-    if (unEscapedImageName.length > 20) {
-      changedImageName = unEscapedImageName.substring(0, 19) + "...";
+    let changedImageName = decodeURIComponent(scanName);
+    if (changedImageName.length > 20) {
+      changedImageName = changedImageName.substring(0, 19) + "...";
     }
     this.props.dispatch(breadcrumbChange([{ name: 'Vulnerability', link: '/vulnerability/scans' }, { name: changedImageName }]));
     if (IS_NOTIFICATION_CHECK_ENABLE) {
@@ -118,12 +115,15 @@ class VulnerabilityView extends React.Component {
       match: {
         params: {
           scanId,
+          scanName,
         } = {},
       } = {},
     } = this.props;
     const unEscapedScanId = decodeURIComponent(scanId);
     const lastUnderscoreIndex = unEscapedScanId.lastIndexOf('_');
     const unEscapedImageName = unEscapedScanId.substring(0, lastUnderscoreIndex);
+
+    const unEscapedScanName = decodeURIComponent(scanName);
 
     dispatch(toaster('Getting SBOM data...'));
     const sbomResponse = await dispatch(getSBOMByScanIdAction({scanId: unEscapedScanId}));
@@ -139,7 +139,8 @@ class VulnerabilityView extends React.Component {
         sbomData: {
           sbomJson,
           nodeId: unEscapedImageName,
-          scanId
+          scanId,
+          scanName: unEscapedScanName,
         }
       });
     } else {
@@ -158,6 +159,7 @@ class VulnerabilityView extends React.Component {
       match: {
         params: {
           scanId,
+          scanName,
         } = {},
       } = {},
     } = this.props;
@@ -176,10 +178,7 @@ class VulnerabilityView extends React.Component {
       'content-header',
       { 'with-filters': isFiltersViewVisible },
     );
-    let changedImageName;
-    if (unEscapedImageName.length > 10) {
-      changedImageName = unEscapedImageName.substring(0, 9) + "...";
-    }
+    const unEscapedScanName = decodeURIComponent(scanName);
     return (
       <div>
 
@@ -192,7 +191,7 @@ class VulnerabilityView extends React.Component {
               <div className="title vulnerability-scan-wrapper">
                 Vulnerabilities
                 <div className="sub-title">
-                  {unEscapedImageName} (scanned {timeOfScan.fromNow()}) {" "}&middot;{" "}
+                  {unEscapedScanName} (scanned {timeOfScan.fromNow()}) {" "}&middot;{" "}
                   <span className='sbom-link' onClick={() => {
                     this.showSBOMModal()
                   }}>


### PR DESCRIPTION
Changes proposed in this pull request:
- To display image name instead of image id for vulnerability

@deepfence/engineering
