### PR TITLE
v2-ui- 1771 Sort all scan result tables

### DIFF
--- a/deepfence_frontend/apps/dashboard/src/features/malwares/pages/MalwareScanResults.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/malwares/pages/MalwareScanResults.tsx
@@ -185,7 +185,10 @@ async function getScans(
   }
   const severity = getSeveritySearch(searchParams);
   const page = getPageFromSearchParams(searchParams);
-  const order = getOrderFromSearchParams(searchParams);
+  const order = getOrderFromSearchParams(searchParams) || {
+    sortBy: 'file_severity',
+    descending: true,
+  };
   const rules = getRulesSearch(searchParams);
   const classes = getClassesSearch(searchParams);
 

--- a/deepfence_frontend/apps/dashboard/src/features/postures/pages/PostureCloudScanResults.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/postures/pages/PostureCloudScanResults.tsx
@@ -207,7 +207,10 @@ async function getScans(
   }
   const status = getStatusSearch(searchParams);
   const page = getPageFromSearchParams(searchParams);
-  const order = getOrderFromSearchParams(searchParams);
+  const order = getOrderFromSearchParams(searchParams) || {
+    sortBy: 'status',
+    descending: true,
+  };
   const mask = getMaskSearch(searchParams);
   const unmask = getUnmaskSearch(searchParams);
   const benchmarkTypes = getBenchmarkType(searchParams);

--- a/deepfence_frontend/apps/dashboard/src/features/postures/pages/PostureScanResults.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/postures/pages/PostureScanResults.tsx
@@ -202,7 +202,10 @@ async function getScans(
 
   const status = getStatusSearch(searchParams);
   const page = getPageFromSearchParams(searchParams);
-  const order = getOrderFromSearchParams(searchParams);
+  const order = getOrderFromSearchParams(searchParams) || {
+    sortBy: 'status',
+    descending: true,
+  };
   const mask = getMaskSearch(searchParams);
   const unmask = getUnmaskSearch(searchParams);
   const benchmarkTypes = getBenchmarkType(searchParams);

--- a/deepfence_frontend/apps/dashboard/src/features/secrets/pages/SecretScanResults.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/secrets/pages/SecretScanResults.tsx
@@ -181,7 +181,10 @@ async function getScans(
   const severity = getSeveritySearch(searchParams);
   const page = getPageFromSearchParams(searchParams);
   const rules = getRulesSearch(searchParams);
-  const order = getOrderFromSearchParams(searchParams);
+  const order = getOrderFromSearchParams(searchParams) || {
+    sortBy: 'level',
+    descending: true,
+  };
 
   const mask = getMaskSearch(searchParams);
   const unmask = getUnmaskSearch(searchParams);

--- a/deepfence_frontend/apps/dashboard/src/features/vulnerabilities/pages/VulnerabilityScanResults.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/vulnerabilities/pages/VulnerabilityScanResults.tsx
@@ -178,7 +178,10 @@ async function getScans(
   // fetch vulnerability scan result
   const severity = getSeveritySearch(searchParams);
   const page = getPageFromSearchParams(searchParams);
-  const order = getOrderFromSearchParams(searchParams);
+  const order = getOrderFromSearchParams(searchParams) || {
+    sortBy: 'cve_severity',
+    descending: true,
+  };
 
   const mask = getMaskSearch(searchParams);
   const unmask = getUnmaskSearch(searchParams);


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- Sort all scan result tables by keeping default sorting 

@deepfence/engineering
