### PR TITLE
add script to install console on docker and k8s

### DIFF
--- a/deployment-scripts/helm-charts/deepfence-console/templates/databases/kafka/kafka.yaml
+++ b/deployment-scripts/helm-charts/deepfence-console/templates/databases/kafka/kafka.yaml
@@ -109,7 +109,7 @@ spec:
         resources:
           requests:
             storage: "{{ .Values.kafka.volumeSize }}"
-        storageClassName: {{ .Values.kafka.storageClass }}
+        storageClassName: {{ default .Values.global.storageClass .Values.kafka.storageClass }}
 ---
 apiVersion: v1
 kind: Service

--- a/deployment-scripts/helm-charts/deepfence-console/templates/databases/minio/minio.yaml
+++ b/deployment-scripts/helm-charts/deepfence-console/templates/databases/minio/minio.yaml
@@ -82,7 +82,7 @@ spec:
         resources:
           requests:
             storage: "{{ .Values.minio.volumeSize }}"
-        storageClassName: {{ .Values.minio.storageClass }}
+        storageClassName: {{ default .Values.global.storageClass .Values.minio.storageClass }}
 ---
 apiVersion: v1
 kind: Service

--- a/deployment-scripts/helm-charts/deepfence-console/templates/databases/neo4j/neo4j.yaml
+++ b/deployment-scripts/helm-charts/deepfence-console/templates/databases/neo4j/neo4j.yaml
@@ -88,7 +88,7 @@ spec:
         resources:
           requests:
             storage: "{{ .Values.neo4j.volumeSize }}"
-        storageClassName: {{ .Values.neo4j.storageClass }}
+        storageClassName: {{ default .Values.global.storageClass .Values.neo4j.storageClass }}
 ---
 apiVersion: v1
 kind: Service

--- a/deployment-scripts/helm-charts/deepfence-console/templates/databases/postgresql/postgresql.yaml
+++ b/deployment-scripts/helm-charts/deepfence-console/templates/databases/postgresql/postgresql.yaml
@@ -79,7 +79,7 @@ spec:
         resources:
           requests:
             storage: "{{ .Values.postgresql.volumeSize }}"
-        storageClassName: {{ .Values.postgresql.storageClass }}
+        storageClassName: {{ default .Values.global.storageClass .Values.postgresql.storageClass }}
 ---
 apiVersion: v1
 kind: Service

--- a/deployment-scripts/helm-charts/deepfence-console/templates/databases/redis/redis.yaml
+++ b/deployment-scripts/helm-charts/deepfence-console/templates/databases/redis/redis.yaml
@@ -72,7 +72,7 @@ spec:
         resources:
           requests:
             storage: "{{ .Values.redis.volumeSize }}"
-        storageClassName: {{ .Values.redis.storageClass }}
+        storageClassName: {{ default .Values.global.storageClass .Values.redis.storageClass }}
 ---
 apiVersion: v1
 kind: Service

--- a/deployment-scripts/helm-charts/deepfence-console/values.yaml
+++ b/deployment-scripts/helm-charts/deepfence-console/values.yaml
@@ -9,7 +9,8 @@ global:
   imageRepoPrefix: "docker.io"
   # this image tag is used every where for console services
   # to override set tag at service level
-  imageTag: 2.0.0 
+  imageTag: 2.0.0
+  storageClass: ""
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -33,7 +34,7 @@ imagePullSecret:
 kafka:
   # Specifies whether a kafka cluster should be created
   create: true
-  # if create false provide name of the existing secret 
+  # if create false provide name of the existing secret
   # secret format refer templates/console-secrets/kafka.yaml
   secretName: ""
   # if create true then below values are used to create kafka cluster
@@ -63,7 +64,7 @@ kafka:
 postgresql:
   # Specifies whether a postgres database instance should be created
   create: true
