### PR TITLE
add ingetser metrics to track number of records inserted

### DIFF
--- a/deepfence_worker/processors/bulk_processor.go
+++ b/deepfence_worker/processors/bulk_processor.go
@@ -271,6 +271,12 @@ func (w *bulkWorker) commit(ctx context.Context) []error {
 			break
 		}
 	}
+	// metrics
+	if len(errs) > 0 {
+		commitNeo4jRecordsCounts.WithLabelValues(w.worker_id, "error").Add(float64(w.buffer.size))
+	} else {
+		commitNeo4jRecordsCounts.WithLabelValues(w.worker_id, "success").Add(float64(w.buffer.size))
+	}
 	// reset buffer after commit
 	w.buffer.Reset()
 	return errs

--- a/deepfence_worker/processors/metrics.go
+++ b/deepfence_worker/processors/metrics.go
@@ -13,70 +13,14 @@ import (
 )
 
 var (
-	publishElasticSearch = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "publish_es_total",
-		Help: "Total number of records sent successfully to elasticsearch",
-	}, []string{"status"})
+	commitNeo4jRecordsCounts = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "neo4j_commit_records_total",
+		Help: "Total number of records committed to neo4j",
+	}, []string{"worker", "status"})
 	topicLag = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "consumer_group_lag",
 		Help: "Consumer group lag per topic",
 	}, []string{"topic"})
-	vulnerabilitiesMasked = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "cve_masked_total",
-		Help: "Total number of cve records masked",
-	})
-	vulnerabilitiesProcessed = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "cve_scan_total",
-		Help: "Total number of cve records processed",
-	})
-	vulnerabilityLogsProcessed = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "cve_scan_logs_total",
-		Help: "Total number of cve log records processed",
-	})
-	secretProcessed = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "secret_scan_total",
-		Help: "Total number of secret scan records processed",
-	})
-	secretLogsProcessed = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "secret_scan_logs_total",
-		Help: "Total number of secret scan log records processed",
-	})
-	malwareProcessed = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "malware_scan_total",
-		Help: "Total number of malware scan records processed",
-	})
-	malwareLogsProcessed = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "malware_scan_logs_total",
-		Help: "Total number of malware scan log records processed",
-	})
-	sbomArtifactsProcessed = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "sbom_artifacts_total",
-		Help: "Total number of sbom artifacts processed",
-	})
-	sbomCveProcessed = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "sbom_cve_total",
-		Help: "Total number of sbom cve records processed",
-	})
-	cloudComplianceProcessed = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "cloud_compliance_scan_total",
-		Help: "Total number of cloud compliance scan records processed",
-	})
-	cloudComplianceLogsProcessed = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "cloud_compliance_scan_logs_total",
-		Help: "Total number of cloud compliance scan log records processed",
-	})
-	complianceProcessed = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "compliance_scan_total",
-		Help: "Total number of compliance scan records processed",
-	})
-	complianceLogsProcessed = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "compliance_scan_logs_total",
-		Help: "Total number of compliance scan log records processed",
-	})
-	cloudTrailAlertsProcessed = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "cloud_trail_alerts_total",
-		Help: "Total number of cloud trail alert records processed",
-	})
 )
 
 func StartGetLagByTopic(ctx context.Context, kafkaBrokers []string, groupID string, kgoLogger kgo.Logger) error {


### PR DESCRIPTION
Changes proposed in this pull request:
- add ingetser metrics to track number of records inserted

sample metrics:
```
$ curl localhost:8181/metrics
# HELP consumer_group_lag Consumer group lag per topic
# TYPE consumer_group_lag gauge
consumer_group_lag{topic="audit-logs"} 0
consumer_group_lag{topic="cloud-compliance-scan"} 0
consumer_group_lag{topic="cloud-compliance-scan-status"} 0
consumer_group_lag{topic="cloud-resource"} 0
consumer_group_lag{topic="cloudtrail-alert"} 0
consumer_group_lag{topic="compliance-scan"} 0
consumer_group_lag{topic="compliance-scan-status"} 0
consumer_group_lag{topic="malware-scan"} 0
consumer_group_lag{topic="malware-scan-status"} 0
consumer_group_lag{topic="sbom-artifact"} 0
consumer_group_lag{topic="sbom-cve-scan"} 0
consumer_group_lag{topic="secret-scan"} 0
consumer_group_lag{topic="secret-scan-status"} 0
consumer_group_lag{topic="vulnerability-scan"} 0
consumer_group_lag{topic="vulnerability-scan-status"} 0
# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
......
# HELP neo4j_commit_records_total Total number of records committed to neo4j
# TYPE neo4j_commit_records_total counter
neo4j_commit_records_total{status="success",worker="malware-scan-status.0"} 11
neo4j_commit_records_total{status="success",worker="malware-scan.0"} 1457
neo4j_commit_records_total{status="success",worker="secret-scan-status.0"} 12
neo4j_commit_records_total{status="success",worker="secret-scan.0"} 99
neo4j_commit_records_total{status="success",worker="vulnerability-scan-status.0"} 43
neo4j_commit_records_total{status="success",worker="vulnerability-scan.0"} 3189
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
......
```
