### PR TITLE
(v2) donot allow email integration if not configured

### DIFF
--- a/deepfence_server/pkg/integration/aws-security-hub/awssecurityhub.go
+++ b/deepfence_server/pkg/integration/aws-security-hub/awssecurityhub.go
@@ -39,7 +39,7 @@ var compStatusAsff = map[string]string{
 	"warn":  "WARNING",
 }
 
-func New(b []byte) (*AwsSecurityHub, error) {
+func New(ctx context.Context, b []byte) (*AwsSecurityHub, error) {
 	s := AwsSecurityHub{}
 	err := json.Unmarshal(b, &s)
 	if err != nil {

--- a/deepfence_server/pkg/integration/elasticsearch/elasticsearch.go
+++ b/deepfence_server/pkg/integration/elasticsearch/elasticsearch.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 )
 
-func New(b []byte) (*ElasticSearch, error) {
+func New(ctx context.Context, b []byte) (*ElasticSearch, error) {
 	p := ElasticSearch{}
 	err := json.Unmarshal(b, &p)
 	if err != nil {

--- a/deepfence_server/pkg/integration/google-chronicle/googlechronicle.go
+++ b/deepfence_server/pkg/integration/google-chronicle/googlechronicle.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 )
 
-func New(b []byte) (*GoogleChronicle, error) {
+func New(ctx context.Context, b []byte) (*GoogleChronicle, error) {
 	p := GoogleChronicle{}
 	err := json.Unmarshal(b, &p)
 	if err != nil {

--- a/deepfence_server/pkg/integration/http-endpoint/http-endpoint.go
+++ b/deepfence_server/pkg/integration/http-endpoint/http-endpoint.go
@@ -10,7 +10,7 @@ import (
 // todo: add support for batch size
 const BatchSize = 100
 
-func New(b []byte) (*HTTPEndpoint, error) {
+func New(ctx context.Context, b []byte) (*HTTPEndpoint, error) {
 	h := HTTPEndpoint{}
 	err := json.Unmarshal(b, &h)
 	if err != nil {

--- a/deepfence_server/pkg/integration/integration.go
+++ b/deepfence_server/pkg/integration/integration.go
@@ -24,32 +24,32 @@ import (
 )
 
 // GetIntegration returns an integration object based on the integration type
-func GetIntegration(integrationType string, b []byte) (Integration, error) {
+func GetIntegration(ctx context.Context, integrationType string, b []byte) (Integration, error) {
 	switch integrationType {
 	case constants.Slack:
-		return slack.New(b)
+		return slack.New(ctx, b)
 	case constants.HTTP:
-		return httpendpoint.New(b)
+		return httpendpoint.New(ctx, b)
 	case constants.Teams:
-		return teams.New(b)
+		return teams.New(ctx, b)
 	case constants.PagerDuty:
-		return pagerduty.New(b)
+		return pagerduty.New(ctx, b)
 	case constants.S3:
-		return s3.New(b)
+		return s3.New(ctx, b)
 	case constants.Splunk:
-		return splunk.New(b)
+		return splunk.New(ctx, b)
 	case constants.ElasticSearch:
-		return elasticsearch.New(b)
+		return elasticsearch.New(ctx, b)
 	case constants.GoogleChronicle:
-		return googlechronicle.New(b)
+		return googlechronicle.New(ctx, b)
 	case constants.AwsSecurityHub:
-		return awssecurityhub.New(b)
+		return awssecurityhub.New(ctx, b)
 	case constants.Email:
-		return email.New(b)
+		return email.New(ctx, b)
 	case constants.Jira:
-		return jira.New(b)
+		return jira.New(ctx, b)
 	case constants.SumoLogic:
-		return sumologic.New(b)
+		return sumologic.New(ctx, b)
 	default:
 		return nil, errors.New("invalid integration type")
 	}

--- a/deepfence_server/pkg/integration/jira/jira.go
+++ b/deepfence_server/pkg/integration/jira/jira.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 )
 
-func New(b []byte) (*Jira, error) {
+func New(ctx context.Context, b []byte) (*Jira, error) {
 	h := Jira{}
 	err := json.Unmarshal(b, &h)
 	if err != nil {

--- a/deepfence_server/pkg/integration/pagerduty/pagerduty.go
+++ b/deepfence_server/pkg/integration/pagerduty/pagerduty.go
@@ -25,7 +25,7 @@ var pagerdutySeverityMapping = map[string]string{
 	"info":     "info",
 }
 
-func New(b []byte) (*PagerDuty, error) {
+func New(ctx context.Context, b []byte) (*PagerDuty, error) {
 	p := PagerDuty{}
 	err := json.Unmarshal(b, &p)
 	if err != nil {

--- a/deepfence_server/pkg/integration/s3/s3.go
+++ b/deepfence_server/pkg/integration/s3/s3.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
-func New(b []byte) (*S3, error) {
+func New(ctx context.Context, b []byte) (*S3, error) {
 	s := S3{}
 	err := json.Unmarshal(b, &s)
 	if err != nil {

--- a/deepfence_server/pkg/integration/slack/slack.go
+++ b/deepfence_server/pkg/integration/slack/slack.go
@@ -11,7 +11,7 @@ import (
 // todo: add support for batch size
 const BatchSize = 100
 
-func New(b []byte) (*Slack, error) {
+func New(ctx context.Context, b []byte) (*Slack, error) {
 	s := Slack{}
 	err := json.Unmarshal(b, &s)
 	if err != nil {

--- a/deepfence_server/pkg/integration/splunk/splunk.go
+++ b/deepfence_server/pkg/integration/splunk/splunk.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-func New(b []byte) (Splunk, error) {
+func New(ctx context.Context, b []byte) (Splunk, error) {
 	var s Splunk
 	err := json.Unmarshal(b, &s.Config)
 	if err != nil {

--- a/deepfence_server/pkg/integration/sumologic/sumologic.go
+++ b/deepfence_server/pkg/integration/sumologic/sumologic.go
@@ -11,7 +11,7 @@ import (
 	"github.com/deepfence/ThreatMapper/deepfence_utils/log"
 )
 
-func New(b []byte) (SumoLogic, error) {
+func New(ctx context.Context, b []byte) (SumoLogic, error) {
 	var s SumoLogic
 	err := json.Unmarshal(b, &s)
 	if err != nil {

--- a/deepfence_server/pkg/integration/teams/teams.go
+++ b/deepfence_server/pkg/integration/teams/teams.go
@@ -11,7 +11,7 @@ import (
 // todo: add support for batch size
 const BatchSize = 100
 
-func New(b []byte) (*Teams, error) {
+func New(ctx context.Context, b []byte) (*Teams, error) {
 	t := Teams{}
 	err := json.Unmarshal(b, &t)
 	if err != nil {

--- a/deepfence_worker/cronjobs/notification.go
+++ b/deepfence_worker/cronjobs/notification.go
@@ -82,7 +82,7 @@ func processIntegration[T any](msg *message.Message, integrationRow postgresql_d
 			log.Error().Msgf("Error Processing for integration json marshall integrationRow: %+v", integrationRow, err)
 			return err
 		}
-		integrationModel, err := integration.GetIntegration(integrationRow.IntegrationType, iByte)
+		integrationModel, err := integration.GetIntegration(ctx, integrationRow.IntegrationType, iByte)
 		if err != nil {
 			log.Error().Msgf("Error Processing for integration GetIntegration: %+v", integrationRow, err)
 			return err


### PR DESCRIPTION
- refactor integration to accept `context` in `New()`
- donot allow user to add email in integration if email os not configured
