### PR TITLE
Fix data refresh issues after scan deletes

### DIFF
--- a/deepfence_ui/app/scripts/components/common/df-table-v2/index.js
+++ b/deepfence_ui/app/scripts/components/common/df-table-v2/index.js
@@ -350,7 +350,10 @@ const DfTableV2 = forwardRef(({
     return {
       resetPageIndex: () => {
         gotoPage(0);
-      }
+      },
+      toggleAllRowsExpanded: (value) => {
+        toggleAllRowsExpanded(value);
+      },
     }
   })
 

--- a/deepfence_ui/app/scripts/components/compliance-view/host-report.js
+++ b/deepfence_ui/app/scripts/components/compliance-view/host-report.js
@@ -165,7 +165,9 @@ class HostReport extends React.PureComponent {
           handleDownload={this.handleDownload}
           dispatch={this.props.dispatch}
           isToasterVisible={isToasterVisible}
-          onDelete={this.getComplianceHostReport}
+          onDelete={() => {
+            this.props.updatePollParams();
+          }}
           scanType={this.props?.scanType || []}
           updatePollParams={this.props?.updatePollParams}
         />

--- a/deepfence_ui/app/scripts/components/settings-view/logs-management/logs-management.js
+++ b/deepfence_ui/app/scripts/components/settings-view/logs-management/logs-management.js
@@ -96,13 +96,13 @@ const VulnerabilityManagementView = props => {
     setAlertsDeleteResponse(props.alertsDeleteResponse);
     setIsSuccess(props.isSuccess);
     setIsError(props.isError);
-  }, [props.isSuccess && !props.isError]);
+  }, [props.isSuccess && !props.isError, props.alertsDeleteResponse]);
 
   useEffect(() => {
     setAlertsDeleteResponse(props.alertsDeleteResponse);
     setIsSuccess(props.isSuccess);
     setIsError(props.isError);
-  }, [!props.isSuccess && props.isError]);
+  }, [!props.isSuccess && props.isError, props.alertsDeleteResponse]);
 
   const resetStates = () => {
     props.dispatch(resetUserProfileStates());

--- a/deepfence_ui/app/scripts/components/vulnerability-view/cve-image-report.js
+++ b/deepfence_ui/app/scripts/components/vulnerability-view/cve-image-report.js
@@ -30,6 +30,7 @@ class CVEImageReport extends React.PureComponent {
     this.setRowCount = this.setRowCount.bind(this);
     this.state = {};
     this.getCVEImageReport = this.getCVEImageReport.bind(this);
+    this.tableRef = React.createRef();
   }
 
   columns = [{
@@ -282,7 +283,10 @@ class CVEImageReport extends React.PureComponent {
         handleShowSBOM={this.handleShowSBOM}
         dispatch={this.props.dispatch}
         isToasterVisible={this.props.isToasterVisible}
-        onDelete={this.getCVEImageReport}
+        onDelete={() => {
+          this.props.updatePollParams({});
+          this.tableRef?.current?.toggleAllRowsExpanded?.(false);
+        }}
       />)
   }
 
@@ -338,6 +342,7 @@ class CVEImageReport extends React.PureComponent {
           />
         </div>
         <DfTableV2
+          ref={this.tableRef}
           data={data}
           columns={this.columns}
           renderRowSubComponent={({ row }) => this.renderSubComponent({ row })}

--- a/deepfence_ui/app/scripts/reducers/root.js
+++ b/deepfence_ui/app/scripts/reducers/root.js
@@ -510,6 +510,16 @@ export function rootReducer(state = initialState, action) {
       return state;
     }
 
+    case ActionTypes.RECEIVE_ALERT_DELETE_RESPONSE: {
+      state = state.set('isSuccess', action.response.isSuccess);
+      state = state.set('isError', action.response.isError);
+      state = state.set(
+        'alertsDeleteResponse',
+        action.response.alertsDeleteResponse
+      );
+      return state;
+    }
+
     case ActionTypes.SELECTED_ACTIVE_MENU: {
       state = state.set('isSelectedMenu', action.response.menuName);
       return state;


### PR DESCRIPTION
Changes proposed in this pull request:
- Vulnerability scan delete from scan page opens wrong sub table as order is changed. We now close any opened sub tables so there is no confusion
- Fixed compliance scan delete not refreshing the table.
- Fixed delete message for logs deletion in settings.

@deepfence/engineering
