### PR TITLE
Set default region for ECR public registry during initialize

### DIFF
--- a/deepfence_backend/api/vulnerability_api.py
+++ b/deepfence_backend/api/vulnerability_api.py
@@ -20,7 +20,7 @@ from utils.constants import CVE_INDEX, TIME_UNIT_MAPPING, USER_ROLES, ES_TERMS_A
     NODE_TYPE_HOST, CVE_SCAN_TYPES, NODE_TYPE_CONTAINER_IMAGE, REGISTRY_IMAGES_CACHE_KEY_PREFIX, \
     MAX_TOTAL_SEVERITY_SCORE, REGISTRY_TYPE_GCLOUD, TOPOLOGY_FILTERS_PREFIX, \
     NODE_TYPE_REGISTRY_IMAGE, DF_ID_TO_SCOPE_ID_REDIS_KEY_PREFIX, NODE_ACTION_CVE_SCAN_START, ES_MAX_CLAUSE, \
-    CVE_SCAN_LOGS_INDEX, SBOM_INDEX, SBOM_DEFAULT_FIELDS, SBOM_ARTIFACT_INDEX, CVE_ES_TYPE
+    CVE_SCAN_LOGS_INDEX, SBOM_INDEX, SBOM_DEFAULT_FIELDS, SBOM_ARTIFACT_INDEX, CVE_ES_TYPE, REGISTRY_TYPE_ECR
 from utils.decorators import non_read_only_user, admin_user_only
 from models.node_tags import NodeTags
 from models.container_image_registry import RegistryCredential
@@ -31,7 +31,8 @@ import pandas as pd
 import json
 import time
 from config.redisconfig import redis
-from cve_scan_registry.scan_registry.cve_scan_registry import DFError as DFErrorFromThreatMapper
+from cve_scan_registry.scan_registry.cve_scan_registry import DFError as DFErrorFromThreatMapper, \
+    AWS_PUBLIC_REGISTRY_REGION
 from utils.resource import filter_node_for_vulnerabilities, get_scan_status_for_registry_images
 from utils.scope import fetch_topology_hosts, fetch_topology_container_images, fetch_topology_containers
 import re
@@ -1203,6 +1204,9 @@ def add_edit_registry_credentials():
                 extras["service_account_json"] = json.dumps(service_account_json)
             except:
                 raise InvalidUsage("unable to read 'service_account_json' json file")
+    elif credentials.get("registry_type", "") == REGISTRY_TYPE_ECR:
+        if credentials.get("non_secret", {}).get("is_public", False):
+            credentials["non_secret"]["aws_region_name"] = AWS_PUBLIC_REGISTRY_REGION
 
     registry_type = credentials.get("registry_type", "")
     secret = credentials.get("secret", {})

--- a/deepfence_backend/cve_scan_registry/scan_registry/cve_scan_registry.py
+++ b/deepfence_backend/cve_scan_registry/scan_registry/cve_scan_registry.py
@@ -405,7 +405,10 @@ class CveScanECRImages(CveScanRegistryImages):
                     raise DFError('region is required for iam role')
         else:
             if not self.aws_access_key_id or not self.aws_secret_access_key or not self.aws_region_name:
-                raise DFError('access key, secret key and region is required')
+                if self.is_public == "true":
+                    raise DFError('access key and secret key are required')
+                else:
+                    raise DFError('access key, secret key and region are required')
         token = None
         try:
             if self.registry_id:


### PR DESCRIPTION
Fixes region validation error when adding ECR public registry.

Changes proposed in this pull request:
- Set default region for public ECR registries in add_registry API call

@deepfence/engineering
