### PR TITLE
Add query for KSPM for cloud node account listing API

### DIFF
--- a/deepfence_server/handler/cloud_node.go
+++ b/deepfence_server/handler/cloud_node.go
@@ -83,7 +83,7 @@ func (h *Handler) RegisterCloudNodeAccountHandler(w http.ResponseWriter, r *http
 				scanDetail := model.CloudComplianceScanDetails{
 					ScanId:    scan.ScanId,
 					ScanType:  scan.BenchmarkType,
-					AccountId: monitoredNodeId,
+					AccountId: monitoredAccountId,
 					Controls:  controls,
 				}
 				scanList[scan.ScanId] = scanDetail
@@ -140,10 +140,12 @@ func (h *Handler) ListCloudNodeAccountHandler(w http.ResponseWriter, r *http.Req
 	}
 
 	if utils.StringToCloudProvider(req.CloudProvider) == -1 {
-		err = fmt.Errorf("unknown CloudProvider: %s", req.CloudProvider)
-		log.Error().Msgf("%v", err)
-		respondError(&BadDecoding{err}, w)
-		return
+		if req.CloudProvider != model.PostureProviderKubernetes && req.CloudProvider != model.PostureProviderLinux {
+			err = fmt.Errorf("unknown Provider: %s", req.CloudProvider)
+			log.Error().Msgf("%v", err)
+			respondError(&BadDecoding{err}, w)
+			return
+		}
 	}
 
 	infos, err := model.GetCloudComplianceNodesList(r.Context(), req.CloudProvider, req.Window)

--- a/deepfence_server/handler/scan_reports.go
+++ b/deepfence_server/handler/scan_reports.go
@@ -649,7 +649,7 @@ func statusScanHandler(w http.ResponseWriter, r *http.Request, scan_type utils.N
 func complianceStatusScanHandler(w http.ResponseWriter, r *http.Request, scan_type utils.Neo4jScanType) {
 	defer r.Body.Close()
 	var req model.ScanStatusReq
-	err := httpext.DecodeQueryParams(r, &req)
+	err := httpext.DecodeJSON(r, httpext.QueryParams, MaxSbomRequestSize, &req)
 	if err != nil {
 		log.Error().Msgf("%v", err)
 		respondError(&BadDecoding{err}, w)

--- a/deepfence_server/model/cloud_node.go
+++ b/deepfence_server/model/cloud_node.go
@@ -3,7 +3,6 @@ package model
 import (
 	"context"
 	"fmt"
-
 	"github.com/deepfence/golang_deepfence_sdk/utils/directory"
 	"github.com/deepfence/golang_deepfence_sdk/utils/log"
 	"github.com/deepfence/golang_deepfence_sdk/utils/utils"
@@ -328,36 +327,68 @@ func GetCloudComplianceNodesList(ctx context.Context, cloudProvider string, fw F
 	defer tx.Close()
 
 	isOrgListing := false
+	neo4jNodeType := "Node"
+	passStatus := []string{"ok", "info", "skip"}
+	scanType := utils.NEO4J_CLOUD_COMPLIANCE_SCAN
 	if cloudProvider == PostureProviderAWSOrg {
 		cloudProvider = PostureProviderAWS
 		isOrgListing = true
+	} else if cloudProvider == PostureProviderKubernetes {
+		neo4jNodeType = "KubernetesCluster"
+	} else if cloudProvider == PostureProviderLinux {
+		passStatus = []string{"warn", "pass"}
 	}
 	var res neo4j.Result
 	if isOrgListing {
-		res, err = tx.Run(`
-		MATCH (m:Node{cloud_provider:$cloud_provider+'_org'}) -[:IS_CHILD]-> (n:Node{cloud_provider: $cloud_provider})
-		WITH DISTINCT m.node_id AS node_id, m.node_name AS node_name, m.cloud_provider AS cloud_provider, m.updated_at AS updated_at
-		OPTIONAL MATCH (n:Node{cloud_provider: $cloud_provider})<-[:SCANNED]-(s:CloudComplianceScan)-[:DETECTED]->(c:CloudComplianceResult)
-		WITH node_id, node_name, cloud_provider, updated_at, COUNT(c) AS total_compliance_count
-		OPTIONAL MATCH (n:Node{cloud_provider: $cloud_provider})<-[:SCANNED]-(s:CloudComplianceScan)-[:DETECTED]->(c1:CloudComplianceResult)
-		WHERE c1.status IN ['ok', 'info', 'skip']
-		RETURN node_id, node_name, cloud_provider, CASE WHEN total_compliance_count = 0 THEN 0.0 ELSE COUNT(c1.status)*100.0/total_compliance_count END AS compliance_percentage, updated_at
-		ORDER BY updated_at`+fw.FetchWindow2CypherQuery(),
-			map[string]interface{}{"cloud_provider": cloudProvider})
+		res, err = tx.Run(fmt.Sprintf(`
+		MATCH (m:%s{cloud_provider:$cloud_provider+'_org'}) -[:IS_CHILD]-> (n:%s{cloud_provider: $cloud_provider})
+		WITH DISTINCT m.node_id AS node_id, m.node_name AS node_name, m.updated_at AS updated_at
+		UNWIND node_id AS x
+		OPTIONAL MATCH (m:%s{cloud_provider:$cloud_provider+'_org', node_id: x}) -[:IS_CHILD]-> (n:%s{cloud_provider: $cloud_provider})<-[:SCANNED]-(s:%s)-[:DETECTED]->(c:CloudComplianceResult)
+		WITH x, node_name, updated_at, COUNT(c) AS total_compliance_count
+		OPTIONAL MATCH (m:%s{cloud_provider:$cloud_provider+'_org', node_id: x}) -[:IS_CHILD]-> (n:%s{cloud_provider: $cloud_provider})<-[:SCANNED]-(s:%s)-[:DETECTED]->(c1:CloudComplianceResult)
+		WHERE c1.status IN $pass_status
+		RETURN x, node_name, $cloud_provider+'_org', CASE WHEN total_compliance_count = 0 THEN 0.0 ELSE COUNT(c1.status)*100.0/total_compliance_count END AS compliance_percentage, updated_at
+		ORDER BY updated_at`, neo4jNodeType, neo4jNodeType, neo4jNodeType, neo4jNodeType, scanType, neo4jNodeType,
+			neo4jNodeType, scanType)+fw.FetchWindow2CypherQuery(),
+			map[string]interface{}{"cloud_provider": cloudProvider, "pass_status": passStatus})
+		if err != nil {
+			return CloudNodeAccountsListResp{Total: 0}, err
+		}
+	} else if cloudProvider == PostureProviderKubernetes || cloudProvider == PostureProviderLinux {
+		scanType = utils.NEO4J_COMPLIANCE_SCAN
+		res, err = tx.Run(fmt.Sprintf(`
+		MATCH (n:%s)
+		WITH n.node_id AS node_id, n.node_name AS node_name, n.updated_at AS updated_at
+		UNWIND node_id AS x
+		OPTIONAL MATCH (n:%s{node_id: x})<-[:SCANNED]-(s:%s)-[:DETECTED]->(c:Compliance)
+		WITH x, node_name, updated_at, COUNT(c) AS total_compliance_count
+		OPTIONAL MATCH (n:%s{node_id: y})<-[:SCANNED]-(s:%s)-[:DETECTED]->(c1:Compliance)
+		WHERE c1.status IN $pass_status
+		RETURN x, node_name, $cloud_provider, CASE WHEN total_compliance_count = 0 THEN 0.0 ELSE COUNT(c1.status)*100.0/total_compliance_count END AS compliance_percentage, updated_at
+		ORDER BY updated_at`, neo4jNodeType, neo4jNodeType, scanType, neo4jNodeType, scanType)+fw.FetchWindow2CypherQuery(),
+			map[string]interface{}{
+				"cloud_provider": cloudProvider,
+				"pass_status":    passStatus,
+			})
 		if err != nil {
 			return CloudNodeAccountsListResp{Total: 0}, err
 		}
 	} else {
-		res, err = tx.Run(`
-		MATCH (n:Node{cloud_provider: $cloud_provider}) 
-		WITH DISTINCT n.node_id AS node_id, n.node_name AS node_name, n.cloud_provider AS cloud_provider, n.updated_at AS updated_at
-		OPTIONAL MATCH (n:Node{cloud_provider: $cloud_provider})<-[:SCANNED]-(s:CloudComplianceScan)-[:DETECTED]->(c:CloudComplianceResult)
-		WITH node_id, node_name, cloud_provider, updated_at, COUNT(c) AS total_compliance_count
-		OPTIONAL MATCH (n:Node{cloud_provider: $cloud_provider})<-[:SCANNED]-(s:CloudComplianceScan)-[:DETECTED]->(c1:CloudComplianceResult)
-		WHERE c1.status IN ['ok', 'info', 'skip']
-		RETURN node_id, node_name, cloud_provider, CASE WHEN total_compliance_count = 0 THEN 0.0 ELSE COUNT(c1.status)*100.0/total_compliance_count END AS compliance_percentage, updated_at
-		ORDER BY updated_at`+fw.FetchWindow2CypherQuery(),
-			map[string]interface{}{"cloud_provider": cloudProvider})
+		res, err = tx.Run(fmt.Sprintf(`
+		MATCH (n:%s{cloud_provider: $cloud_provider}) 
+		WITH n.node_id AS node_id, n.node_name AS node_name, n.cloud_provider AS cloud_provider, n.updated_at AS updated_at
+		UNWIND node_id AS x
+		OPTIONAL MATCH (n:%s{cloud_provider: $cloud_provider, node_id: x})<-[:SCANNED]-(s:%s)-[:DETECTED]->(c:CloudComplianceResult)
+		WITH x, node_name, cloud_provider, updated_at, COUNT(c) AS total_compliance_count
+		OPTIONAL MATCH (n:%s{cloud_provider: $cloud_provider, node_id: x})<-[:SCANNED]-(s:%s)-[:DETECTED]->(c1:CloudComplianceResult)
+		WHERE c1.status IN $pass_status
+		RETURN x, node_name, cloud_provider, CASE WHEN total_compliance_count = 0 THEN 0.0 ELSE COUNT(c1.status)*100.0/total_compliance_count END AS compliance_percentage, updated_at
+		ORDER BY updated_at`, neo4jNodeType, neo4jNodeType, scanType, neo4jNodeType, scanType)+fw.FetchWindow2CypherQuery(),
+			map[string]interface{}{
+				"cloud_provider": cloudProvider,
+				"pass_status":    passStatus,
+			})
 		if err != nil {
 			return CloudNodeAccountsListResp{Total: 0}, err
 		}

--- a/deepfence_server/reporters/scan/scan_reporters.go
+++ b/deepfence_server/reporters/scan/scan_reporters.go
@@ -865,17 +865,20 @@ func GetComplianceBulkScans(ctx context.Context, scanType utils.Neo4jScanType, s
 	}
 	driver, err := directory.Neo4jClient(ctx)
 	if err != nil {
+		log.Error().Msgf("Neo4j client init failed: %+v", err)
 		return scanIds, err
 	}
 
 	session := driver.NewSession(neo4j.SessionConfig{AccessMode: neo4j.AccessModeRead})
 	if err != nil {
+		log.Error().Msgf("Neo4j session creation failed: %+v", err)
 		return scanIds, err
 	}
 	defer session.Close()
 
 	tx, err := session.BeginTransaction()
 	if err != nil {
+		log.Error().Msgf("Failed to begin new neo4j transaction: %+v", err)
 		return scanIds, err
 	}
 	defer tx.Close()
@@ -885,11 +888,13 @@ func GetComplianceBulkScans(ctx context.Context, scanType utils.Neo4jScanType, s
 		RETURN d.node_id, d.benchmark_type, d.status, n.node_id, d.updated_at`,
 		map[string]interface{}{"scan_id": scanId})
 	if err != nil {
+		log.Error().Msgf("Compliance bulk scans status query failed: %+v", err)
 		return scanIds, err
 	}
 
 	recs, err := neo_res.Collect()
 	if err != nil {
+		log.Error().Msgf("Compliance bulk scan neo4j result collection failed: %+v", err)
 		return scanIds, err
 	}
 


### PR DESCRIPTION
Add query for KSPM for cloud node account listing API.

Changes proposed in this pull request:
- Add query for KSPM for cloud node account listing API
- Update match condition for cloud node upsert with parent during register
- Change query param parsing to json parsing for cloud compliance status API
- Update account id sent in response for register cloud node API
- Add verbose errors in scan status API for bulk scan status

@deepfence/engineering
