### PR TITLE
search hosts that are available for clusters only for pods table

### DIFF
--- a/deepfence_frontend/apps/dashboard/src/components/forms/SearchableHostList.tsx
+++ b/deepfence_frontend/apps/dashboard/src/components/forms/SearchableHostList.tsx
@@ -14,6 +14,7 @@ export type SearchableHostListProps = {
   valueKey?: 'nodeId' | 'hostName' | 'nodeName';
   active?: boolean;
   agentRunning?: boolean;
+  showOnlyKubernetesHosts?: boolean;
   triggerVariant?: 'select' | 'button';
   helperText?: string;
   color?: 'error' | 'default';
@@ -28,6 +29,7 @@ const SearchableHost = ({
   valueKey = 'nodeId',
   active,
   agentRunning = true,
+  showOnlyKubernetesHosts,
   triggerVariant,
   helperText,
   color,
@@ -54,6 +56,7 @@ const SearchableHost = ({
         searchText,
         active,
         agentRunning,
+        showOnlyKubernetesHosts,
         order: {
           sortBy: 'host_name',
           descending: false,

--- a/deepfence_frontend/apps/dashboard/src/features/topology/data-components/tables/PodsTable.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/topology/data-components/tables/PodsTable.tsx
@@ -137,6 +137,7 @@ function Filters() {
         </Combobox>
         <SearchableHostList
           valueKey="hostName"
+          showOnlyKubernetesHosts
           scanType={ScanTypeEnum.VulnerabilityScan}
           defaultSelectedHosts={searchParams.getAll('hosts')}
           onClearAll={() => {

--- a/deepfence_frontend/apps/dashboard/src/queries/search.tsx
+++ b/deepfence_frontend/apps/dashboard/src/queries/search.tsx
@@ -22,6 +22,7 @@ export const searchQueries = createQueryKeys('search', {
     size: number;
     active?: boolean;
     agentRunning?: boolean;
+    showOnlyKubernetesHosts?: boolean;
     order?: {
       sortBy: string;
       descending: boolean;
@@ -38,7 +39,8 @@ export const searchQueries = createQueryKeys('search', {
           nodeName: string;
         }[];
       }> => {
-        const { searchText, size, active, agentRunning, order } = filters;
+        const { searchText, size, active, agentRunning, showOnlyKubernetesHosts, order } =
+          filters;
         const searchSearchNodeReq: SearchSearchNodeReq = {
           node_filter: {
             filters: {
@@ -47,6 +49,9 @@ export const searchQueries = createQueryKeys('search', {
                   pseudo: [false],
                   ...(active && { active: [active === true] }),
                 },
+              },
+              not_contains_filter: {
+                filter_in: {},
               },
               order_filter: {
                 order_fields: [
@@ -87,6 +92,11 @@ export const searchQueries = createQueryKeys('search', {
           searchSearchNodeReq.node_filter.filters.contains_filter.filter_in![
             'agent_running'
           ] = [agentRunning];
+        }
+        if (showOnlyKubernetesHosts) {
+          searchSearchNodeReq.node_filter.filters.not_contains_filter!.filter_in![
+            'kubernetes_cluster_id'
+          ] = [''];
         }
         const searchHostsApi = apiWrapper({
           fn: getSearchApiClient().searchHosts,


### PR DESCRIPTION
Fixes https://github.com/deepfence/enterprise-roadmap/issues/1919

Changes proposed in this pull request:
- search hosts that are available for clusters only for pods table
