### PR TITLE
ISSUE-1822: Optimizing workflow for most exploitable vulnerabilities

### DIFF
--- a/deepfence_worker/cronjobs/threat.go
+++ b/deepfence_worker/cronjobs/threat.go
@@ -49,17 +49,6 @@ func computeThreatExploitability(session neo4j.Session) error {
 	}
 	defer tx.Close()
 
-	// Following cypher queries applies to Vulnerabilities
-	if _, err = tx.Run(`
-		MATCH (v:Vulnerability)
-		WITH v, CASE WHEN v.cve_attack_vector =~ ".*AV:N.*" THEN 2 ELSE CASE WHEN v.cve_severity = 'critical' THEN 1 ELSE 0 END END as score
-		SET v.exploitability_score = score,
-		v.parsed_attack_vector = CASE WHEN score = 2 THEN 'network' ELSE 'local' END,
-		v.has_live_connection = false`,
-		map[string]interface{}{}); err != nil {
-		return err
-	}
-
 	// Following cypher request applies to Images & Containers
 	if _, err = tx.Run(`
 		MATCH (n:Node{node_id:"in-the-internet"}) -[:CONNECTS*1..3]-> (m:Node)

--- a/deepfence_worker/ingesters/vulnerabilites.go
+++ b/deepfence_worker/ingesters/vulnerabilites.go
@@ -37,6 +37,9 @@ type Vulnerability struct {
 	Cve_attack_vector          string   `json:"cve_attack_vector"`
 	URLs                       []string `json:"urls"`
 	ExploitPOC                 string   `json:"exploit_poc"`
+	ParsedAttackVector         string   `json:"parsed_attack_vector"`
+	ExploitabilityScore        int      `json:"exploitability_score"`
+	HasLiveConnection          bool     `json:"has_live_connection"`
 }
 
 func CommitFuncVulnerabilities(ns string, data []Vulnerability) error {


### PR DESCRIPTION
Fixes #
https://github.com/deepfence/enterprise-roadmap/issues/1822

Changes proposed in this pull request:
- Add logic to generate initial data for 'parsed_attack_vector', 'exploitability_score' and 'has_live_connection' after the scan is done. 
- Removed the query from the cronjob to generate the initial data for the fields listed above.