-  # if create false provide name of the existing secret 
+  # if create false provide name of the existing secret
   # secret format refer templates/console-secrets/postgresql.yaml
   secretName: ""
   # if create true then below values are used to create postgres database instance
@@ -96,10 +97,10 @@ postgresql:
 redis:
   # Specifies whether a postgres database instance should be created
   create: true
-  # if create false provide name of the existing secret 
+  # if create false provide name of the existing secret
   # secret format refer templates/console-secrets/redis.yaml
   secretName: ""
-  # if create true then below values are used to create postgres database instance 
+  # if create true then below values are used to create postgres database instance
   image:
     repository: deepfenceio/deepfence_redis_ce
     pullPolicy: Always
@@ -107,7 +108,7 @@ redis:
     # tag: 2.0.0
   storageClass: ""
   volumeSize: 5G
-  resources: 
+  resources:
     limits:
       # cpu: 100m
       memory: 1000Mi
@@ -124,11 +125,11 @@ redis:
 minio:
   # Specifies whether a postgres database instance should be created
   create: true
-  # if create false provide name of the existing secret 
+  # if create false provide name of the existing secret
   # secret format refer templates/console-secrets/minio.yaml
   secretName: ""
-  # if create true then below values are used to create postgres database instance 
-  secrets: 
+  # if create true then below values are used to create postgres database instance
+  secrets:
     MINIO_ROOT_USER: deepfence
     MINIO_ROOT_PASSWORD: deepfence
   image:
@@ -155,10 +156,10 @@ minio:
 neo4j:
   # Specifies whether a neo4j database instance should be created
   create: true
-  # if create false provide name of the existing secret 
+  # if create false provide name of the existing secret
   # secret format refer templates/console-secrets/neo4j.yaml
   secretName: ""
-  # if create true then below values are used to create neo4j database instance 
+  # if create true then below values are used to create neo4j database instance
   secrets:
     # format should be username/password
     NEO4J_AUTH: neo4j/e16908ffa5b9f8e9d4ed
@@ -173,7 +174,8 @@ neo4j:
     tag: 4.4.12
   storageClass: ""
   volumeSize: 30G
-  resources: {}
+  resources:
+    {}
     # limits:
     #   # cpu: 100m
     #   memory: 5000Mi
@@ -187,7 +189,7 @@ neo4j:
   tolerations: []
   affinity: {}
 
-# ingress for console 
+# ingress for console
 ingress:
   enable: false
   ## name of the ingress class for ingress provider installed on the cluster, cannot be empty
@@ -230,12 +232,13 @@ router:
     ## useful if deepfence-router chart is not installed
     create: false
     # useful for configuring loadbalancer options on supported clouds
-    annotations: {}  
+    annotations: {}
     ## service.beta.kubernetes.io/do-loadbalancer-enable-proxy-protocol: "true"
-    type: ClusterIP  # set service type to cluster ip and enable ingress if available
+    type: ClusterIP # set service type to cluster ip and enable ingress if available
     httpsPort: 443
     httpPort: 80
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -291,7 +294,8 @@ server:
     type: ClusterIP
     port: 8080
     internalPort: 8081
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -321,7 +325,8 @@ worker:
   service:
     type: ClusterIP
     port: 8080
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -351,7 +356,8 @@ ingester:
   service:
     type: ClusterIP
     port: 8080
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -377,7 +383,8 @@ scheduler:
   service:
     type: ClusterIP
     port: 8080
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -401,7 +408,8 @@ ui:
   service:
     type: ClusterIP
     port: 8081
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -420,4 +428,3 @@ ui:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-

--- a/install.sh
+++ b/install.sh
@@ -29,12 +29,17 @@ while [[ $# -gt 0 ]]; do
         shift
         shift
         ;;
-        -n|--no-prompt)
-        NO_PROMPT=true
-        shift
+        -h|--help)
+        echo "Usage: $0 [OPTIONS]"
+        echo "Options:"
+        echo "  -d, --deployment     Specify the deployment type: 'docker' or 'kubernetes'"
+        echo "  -t, --image-tag      Specify the image tag for the Deepfence components (default: $DEFAULT_IMAGE_TAG)"
+        echo "  -h, --help           Display usage instructions"
+        exit 0
         ;;
         *) # Unknown option
