### PR TITLE
Add cloud compliance scan results API deepfence/ThreatMapper#838

### DIFF
--- a/deepfence_server/apiDocs/operation.go
+++ b/deepfence_server/apiDocs/operation.go
@@ -287,6 +287,9 @@ func (d *OpenApiDocs) AddScansOperations() {
 	d.AddOperation("resultsMalwareScan", http.MethodPost, "/deepfence/scan/results/malware",
 		"Get Malware Scans Results", "Get Malware Scans results on agent or registry",
 		http.StatusOK, []string{tagMalwareScan}, bearerToken, new(model.ScanResultsReq), new(model.MalwareScanResult))
+	d.AddOperation("resultsCloudComplianceScan", http.MethodPost, "/deepfence/scan/results/cloud-compliance",
+		"Get Cloud Compliance Scan Results", "Get Cloud Compliance Scan results for cloud node",
+		http.StatusOK, []string{tagCloudScanner}, bearerToken, new(model.ScanResultsReq), new(model.CloudComplianceScanResult))
 }
 
 func (d *OpenApiDocs) AddDiagnosisOperations() {

--- a/deepfence_server/handler/scan_reports.go
+++ b/deepfence_server/handler/scan_reports.go
@@ -677,6 +677,16 @@ func (h *Handler) ListMalwareScanResultsHandler(w http.ResponseWriter, r *http.R
 	httpext.JSON(w, http.StatusOK, model.MalwareScanResult{Malwares: entries, ScanResultsCommon: common, SeverityCounts: counts})
 }
 
+func (h *Handler) ListCloudComplianceScanResultsHandler(w http.ResponseWriter, r *http.Request) {
+	entries, common, err := listScanResultsHandler[model.CloudCompliance](w, r, utils.NEO4J_CLOUD_COMPLIANCE_SCAN)
+	if err != nil {
+		respondError(err, w)
+		return
+	}
+
+	httpext.JSON(w, http.StatusOK, model.CloudComplianceScanResult{Compliances: entries, ScanResultsCommon: common})
+}
+
 func listScanResultsHandler[T any](w http.ResponseWriter, r *http.Request, scan_type utils.Neo4jScanType) ([]T, model.ScanResultsCommon, error) {
 	defer r.Body.Close()
 	var req model.ScanResultsReq

--- a/deepfence_server/model/scans.go
+++ b/deepfence_server/model/scans.go
@@ -158,6 +158,11 @@ type ComplianceScanResult struct {
 	Compliances []Compliance `json:"compliances" required:"true"`
 }
 
+type CloudComplianceScanResult struct {
+	ScanResultsCommon
+	Compliances []CloudCompliance `json:"compliances" required:"true"`
+}
+
 type Secret struct {
 	StartingIndex         int    `json:"starting_index" required:"true"`
 	RelativeStartingIndex int    `json:"relative_starting_index" required:"true"`
@@ -220,4 +225,27 @@ type Compliance struct {
 	Status              string `json:"status" required:"true"`
 	ComplianceCheckType string `json:"compliance_check_type" required:"true"`
 	ComplianceNodeType  string `json:"compliance_node_type" required:"true"`
+}
+
+type CloudCompliance struct {
+	Timestamp           string `json:"@timestamp" required:"true"`
+	Count               int    `json:"count,omitempty" required:"true"`
+	Reason              string `json:"reason" required:"true"`
+	Resource            string `json:"resource" required:"true"`
+	Status              string `json:"status" required:"true"`
+	Region              string `json:"region" required:"true"`
+	AccountID           string `json:"account_id" required:"true"`
+	Group               string `json:"group" required:"true"`
+	Service             string `json:"service" required:"true"`
+	Title               string `json:"title" required:"true"`
+	ComplianceCheckType string `json:"compliance_check_type" required:"true"`
+	CloudProvider       string `json:"cloud_provider" required:"true"`
+	NodeName            string `json:"node_name" required:"true"`
+	NodeID              string `json:"node_id" required:"true"`
+	ScanID              string `json:"scan_id" required:"true"`
+	Masked              string `json:"masked" required:"true"`
+	Type                string `json:"type" required:"true"`
+	ControlID           string `json:"control_id" required:"true"`
+	Description         string `json:"description" required:"true"`
+	Severity            string `json:"severity" required:"true"`
 }

--- a/deepfence_server/router/router.go
+++ b/deepfence_server/router/router.go
@@ -214,6 +214,7 @@ func SetupRoutes(r *chi.Mux, serverPort string, jwtSecret []byte, serveOpenapiDo
 				r.Post("/secret", dfHandler.AuthHandler(ResourceScanReport, PermissionRead, dfHandler.ListSecretScanResultsHandler))
 				r.Post("/compliance", dfHandler.AuthHandler(ResourceScanReport, PermissionRead, dfHandler.ListComplianceScanResultsHandler))
 				r.Post("/malware", dfHandler.AuthHandler(ResourceScanReport, PermissionRead, dfHandler.ListMalwareScanResultsHandler))
+				r.Post("/cloud-compliance", dfHandler.AuthHandler(ResourceScanReport, PermissionRead, dfHandler.ListCloudComplianceScanResultsHandler))
 			})
 
 			r.Route("/registryaccount", func(r chi.Router) {


### PR DESCRIPTION
Add cloud compliance scan results API.

Changes proposed in this pull request:
- Add cloud compliance scan results API

@deepfence/engineering
