### PR TITLE
Removed duplicate option in the reports generation page

### DIFF
--- a/deepfence_ui/app/scripts/components/integration-view/reports/reports.js
+++ b/deepfence_ui/app/scripts/components/integration-view/reports/reports.js
@@ -35,10 +35,6 @@ const config = [
     label: 'Malware Scan',
     value: 'malware-scan',
   },
-  {
-    label: 'Secret Scan',
-    value: 'secret-scan',
-  }
 ];
 
 const cveSeverityOptions = [


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- Removed the Duplicate option in the reports generation page

@deepfence/engineering