-        shift
+        echo "Unknown option: $key"
+        exit 1
         ;;
     esac
 done

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+
+# Define color codes
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'  # No color
+
+# Checkmark and Cross symbols
+CHECKMARK="${GREEN}✔${NC}"
+CROSS="${RED}✘${NC}"
+
+# Default image tag
+DEFAULT_IMAGE_TAG="2.0.0"
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    key="$1"
+    case $key in
+        -d|--deployment)
+        DEPLOYMENT="$2"
+        shift
+        shift
+        ;;
+        -t|--image-tag)
+        IMAGE_TAG="$2"
+        shift
+        shift
+        ;;
+        *) # Unknown option
+        shift
+        ;;
+    esac
+done
+
+# Set image tag
+if [[ -n $IMAGE_TAG ]]; then
+    echo -e "${CHECKMARK} Using image tag: $IMAGE_TAG"
+elif [[ -n $DF_IMG_TAG ]]; then
+    IMAGE_TAG=$DF_IMG_TAG
+    echo -e "${CHECKMARK} Using image tag from DF_IMG_TAG environment variable: $IMAGE_TAG"
+else
+    IMAGE_TAG=$DEFAULT_IMAGE_TAG
+    echo -e "${CHECKMARK} Using default image tag: $IMAGE_TAG"
+fi
+
+# Check minimum system requirements for Docker
+check_docker_requirements() {
+    echo -e "${GREEN}Checking minimum system requirements for Docker...${NC}"
+
+    # Check CPU cores
+    MIN_CPU=4
+    ACTUAL_CPU=$(nproc)
+    if [[ $ACTUAL_CPU -lt $MIN_CPU ]]; then
+        echo -e "${CROSS} Insufficient CPU cores for Docker. Minimum requirement: $MIN_CPU cores.${NC}"
+        exit 1
+    fi
+    echo -e "${CHECKMARK} CPU cores check passed for Docker."
+
+    # Check RAM
+    MIN_RAM=16
+    ACTUAL_RAM=$(free -g | awk '/^Mem:/{print $2}')
+    if [[ $ACTUAL_RAM -lt $MIN_RAM ]]; then
+        echo -e "${CROSS} Insufficient RAM for Docker. Minimum requirement: $MIN_RAM GB.${NC}"
+        exit 1
+    fi
+    echo -e "${CHECKMARK} RAM check passed for Docker."
+}
+
+# Check Docker and Docker Compose
+check_docker() {
+    echo -e "${GREEN}Checking Docker and Docker Compose...${NC}"
+    if ! command -v docker &> /dev/null; then
+        echo -e "${CROSS} Docker not found. Please install Docker.${NC}"
+        exit 1
+    fi
+    echo -e "${CHECKMARK} Docker check passed."
+
+    if ! command -v docker-compose &> /dev/null; then
+        echo -e "${CROSS} Docker Compose not found. Please install Docker Compose.${NC}"
+        exit 1
+    fi
+    echo -e "${CHECKMARK} Docker Compose check passed."
+}
+
+# Check CPU and RAM for each Kubernetes node
+check_kubernetes_node_requirements() {
+    echo -e "${GREEN}Checking CPU and RAM for each Kubernetes node...${NC}"
+    MIN_CPU=4
+    MIN_RAM=8
+
+    # Get the number of nodes in the Kubernetes cluster
+    NODE_COUNT=$(kubectl get nodes --no-headers | wc -l)
+    if [[ $NODE_COUNT -lt 3 ]]; then
+        echo -e "${CROSS} Insufficient number of Kubernetes nodes. Minimum requirement: 3 nodes.${NC}"
+        exit 1
+    fi
+    echo -e "${CHECKMARK} Kubernetes nodes check passed."
+
+    # Check CPU and RAM for each node
+    NODES=$(kubectl get nodes --no-headers | awk '{print $1}')
+    while IFS= read -r node; do
+        CPU=$(kubectl describe node "$node" | grep "cpu: " | awk '{print $2}')
+        RAM=$(kubectl describe node "$node" | grep "memory: " | awk '{print $2}')
+
+        if [[ $CPU -lt $MIN_CPU || $RAM -lt $MIN_RAM ]]; then
+            echo -e "${CROSS} Insufficient CPU or RAM for Kubernetes node: $node. Minimum requirement: $MIN_CPU cores, $MIN_RAM GB RAM.${NC}"
+            exit 1
+        fi
+
+        echo -e "${CHECKMARK} CPU and RAM check passed for Kubernetes node: $node."
+    done <<< "$NODES"
+}
+
+# Check Kubernetes, Helm, and the cluster
+check_kubernetes() {
+    echo -e "${GREEN}Checking Kubernetes, Helm, and the cluster...${NC}"
+    if ! command -v kubectl &> /dev/null; then
+        echo -e "${CROSS} kubectl not found. Please install kubectl.${NC}"
+        exit 1
+    fi
+    echo -e "${CHECKMARK} kubectl check passed."
+
+    if ! command -v helm &> /dev/null; then
+        echo -e "${CROSS} Helm not found. Please install Helm.${NC}"
+        exit 1
+    fi
+    echo -e "${CHECKMARK} Helm check passed."
+
+    # Check cluster connectivity or any other cluster-specific checks
+    # Add your custom checks here
+
+    # Check CPU and RAM for each Kubernetes node
+    check_kubernetes_node_requirements
+}
+
+# Perform preflight checks based on the deployment option
+preflight_checks() {
+    case $DEPLOYMENT in
+        docker)
+        check_docker_requirements
+        check_docker
+        ;;
+        kubernetes)
+        check_kubernetes
+        ;;
+        *)
+        echo -e "${RED}Invalid deployment option. Please specify 'docker' or 'kubernetes'.${NC}"
+        exit 1
+        ;;
+    esac
+}
+
+# Deploy using Docker Compose
+docker_deployment() {
+    echo -e "${GREEN}Performing Docker deployment with image tag: $IMAGE_TAG${NC}"
+    docker-compose -f deployment-scripts/docker-compose.yml up -d
+}
+
+# Deploy using Kubernetes and Helm
+kubernetes_deployment() {
+    echo -e "${GREEN}Performing Kubernetes deployment with image tag: $IMAGE_TAG${NC}"
+    # Execute helm chart apply or any other necessary commands
+}
+
+# Main script flow
+preflight_checks
+
+case $DEPLOYMENT in
+    docker)
+    docker_deployment
+    ;;
+    kubernetes)
+    kubernetes_deployment
+    ;;
+    *)
+    # This should not happen since we check the option earlier, but adding for completeness
+    echo -e "${RED}Invalid deployment option. Please specify 'docker' or 'kubernetes'.${NC}"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
This commits adds the `install.sh` script. That performs pre-flight checks for console installation, like CPU, memory, number of nodes.

Accepts two flags:
-d, --deployment: `docker` or `kubernetes` [Required]
-t, --image-tag: `2.0.0`
-n, --no-prompt

By default picks up image tag from env variable `DF_IMG_TAG`, falls back to default version  provided in script `2.0.0` these ways can be overridden by simply passing the `-t` flag e.g. `-t 2.0.1` 


### Screenshots

![image](https://github.com/deepfence/ThreatMapper/assets/18168330/6cf0ca8f-ba28-4b24-82d7-a499dd14fca8)
![image](https://github.com/deepfence/ThreatMapper/assets/18168330/5b533daf-d91d-4579-a8f7-9eff682d9831)


@deepfence/engineering
