### PR TITLE
fix stats not loading for scan details for secrets and malware

### DIFF
--- a/deepfence_ui/app/scripts/components/malware-scan-view/malware-scan-stats-per-image.js
+++ b/deepfence_ui/app/scripts/components/malware-scan-view/malware-scan-stats-per-image.js
@@ -8,7 +8,7 @@ import { constructGlobalSearchQuery } from '../../utils/search-utils';
 const MalwareScanStatsPerImage = props => {
   const dispatch = useDispatch();
 
-  const { refreshCounter, hideMasked } = props;
+  const { refreshCounter, hideMasked, scanId } = props;
 
   useEffect(() => {
     const {registerPolling, startPolling} = props;
@@ -38,7 +38,10 @@ const MalwareScanStatsPerImage = props => {
     } = pollParams;
     const params = {
       lucene_query: globalSearchQuery,
-      hideMasked
+      hideMasked,
+      filters: {
+        scan_id: scanId
+      }
     };
     return dispatch(getMalwareScanDataAction(params));
   }

--- a/deepfence_ui/app/scripts/components/secret-scan-view/secret-scan-stats-per-image.js
+++ b/deepfence_ui/app/scripts/components/secret-scan-view/secret-scan-stats-per-image.js
@@ -8,7 +8,7 @@ import { constructGlobalSearchQuery } from '../../utils/search-utils';
 const SecretScanStatsPerImage = props => {
   const dispatch = useDispatch();
 
-  const { refreshCounter, hideMasked } = props;
+  const { refreshCounter, hideMasked, scanId } = props;
 
   useEffect(() => {
     const { updatePollParams } = props;
@@ -39,6 +39,9 @@ const SecretScanStatsPerImage = props => {
     const params = {
       lucene_query: globalSearchQuery,
       hideMasked,
+      filters: {
+        scan_id: scanId
+      }
     };
     return dispatch(getSecretScanDataAction(params));
   }


### PR DESCRIPTION
fixes https://github.com/deepfence/enterprise-roadmap/issues/1716

Changes proposed in this pull request:
- Fix top satats not loading for secret and malware scan details for scans not on page 1.

@deepfence/engineering
