### PR TITLE
Skip registry id for ecr public get authorization token call as inval…

### DIFF
--- a/deepfence_backend/cve_scan_registry/scan_registry/cve_scan_registry.py
+++ b/deepfence_backend/cve_scan_registry/scan_registry/cve_scan_registry.py
@@ -387,7 +387,7 @@ class CveScanECRImages(CveScanRegistryImages):
 
     def docker_login(self):
         # Docker login to ecr
-        if self.registry_id:
+        if self.registry_id and self.is_public != "true":
             tmp_auth_token = self.ecr_client.get_authorization_token(registryIds=[self.registry_id])
         else:
             tmp_auth_token = self.ecr_client.get_authorization_token()
@@ -411,7 +411,7 @@ class CveScanECRImages(CveScanRegistryImages):
                     raise DFError('access key, secret key and region are required')
         token = None
         try:
-            if self.registry_id:
+            if self.registry_id and self.is_public != "true":
                 token = self.ecr_client.get_authorization_token(registryIds=[self.registry_id])
             else:
                 token = self.ecr_client.get_authorization_token()


### PR DESCRIPTION
…id parameter

Remove registryIds parameter from get_authorization_token call

Changes proposed in this pull request:
- Remove registryIds parameter from get_authorization_token call



@deepfence/engineering
