### PR TITLE
Add updated AWS CloudFormation template link for cloud scanner org deployment

### DIFF
--- a/deepfence_ui/app/scripts/components/compliance-view/aws-scripts/index.js
+++ b/deepfence_ui/app/scripts/components/compliance-view/aws-scripts/index.js
@@ -104,18 +104,17 @@ export const AwsTerraFormScript = withRouter(props => {
                     target="_blank"
                     rel="noreferrer"
                   >
-                    Deploy on one AWS account--&gt;{' '}
+                    Deploy single AWS account--&gt;{' '}
                   </a>
                   <br/>
                   <a
-                    href={`https://${regionValue}.console.aws.amazon.com/cloudformation/home?region=${regionValue}#/stacksets/create`}
+                    href={`https://${regionValue}.console.aws.amazon.com/cloudformation/home?region=${regionValue}#/stacks/create/review?templateURL=https://deepfence-public.s3.amazonaws.com/cloud-scanner/deepfence-cloud-scanner-org-common.template&stackName=Deepfence-Cloud-Scanner-Org`}
                     disabled={regionValue === undefined}
                     target="_blank"
                     rel="noreferrer"
                   >
-                    Deploy on multiple AWS accounts--&gt;{' '}
+                    Deploy all AWS organization accounts--&gt;{' '}
                   </a>
-                  <p>(Template URL: https://deepfence-public.s3.amazonaws.com/cloud-scanner/deepfence-cloud-scanner.template)</p>
                 </div>
               )}
             </div>

--- a/docs/docs/threatmapper/cloudscanner/aws.md
+++ b/docs/docs/threatmapper/cloudscanner/aws.md
@@ -6,6 +6,16 @@ title: AWS
 
 ## CloudFormation
 
+### Organization Deployment
+
+Log in to the AWS management console account and open the following url link to deploy Cloud Scanner using CloudFormation in `us-east-1` region.
+
+[https://us-east-1.console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://deepfence-public.s3.amazonaws.com/cloud-scanner/deepfence-cloud-scanner.template&stackName=Deepfence-Cloud-Scanner](https://us-east-1.console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://deepfence-public.s3.amazonaws.com/cloud-scanner/deepfence-cloud-scanner.template&stackName=Deepfence-Cloud-Scanner-)
+
+(Template URL: https://deepfence-public.s3.amazonaws.com/cloud-scanner/deepfence-cloud-scanner-org-common.template)
+
+### Single Account Deployment
+
 Open one of the following url links to deploy Cloud Scanner using CloudFormation in `us-east-1` region.
 
 [Deploy across multiple AWS accounts or AWS organization](https://us-east-1.console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacksets/create)


### PR DESCRIPTION
Adds updated link to AWS CloudFormation for Cloud Scanner organization deployment.

Changes proposed in this pull request:
- Adds updated link to AWS CloudFormation for Cloud Scanner organization deployment.

@deepfence/engineering
