### PR TITLE
Add Start Cloud Compliance Scan API to v2 deepfence/ThreatMapper#838

### DIFF
--- a/deepfence_server/apiDocs/operation.go
+++ b/deepfence_server/apiDocs/operation.go
@@ -214,6 +214,9 @@ func (d *OpenApiDocs) AddScansOperations() {
 	d.AddOperation("startMalwareScan", http.MethodPost, "/deepfence/scan/start/malware",
 		"Start Malware Scan", "Start Malware Scan on agent or registry",
 		http.StatusAccepted, []string{tagMalwareScan}, bearerToken, new(model.MalwareScanTriggerReq), new(model.ScanTriggerResp))
+	d.AddOperation("startCloudComplianceScans", http.MethodPost, "/deepfence/scan/start/cloud-compliance",
+		"Start Cloud Compliance Scans", "Start Cloud Compliance Scans on cloud nodes", http.StatusAccepted,
+		[]string{tagCloudScanner}, bearerToken, new(model.CloudComplianceScanTriggerReq), new(model.ScanTriggerResp))
 
 	// Stop scan
 	d.AddOperation("stopVulnerabilityScan", http.MethodPost, "/deepfence/scan/stop/vulnerability",

--- a/deepfence_server/ingesters/scan_status.go
+++ b/deepfence_server/ingesters/scan_status.go
@@ -152,6 +152,88 @@ func AddNewScan(tx WriteDBTransaction,
 	return nil
 }
 
+func AddNewCloudComplianceScan(tx WriteDBTransaction,
+	scan_id string,
+	benchmark_type string,
+	node_id string) error {
+
+	res, err := tx.Run(`
+		OPTIONAL MATCH (n:Node{node_id:$node_id})
+		RETURN n IS NOT NULL AS Exists`,
+		map[string]interface{}{
+			"node_id": node_id,
+		})
+	if err != nil {
+		return err
+	}
+
+	rec, err := res.Single()
+	if err != nil {
+		return err
+	}
+
+	if !rec.Values[0].(bool) {
+		return &NodeNotFoundError{
+			node_id: node_id,
+		}
+	}
+
+	res, err = tx.Run(fmt.Sprintf(`
+		OPTIONAL MATCH (n:%s)-[:SCANNED]->(:Node{node_id:$node_id})
+		WHERE NOT n.status = $complete
+		AND NOT n.status = $failed
+		AND n.benchmark_type = $benchmark_type
+		RETURN n.node_id`, utils.NEO4J_CLOUD_COMPLIANCE_SCAN),
+		map[string]interface{}{
+			"node_id":        node_id,
+			"complete":       utils.SCAN_STATUS_SUCCESS,
+			"failed":         utils.SCAN_STATUS_FAILED,
+			"benchmark_type": benchmark_type,
+		})
+	if err != nil {
+		return err
+	}
+
+	rec, err = res.Single()
+	if err != nil {
+		return err
+	}
+
+	if rec.Values[0] != nil {
+		return &AlreadyRunningScanError{
+			scan_id:   rec.Values[0].(string),
+			node_id:   node_id,
+			scan_type: string(utils.NEO4J_CLOUD_COMPLIANCE_SCAN),
+		}
+	}
+
+	if _, err = tx.Run(fmt.Sprintf(`
+		MERGE (n:%s{node_id: $scan_id, status: $status, retries: 0, updated_at: TIMESTAMP(), benchmark_type: $benchmark_type})
+		MERGE (m:Node{node_id:$node_id})
+		MERGE (n)-[:SCANNED]->(m)`, utils.NEO4J_CLOUD_COMPLIANCE_SCAN),
+		map[string]interface{}{
+			"scan_id":        scan_id,
+			"status":         utils.SCAN_STATUS_STARTING,
+			"node_id":        node_id,
+			"benchmark_type": benchmark_type,
+		}); err != nil {
+		return err
+	}
+
+	if _, err = tx.Run(fmt.Sprintf(`
+		MATCH (n:%s{node_id: $scan_id})
+		MATCH (m:Node{node_id:$node_id})
+		MERGE (n)-[:SCHEDULED]->(m)`, utils.NEO4J_CLOUD_COMPLIANCE_SCAN),
+		map[string]interface{}{
+			"scan_id": scan_id,
+			"node_id": node_id,
+		}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func UpdateScanStatus(ctx context.Context, scan_type string, scan_id string, status string) error {
 
 	driver, err := directory.Neo4jClient(ctx)

--- a/deepfence_server/model/scans.go
+++ b/deepfence_server/model/scans.go
@@ -25,6 +25,10 @@ type ComplianceScanTriggerReq struct {
 	ScanTriggerCommon
 }
 
+type CloudComplianceScanTriggerReq struct {
+	ScanTriggers []CloudComplianceScanTrigger `json:"scan_triggers" required:"true"`
+}
+
 type ScanTriggerCommon struct {
 	ScanTriggers       []ScanTrigger `json:"scan_triggers" required:"true"`
 	GenerateBulkScanId bool          `json:"generate_bulk_scan_id" required:"true"`
@@ -33,6 +37,11 @@ type ScanTriggerCommon struct {
 type ScanTrigger struct {
 	NodeId   string `json:"node_id" required:"true"`
 	NodeType string `json:"node_type" required:"true" enum:"image,host,container"`
+}
+
+type CloudComplianceScanTrigger struct {
+	NodeId         string   `json:"node_id" required:"true"`
+	BenchmarkTypes []string `json:"benchmark_types" required:"true"`
 }
 
 type ScanStatus string

--- a/deepfence_server/router/router.go
+++ b/deepfence_server/router/router.go
@@ -183,6 +183,7 @@ func SetupRoutes(r *chi.Mux, serverPort string, jwtSecret []byte, serveOpenapiDo
 				r.Post("/secret", dfHandler.AuthHandler(ResourceScan, PermissionStart, dfHandler.StartSecretScanHandler))
 				r.Post("/compliance", dfHandler.AuthHandler(ResourceScan, PermissionStart, dfHandler.StartComplianceScanHandler))
 				r.Post("/malware", dfHandler.AuthHandler(ResourceScan, PermissionStart, dfHandler.StartMalwareScanHandler))
+				r.Post("/cloud-compliance", dfHandler.AuthHandler(ResourceScan, PermissionStart, dfHandler.StartCloudComplianceScanHandler))
 			})
 			r.Route("/scan/stop", func(r chi.Router) {
 				r.Post("/vulnerability", dfHandler.AuthHandler(ResourceScan, PermissionStop, dfHandler.StopVulnerabilityScanHandler))


### PR DESCRIPTION
Add Start Cloud Compliance Scan API

Changes proposed in this pull request:
- Adds a Bulk Cloud Compliance Scan node to Neo4j when starting a scan on cloud nodes
- Adds Cloud Compliance Scan nodes to Neo4j for each benchmark type(cis, pci-dss, etc.) and node when starting a scan on cloud nodes

@deepfence/engineering
