### PR TITLE
change secret input type, account to use account number

### DIFF
--- a/deepfence_frontend/apps/dashboard/src/components/forms/SearchableCloudAccountsList.tsx
+++ b/deepfence_frontend/apps/dashboard/src/components/forms/SearchableCloudAccountsList.tsx
@@ -14,6 +14,8 @@ export type SearchableCloudAccountsListProps = {
   active?: boolean;
   triggerVariant?: 'select' | 'button';
   label?: string;
+  helperText?: string;
+  color?: 'error' | 'default';
 };
 
 const PAGE_SIZE = 15;
@@ -26,6 +28,8 @@ const SearchableCloudAccounts = ({
   active,
   triggerVariant,
   label,
+  helperText,
+  color,
 }: SearchableCloudAccountsListProps) => {
   const [searchText, setSearchText] = useState('');
 
@@ -100,6 +104,8 @@ const SearchableCloudAccounts = ({
         clearAllElement="Clear"
         onClearAll={onClearAll}
         onEndReached={onEndReached}
+        helperText={helperText}
+        color={color}
       >
         {data?.pages
           .flatMap((page) => {

--- a/deepfence_frontend/apps/dashboard/src/features/integrations/components/IntegrationForm.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/integrations/components/IntegrationForm.tsx
@@ -542,6 +542,7 @@ export const IntegrationForm = ({
                   placeholder="AWS secret key"
                   helperText={fieldErrors?.aws_secret_key}
                   color={fieldErrors?.aws_secret_key ? 'error' : 'default'}
+                  type="password"
                 />
                 <TextInputType
                   name="region"
@@ -555,12 +556,15 @@ export const IntegrationForm = ({
                   triggerVariant="select"
                   defaultSelectedAccounts={awsAccounts}
                   cloudProvider="aws"
+                  valueKey="nodeName"
                   onClearAll={() => {
                     setAccounts([]);
                   }}
                   onChange={(value) => {
                     setAccounts(value);
                   }}
+                  helperText={fieldErrors?.aws_account_id}
+                  color={fieldErrors?.aws_account_id ? 'error' : 'default'}
                 />
               </>
             )}

--- a/deepfence_frontend/apps/dashboard/src/features/integrations/pages/IntegrationAdd.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/integrations/pages/IntegrationAdd.tsx
@@ -111,7 +111,7 @@ const getConfigBodyNotificationType = (formData: FormData, integrationType: stri
         aws_access_key: formBody.accessKey,
         aws_secret_key: formBody.secretKey,
         aws_region: formBody.region,
-        aws_account_ids: accounts,
+        aws_account_id: accounts,
       };
     }
     case IntegrationType.jira: {


### PR DESCRIPTION
Fixes https://github.com/deepfence/enterprise-roadmap/issues/1929

Changes proposed in this pull request:
- to hide secret key
- display error message for account
-  send account number instead of node id
