### PR TITLE
(v2) Fix imagestub to fix edge cases

### DIFF
--- a/deepfence_server/ingesters/agent.go
+++ b/deepfence_server/ingesters/agent.go
@@ -679,9 +679,10 @@ func (nc *neo4jIngester) PushToDBSeq(batches ReportIngestionData, session neo4j.
 	if _, err := tx.Run(`
 		UNWIND $batch as row
 		MERGE (n:ContainerImage{node_id:row.node_id})
-		MERGE (s:ImageStub{node_id: row.docker_image_name})
+		MERGE (s:ImageStub{node_id: row.docker_image_name, docker_image_name: row.docker_image_name})
 		MERGE (n) -[:IS]-> (s)
-		SET n+= row, n.updated_at = TIMESTAMP(), n.active = true, s.updated_at = TIMESTAMP(), n.docker_image_id=row.node_id`,
+		SET n+= row, n.updated_at = TIMESTAMP(), n.active = true, s.updated_at = TIMESTAMP(), n.docker_image_id=row.node_id
+		s.tags = REDUCE(distinctElements = [], element IN COALESCE(s.tags, []) + row.docker_image_tag | CASE WHEN NOT element in distinctElements THEN distinctElements + element ELSE distinctElements END)`,
 		map[string]interface{}{"batch": batches.Container_image_batch}); err != nil {
 		return err
 	}

--- a/deepfence_server/pkg/registry/acr/client.go
+++ b/deepfence_server/pkg/registry/acr/client.go
@@ -176,10 +176,11 @@ func getImageWithTags(url, namespace, userName, password, repoName string, repoT
 		details := getImageDetails(tag, manifests)
 		if details != nil {
 			tt := model.IngestedContainerImage{
-				ID:   model.DigestToID(details.Digest),
-				Name: repoName,
-				Tag:  tag,
-				Size: fmt.Sprint(details.ImageSize),
+				ID:            model.DigestToID(details.Digest),
+				DockerImageID: model.DigestToID(details.Digest),
+				Name:          repoName,
+				Tag:           tag,
+				Size:          fmt.Sprint(details.ImageSize),
 				Metadata: model.Metadata{
 					"created_time": details.CreatedTime.Unix(),
 					"digest":       details.Digest,

--- a/deepfence_server/pkg/registry/gcr/client.go
+++ b/deepfence_server/pkg/registry/gcr/client.go
@@ -177,9 +177,9 @@ func getImageWithTags(url, namespace, userName, password, repoName string, repoT
 			Tag:           tag,
 			Size:          fmt.Sprint(details.ImageSizeBytes),
 			Metadata: model.Metadata{
-				"timeCreatedMs":  details.TimeCreatedMs,
-				"digest":         *digest,
-				"timeUploadedMs": details.TimeUploadedMs,
+				"timeCreatedMs": details.TimeCreatedMs,
+				"digest":        *digest,
+				"last_updated":  details.TimeUploadedMs,
 			},
 		}
 		imageAndTag = append(imageAndTag, tt)

--- a/deepfence_server/pkg/registrysync/sync.go
+++ b/deepfence_server/pkg/registrysync/sync.go
@@ -100,10 +100,11 @@ func insertToNeo4j(ctx context.Context, images []model.IngestedContainerImage, r
 	_, err = tx.Run(`
 		UNWIND $batch as row
 		MERGE (n:ContainerImage{node_id:row.node_id})
-		MERGE (s:ImageStub{node_id: row.docker_image_name})
+		MERGE (s:ImageStub{node_id: row.docker_image_name, docker_image_name: row.docker_image_name})
 		MERGE (n) -[:IS]-> (s)
 		MERGE (m:RegistryAccount{node_id:$node_id})
 		MERGE (m) -[:HOSTS]-> (n)
+		MERGE (m) -[:HOSTS]-> (s)
 		SET n+= row, n.updated_at = TIMESTAMP(),
 		m.container_registry_ids = REDUCE(distinctElements = [], element IN COALESCE(m.container_registry_ids, []) + $pgId | CASE WHEN NOT element in distinctElements THEN distinctElements + element ELSE distinctElements END),
 		n.node_type='container_image',
@@ -111,7 +112,8 @@ func insertToNeo4j(ctx context.Context, images []model.IngestedContainerImage, r
 		n.pseudo=false,
 		n.active=true,
 		n.node_name=n.docker_image_name+":"+n.docker_image_tag,
-		s.updated_at = TIMESTAMP()`,
+		s.updated_at = TIMESTAMP(),
+		s.tags = REDUCE(distinctElements = [], element IN COALESCE(s.tags, []) + row.docker_image_tag | CASE WHEN NOT element in distinctElements THEN distinctElements + element ELSE distinctElements END)`,
 		map[string]interface{}{
 			"batch": imageMap, "node_id": registryId,
 			"pgId": pgId, "registry_type": r.GetRegistryType(),


### PR DESCRIPTION
Registry behave undesirable for following edge cases

- `a:latest` is pushed to `RegistryAccount1`, retagged to `b:latest` and pushed to `RegistryAccount2`
- `a:latest` is retagged to `a:v1` and pushed to `RegistryAccount1`

Above scenario was leading to image duplication in both Registries and missing tags

