### PR TITLE
(v2) trigger registry sync task when new registry is added

### DIFF
--- a/deepfence_server/pkg/registry/gitlab/types.go
+++ b/deepfence_server/pkg/registry/gitlab/types.go
@@ -13,5 +13,5 @@ type NonSecret struct {
 }
 
 type Secret struct {
-	GitlabToken string `json:"gitlab_token"`
+	GitlabToken string `json:"gitlab_access_token"`
 }

--- a/deepfence_server/pkg/registry/registry.go
+++ b/deepfence_server/pkg/registry/registry.go
@@ -274,7 +274,7 @@ func GetRegistryWithRegistryRow(row postgresql_db.GetContainerRegistriesRow) (Re
 				GitlabRegistryURL: nonSecret["gitlab_registry_url"],
 			},
 			Secret: gitlab.Secret{
-				GitlabToken: secret["gitlab_token"],
+				GitlabToken: secret["gitlab_access_token"],
 			},
 		}
 		return r, nil

--- a/deepfence_worker/cronjobs/registry.go
+++ b/deepfence_worker/cronjobs/registry.go
@@ -1,11 +1,15 @@
 package cronjobs
 
 import (
+	"encoding/json"
+
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/deepfence/ThreatMapper/deepfence_server/pkg/registry"
 	sync "github.com/deepfence/ThreatMapper/deepfence_server/pkg/registrysync"
 	"github.com/deepfence/golang_deepfence_sdk/utils/directory"
 	"github.com/deepfence/golang_deepfence_sdk/utils/log"
+	postgresql_db "github.com/deepfence/golang_deepfence_sdk/utils/postgresql/postgresql-db"
+	"github.com/deepfence/golang_deepfence_sdk/utils/utils"
 )
 
 func SyncRegistry(msg *message.Message) error {
@@ -18,9 +22,39 @@ func SyncRegistry(msg *message.Message) error {
 		return err
 	}
 
-	registries, err := pgClient.GetContainerRegistries(postgresCtx)
-	if err != nil {
-		return err
+	var registries []postgresql_db.GetContainerRegistriesRow
+
+	rsp := utils.RegistrySyncParams{}
+
+	if msg.Payload != nil {
+		err = json.Unmarshal(msg.Payload, &rsp)
+		if err != nil {
+			log.Error().Msgf("unable to unmarshal payload: %v", err)
+			registries, err = pgClient.GetContainerRegistries(postgresCtx)
+			if err != nil {
+				return err
+			}
+		}
+
+		if rsp.PgID != 0 {
+			r, err := pgClient.GetContainerRegistry(postgresCtx, rsp.PgID)
+			if err != nil {
+				return err
+			}
+			// kludge: marshal and unmarshal back r to postgresql_db.GetContainerRegistriesRow
+			rByte, err := json.Marshal(r)
+			if err != nil {
+				return err
+			}
+			var getContainerRegistriesRow postgresql_db.GetContainerRegistriesRow
+			err = json.Unmarshal(rByte, &getContainerRegistriesRow)
+			registries = append(registries, getContainerRegistriesRow)
+		}
+	} else {
+		registries, err = pgClient.GetContainerRegistries(postgresCtx)
+		if err != nil {
+			return err
+		}
 	}
 
 	for _, row := range registries {


### PR DESCRIPTION
Triggers a registry sync task in deepfence_worker to sync single registry whenever a new registry is added.
