### PR TITLE
fix: wrong key pass for severity filter, remove separator from dropdown

### DIFF
--- a/deepfence_frontend/apps/dashboard/src/features/malwares/pages/MalwareScanResults.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/malwares/pages/MalwareScanResults.tsx
@@ -638,7 +638,6 @@ const ActionDropdown = ({
             Un-mask malware across hosts and images
           </DropdownItem>
           <DropdownSeparator />
-          <DropdownSeparator />
           <DropdownItem
             onClick={() => {
               setIdsToDelete(ids);

--- a/deepfence_frontend/apps/dashboard/src/features/postures/pages/PostureCloudScanResults.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/postures/pages/PostureCloudScanResults.tsx
@@ -610,12 +610,9 @@ const ActionDropdown = ({
           <DropdownItem onClick={() => onTableAction(ids, ActionEnumType.MASK)}>
             Mask
           </DropdownItem>
-          <DropdownSeparator />
           <DropdownItem onClick={() => onTableAction(ids, ActionEnumType.UNMASK)}>
             Un-mask
           </DropdownItem>
-          <DropdownSeparator />
-          <DropdownSeparator />
           <DropdownItem
             onClick={() => {
               setIdsToDelete(ids);

--- a/deepfence_frontend/apps/dashboard/src/features/postures/pages/PostureScanResults.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/postures/pages/PostureScanResults.tsx
@@ -608,12 +608,9 @@ const ActionDropdown = ({
           <DropdownItem onClick={() => onTableAction(ids, ActionEnumType.MASK)}>
             Mask
           </DropdownItem>
-          <DropdownSeparator />
           <DropdownItem onClick={() => onTableAction(ids, ActionEnumType.UNMASK)}>
             Un-mask
           </DropdownItem>
-          <DropdownSeparator />
-          <DropdownSeparator />
           <DropdownItem
             onClick={() => {
               setIdsToDelete(ids);

--- a/deepfence_frontend/apps/dashboard/src/features/secrets/pages/SecretScanResults.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/secrets/pages/SecretScanResults.tsx
@@ -67,7 +67,7 @@ import { useDownloadScan } from '@/features/common/data-component/downloadScanAc
 import { SecretScanResultsPieChart } from '@/features/secrets/components/scan-results/SecretScanResultsPieChart';
 import { SuccessModalContent } from '@/features/settings/components/SuccessModalContent';
 import { invalidateAllQueries, queries } from '@/queries';
-import { ScanStatusEnum, ScanTypeEnum, SecretSeverityType } from '@/types/common';
+import { ScanTypeEnum, SecretSeverityType } from '@/types/common';
 import { get403Message } from '@/utils/403';
 import { apiWrapper } from '@/utils/api';
 import { formatMilliseconds } from '@/utils/date';
@@ -637,7 +637,6 @@ const ActionDropdown = ({
           >
             Un-mask secret across hosts and images
           </DropdownItem>
-          <DropdownSeparator />
           <DropdownSeparator />
           <DropdownItem
             onClick={() => {

--- a/deepfence_frontend/apps/dashboard/src/features/vulnerabilities/pages/VulnerabilityScanResults.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/vulnerabilities/pages/VulnerabilityScanResults.tsx
@@ -599,7 +599,6 @@ const ActionDropdown = ({
             Un-mask vulnerability across hosts and images
           </DropdownItem>
           <DropdownSeparator />
-          <DropdownSeparator />
           <DropdownItem
             onClick={() => {
               setIdsToDelete(ids);

--- a/deepfence_frontend/apps/dashboard/src/queries/malware.tsx
+++ b/deepfence_frontend/apps/dashboard/src/queries/malware.tsx
@@ -295,7 +295,7 @@ export const malwareQueries = createQueryKeys('malware', {
         };
 
         if (severity.length) {
-          scanResultsReq.fields_filter.contains_filter.filter_in!['cve_severity'] =
+          scanResultsReq.fields_filter.contains_filter.filter_in!['file_severity'] =
             severity;
         }
 

--- a/deepfence_frontend/apps/dashboard/src/queries/secret.tsx
+++ b/deepfence_frontend/apps/dashboard/src/queries/secret.tsx
@@ -293,8 +293,7 @@ export const secretQueries = createQueryKeys('secret', {
         };
 
         if (severity.length) {
-          scanResultsReq.fields_filter.contains_filter.filter_in!['cve_severity'] =
-            severity;
+          scanResultsReq.fields_filter.contains_filter.filter_in!['level'] = severity;
         }
 
         if (rules.length) {


### PR DESCRIPTION
Fixes #
https://github.com/deepfence/enterprise-roadmap/issues/1918
https://github.com/deepfence/enterprise-roadmap/issues/1928

Changes proposed in this pull request:
- fix mask/unmask dropdown
- fix incorrect key for severity filters
