### PR TITLE
replace images id by registry id for start scan for multiple images

### DIFF
--- a/deepfence_frontend/apps/dashboard/src/features/registries/components/RegistryImagesTable.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/registries/components/RegistryImagesTable.tsx
@@ -145,7 +145,7 @@ export const RegistryImagesTable = ({
         onOpenChange={() => setSelectedScanType(undefined)}
         scanOptions={
           selectedScanType
-            ? getScanOptions(selectedScanType, selectedIds, selectedIds)
+            ? getScanOptions(selectedScanType, [nodeId], selectedIds)
             : undefined
         }
       />


### PR DESCRIPTION
Fixes https://github.com/deepfence/ThreatMapper/issues/1113#issuecomment-1571522204

