### PR TITLE
Fix 400 error in gcr registry add

### DIFF
--- a/deepfence_server/handler/container_registry.go
+++ b/deepfence_server/handler/container_registry.go
@@ -341,7 +341,7 @@ func (h *Handler) AddGoogleContainerRegistry(w http.ResponseWriter, r *http.Requ
 	req := model.RegistryAddReq{
 		Name:         registryName,
 		NonSecret:    map[string]interface{}{"registry_url": registryURL, "project_id": sa.ProjectID},
-		Secret:       map[string]interface{}{"project_id_secret": sa.ProjectID, "private_key_id": sa.PrivateKeyID},
+		Secret:       map[string]interface{}{"private_key_id": sa.PrivateKeyID},
 		Extras:       map[string]interface{}{"service_account_json": string(fileBytes)},
 		RegistryType: constants.GCR,
 	}

--- a/deepfence_server/pkg/registry/gcr/gcr.go
+++ b/deepfence_server/pkg/registry/gcr/gcr.go
@@ -57,14 +57,12 @@ func (d *RegistryGCR) IsValidCredential() bool {
 
 func (d *RegistryGCR) EncryptSecret(aes encryption.AES) error {
 	var err error
-	d.Secret.ProjectId, err = aes.Encrypt(d.Secret.ProjectId)
 	d.Secret.PrivateKeyId, err = aes.Encrypt(d.Secret.PrivateKeyId)
 	return err
 }
 
 func (d *RegistryGCR) DecryptSecret(aes encryption.AES) error {
 	var err error
-	d.Secret.ProjectId, err = aes.Decrypt(d.Secret.ProjectId)
 	d.Secret.PrivateKeyId, err = aes.Decrypt(d.Secret.PrivateKeyId)
 	return err
 }

--- a/deepfence_server/pkg/registry/gcr/types.go
+++ b/deepfence_server/pkg/registry/gcr/types.go
@@ -14,7 +14,6 @@ type NonSecret struct {
 }
 
 type Secret struct {
-	ProjectId    string `json:"project_id" validate:"required,min=2,max=64"`
 	PrivateKeyId string `json:"private_key_id" validate:"required"`
 }
 

--- a/deepfence_server/pkg/registry/registry.go
+++ b/deepfence_server/pkg/registry/registry.go
@@ -124,7 +124,6 @@ func GetRegistryWithRegistryRow(row postgresql_db.GetContainerRegistriesRow) (Re
 				ProjectId:   nonSecret["project_id"],
 			},
 			Secret: gcr.Secret{
-				ProjectId:    secret["project_id"],
 				PrivateKeyId: secret["private_key_id"],
 			},
 			Extras: gcr.Extras{

--- a/install.sh
+++ b/install.sh
@@ -31,6 +31,10 @@ while [[ $# -gt 0 ]]; do
         shift
         shift
         ;;
+        -n|--no-prompt)
+        NO_PROMPT=true
+        shift
+        ;;
         -h|--help)
         echo "Usage: $0 [OPTIONS]"
         echo "Options:"


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix 400 error while adding registry in GCR (remove `project_id` from secret field)
- Add no-prompt flag in install script to install with default parameter w/o prompting user
