### PR TITLE
Headless UI components add noPortal option

### DIFF
--- a/deepfence_frontend/packages/ui-components/src/components/select/Combobox.stories.tsx
+++ b/deepfence_frontend/packages/ui-components/src/components/select/Combobox.stories.tsx
@@ -2,6 +2,12 @@ import { Meta, StoryFn } from '@storybook/react';
 import { useState } from 'react';
 
 import { Combobox, ComboboxOption } from '@/components/select/Combobox';
+import {
+  Button,
+  SlidingModal,
+  SlidingModalCloseButton,
+  SlidingModalContent,
+} from '@/main';
 
 export default {
   title: 'Components/Combobox',
@@ -353,5 +359,69 @@ const MultiSelectNonNullableTemplate: StoryFn<typeof Combobox> = () => {
 
 export const MultiSelectNonNullable = {
   render: MultiSelectNonNullableTemplate,
+  args: {},
+};
+
+const MultiSelectNonNullableTemplateInsideDialog: StoryFn<typeof Combobox> = () => {
+  const [selected, setSelected] = useState<typeof OPTIONS>([]);
+  const [options, setOptions] = useState<typeof OPTIONS>([...OPTIONS]);
+  const [loading, setLoading] = useState(false);
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const [query, setQuery] = useState('');
+
+  function fetchMoreData() {
+    // we can use query here as well
+    setLoading(true);
+    setTimeout(() => {
+      setOptions([...options, ...OPTIONS]);
+      setLoading(false);
+    }, 1000);
+  }
+
+  return (
+    <>
+      <Button onClick={() => setDialogOpen(true)}>Open Modal</Button>
+      <SlidingModal open={dialogOpen} onOpenChange={setDialogOpen}>
+        <SlidingModalCloseButton />
+        <SlidingModalContent>
+          <div className="p-2">
+            <Combobox
+              value={selected}
+              onQueryChange={(query) => {
+                setQuery(query);
+              }}
+              label="Select your value"
+              clearAllElement="Clear filters"
+              onChange={(value) => {
+                setSelected(value);
+              }}
+              multiple
+              getDisplayValue={() => {
+                return 'PropertyName';
+              }}
+              onEndReached={() => {
+                fetchMoreData();
+              }}
+              loading={loading}
+              noPortal
+            >
+              {options.map((person, index) => {
+                return (
+                  <ComboboxOption key={`${person.id}-${index}`} value={person}>
+                    {person.name}
+                  </ComboboxOption>
+                );
+              })}
+            </Combobox>
+          </div>
+        </SlidingModalContent>
+      </SlidingModal>
+    </>
+  );
+};
+
+export const MultiSelectNonNullableInsideDialog = {
+  render: MultiSelectNonNullableTemplateInsideDialog,
   args: {},
 };

--- a/deepfence_frontend/packages/ui-components/src/components/select/Combobox.tsx
+++ b/deepfence_frontend/packages/ui-components/src/components/select/Combobox.tsx
@@ -98,6 +98,9 @@ type ComboboxProps<
   loading?: boolean;
   getDisplayValue?: (item: TValue) => string | null;
   onQueryChange: (query: string) => void;
+  // radix dialog doesn't play well with focusable stuff outside of its own portal
+  // so not using portal kind of fixes it.
+  noPortal?: boolean;
 };
 
 let DEFAULT_COMBOBOX_TAG: React.ExoticComponent<{
@@ -134,6 +137,7 @@ export function Combobox<TValue, TTag extends ElementType = typeof DEFAULT_COMBO
   placeholder,
   helperText,
   color = 'default',
+  noPortal = false,
   ...props
 }: ComboboxProps<TValue, boolean | undefined, boolean | undefined, TTag>) {
   const intersectionRef = useRef<RefObject<HTMLElement> | null>(null);
@@ -293,7 +297,7 @@ export function Combobox<TValue, TTag extends ElementType = typeof DEFAULT_COMBO
                   )}
                 </>
               )}
-              <Portal>
+              <ContentWrapper noPortal={noPortal}>
                 <Transition
                   className="pointer-events-auto"
                   as={'div'}
@@ -385,7 +389,7 @@ export function Combobox<TValue, TTag extends ElementType = typeof DEFAULT_COMBO
                     ) : null}
                   </div>
                 </Transition>
-              </Portal>
+              </ContentWrapper>
             </div>
           );
         }}
@@ -437,6 +441,19 @@ function Portal(props: { children: ReactNode }) {
   if (!mounted) return null;
   return createPortal(children, document.body);
 }
+
+const ContentWrapper = ({
+  noPortal,
+  children,
+}: {
+  noPortal: boolean;
+  children: ReactNode;
+}) => {
+  if (noPortal) {
+    return <div>{children}</div>;
+  }
+  return <Portal>{children}</Portal>;
+};
 
 const CaretDownIcon = () => {
   return (

--- a/deepfence_frontend/packages/ui-components/src/components/select/Listbox.tsx
+++ b/deepfence_frontend/packages/ui-components/src/components/select/Listbox.tsx
@@ -150,6 +150,7 @@ interface ListboxProps<TType, TActualType>
   required?: boolean;
   id?: string;
   helperText?: string;
+  noPortal?: boolean;
 }
 export function Listbox<TType, TActualType>({
   color,
@@ -166,6 +167,7 @@ export function Listbox<TType, TActualType>({
   helperText,
   disabled,
   multiple,
+  noPortal = false,
   ...props
 }: ListboxProps<TType, TActualType>) {
   const internalId = useId();
@@ -248,7 +250,7 @@ export function Listbox<TType, TActualType>({
               <HelperText color={color} text={helperText} />
             </div>
           )}
-          <Portal>
+          <ContentWrapper noPortal={noPortal}>
             <Transition
               className="pointer-events-auto"
               as={'div'}
@@ -308,7 +310,7 @@ export function Listbox<TType, TActualType>({
                 </>
               ) : null}
             </Transition>
-          </Portal>
+          </ContentWrapper>
         </div>
       </HUIListbox>
     </ListboxContext.Provider>
@@ -377,3 +379,16 @@ function Portal(props: { children: ReactNode }) {
   if (!mounted) return null;
   return createPortal(children, document.body);
 }
+
+const ContentWrapper = ({
+  noPortal,
+  children,
+}: {
+  noPortal: boolean;
+  children: ReactNode;
+}) => {
+  if (noPortal) {
+    return <div>{children}</div>;
+  }
+  return <Portal>{children}</Portal>;
+};


### PR DESCRIPTION
- adds noPortal option for listbox and combobox components since radix ui dialog doesn't play well with focusable elements outside its own portal.