### PR TITLE
agent: Disable cgo for compliance checker

### DIFF
--- a/deepfence_agent/Makefile
+++ b/deepfence_agent/Makefile
@@ -37,7 +37,7 @@ gocode:
 	$(CD) tools/apache/deepfence/df-utils/get_cloud_instance_id && env CGO_ENABLED=0 go build -o getCloudInstanceId $(GOFLAGS) .
 
 	echo "Building compliance checker"
-	$(CD) tools/apache/compliance_check/ && go build -o deepfence_compliance_check $(GOFLAGS) *.go
+	$(CD) tools/apache/compliance_check/ && env CGO_ENABLED=0 go build -o deepfence_compliance_check $(GOFLAGS) *.go
 
 install:
 


### PR DESCRIPTION
Use the CGO_ENABLED=0 env variable to ensure that we are not dynamically linking glibc.

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>

@deepfence/engineering
