### PR TITLE
ISSUE-1788: Fixing the race condition and handle AlreadyExists error

### DIFF
--- a/deepfence_server/controls/agent.go
+++ b/deepfence_server/controls/agent.go
@@ -273,7 +273,7 @@ func ExtractStartingAgentScans(ctx context.Context, nodeId string, max_work int)
 		WHERE s.status = '`+utils.SCAN_STATUS_STARTING+`'
 		AND s.retries < 3
 		WITH s LIMIT $max_work
-		SET s.status = '`+utils.SCAN_STATUS_INPROGRESS+`'
+		SET s.status = '`+utils.SCAN_STATUS_INPROGRESS+`', s.updated_at = TIMESTAMP()
 		WITH s
 		RETURN s.trigger_action`,
 		map[string]interface{}{"id": nodeId, "max_work": max_work})

--- a/deepfence_worker/tasks/sbom/generate_sbom.go
+++ b/deepfence_worker/tasks/sbom/generate_sbom.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/ThreeDotsLabs/watermill"
 	"github.com/ThreeDotsLabs/watermill/message"
@@ -133,18 +134,49 @@ func (s SbomGenerator) GenerateSbom(msg *message.Message) ([]*message.Message, e
 	mc, err := directory.MinioClient(ctx)
 	if err != nil {
 		log.Error().Msg(err.Error())
-		SendScanStatus(s.ingestC, NewSbomScanStatus(params, utils.SCAN_STATUS_FAILED, err.Error(), nil), rh)
+		SendScanStatus(s.ingestC,
+			NewSbomScanStatus(params, utils.SCAN_STATUS_FAILED, err.Error(), nil), rh)
 		return nil, nil
 	}
 
 	sbomFile := path.Join("/sbom/", utils.ScanIdReplacer.Replace(params.ScanId)+".json.gz")
 	info, err := mc.UploadFile(ctx, sbomFile, gzpb64Sbom.Bytes(),
 		minio.PutObjectOptions{ContentType: "application/gzip"})
+
 	if err != nil {
-		log.Error().Msg(err.Error())
-		SendScanStatus(s.ingestC, NewSbomScanStatus(params, utils.SCAN_STATUS_FAILED, err.Error(), nil), rh)
-		return nil, nil
+		logError := true
+		if strings.Contains(err.Error(), "Already exists here") {
+			/*If the file already exists, we will delete the old file and upload the new one
+			File can exists in 2 conditions:
+			- When the earlier scan was stuck during the scan phase
+			- When the service was restarted
+			- Bug/Race conditon in the worker service
+			*/
+			log.Warn().Msg(err.Error() + ", Will try to overwrite the file: " + sbomFile)
+			err = mc.DeleteFile(ctx, sbomFile, true, minio.RemoveObjectOptions{ForceDelete: true})
+			if err == nil {
+				info, err = mc.UploadFile(ctx, sbomFile, gzpb64Sbom.Bytes(),
+					minio.PutObjectOptions{ContentType: "application/gzip"})
+
+				if err == nil {
+					log.Info().Msgf("Successfully overwritten the file: %s", sbomFile)
+					logError = false
+				} else {
+					log.Error().Msgf("Failed to upload the file, error is: %v", err)
+				}
+			} else {
+				log.Error().Msgf("Failed to delete the old file, error is: %v", err)
+			}
+		}
+
+		if logError == true {
+			log.Error().Msg(err.Error())
+			SendScanStatus(s.ingestC,
+				NewSbomScanStatus(params, utils.SCAN_STATUS_FAILED, err.Error(), nil), rh)
+			return nil, nil
+		}
 	}
+
 	log.Info().Msgf("sbom file uploaded %+v", info)
 
 	// write sbom to minio and return details another task will scan sbom


### PR DESCRIPTION
Fixes #
https://github.com/deepfence/enterprise-roadmap/issues/1788

Changes proposed in this pull request:
- Fix the race condition between the Retry cronjob and console cronjob.
- Handle the file upload error when the file already exists.
