### PR TITLE
ISSUE-1860: Increasing time limits to reduce chances of timeouts

### DIFF
--- a/deepfence_worker/worker.go
+++ b/deepfence_worker/worker.go
@@ -92,6 +92,10 @@ func subscribe(consumerGroup string, brokers []string, logger watermill.LoggerAd
 	subscriberConf := kafka.DefaultSaramaSubscriberConfig()
 	subscriberConf.Consumer.Offsets.AutoCommit.Enable = true
 
+	subscriberConf.Consumer.Group.Session.Timeout = 20 * time.Second
+	subscriberConf.Consumer.Group.Heartbeat.Interval = 6 * time.Second
+	subscriberConf.Consumer.MaxProcessingTime = 500 * time.Millisecond
+
 	sub, err := kafka.NewSubscriber(
 		kafka.SubscriberConfig{
 			Brokers:               brokers,


### PR DESCRIPTION
Fixes #
https://github.com/deepfence/enterprise-roadmap/issues/1860

Changes proposed in this pull request:
- Increasing the time limits (group and heartbeat) for the consumer. This should minimize the chances of timeouts and broker removing the consumer

