### PR TITLE
expose prometheus metrics port

### DIFF
--- a/deployment-scripts/helm-charts/deepfence-console/templates/backend/service.yaml
+++ b/deployment-scripts/helm-charts/deepfence-console/templates/backend/service.yaml
@@ -14,6 +14,10 @@ spec:
       port: 4041
       protocol: TCP
       targetPort: 4041
+    - name: deepfence-backend-metrics
+      port: 8181
+      protocol: TCP
+      targetPort: 8181
 
   selector:
     {{- include "deepfence-console.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- expose prometheus metrics port 8181 for deepfence-backend in helm chart service

@deepfence/engineering
