### PR TITLE
Fix duplication on merge

### DIFF
--- a/deepfence_server/controls/version.go
+++ b/deepfence_server/controls/version.go
@@ -129,7 +129,9 @@ func CompleteAgentUpgrade(ctx context.Context, version string, nodeId string) er
 	}
 
 	_, err = tx.Run(`
-		MERGE (n:Node{node_id:$node_id}) -[r:VERSIONED]-> (v:AgentVersion{node_id:$version})
+		MERGE (n:Node{node_id:$node_id})
+		MERGE (v:AgentVersion{node_id:$version})
+		MERGE (n) -[r:VERSIONED]-> (v)
 		WITH n, v
 		OPTIONAL MATCH (v) -[r:SCHEDULED]-> (n)
 		DELETE r`,


### PR DESCRIPTION
Merging relationship directly tries to create new nodes. We need to separate them to match when a node already exists.

Fixes # .

Changes proposed in this pull request:
-
-
-

@deepfence/engineering
