### PR TITLE
use aws node type for aws cloud controls

### DIFF
--- a/deepfence_frontend/apps/dashboard/src/components/scan-configure-forms/ComplianceScanConfigureForm.tsx
+++ b/deepfence_frontend/apps/dashboard/src/components/scan-configure-forms/ComplianceScanConfigureForm.tsx
@@ -52,6 +52,11 @@ export type ScanActionReturnType = {
   };
 };
 
+type ControlActionDta = {
+  message?: string;
+  success: boolean;
+};
+
 type TabsType = {
   label: string;
   value: string;
@@ -140,7 +145,7 @@ const toggleControls = ({
   nodeId: string;
   checked: boolean;
   controlIds: string[] | undefined;
-  fetcher: FetcherWithComponents<any>;
+  fetcher: FetcherWithComponents<ControlActionDta>;
   checkType: string;
   nodeType: string;
 }) => {
@@ -188,7 +193,7 @@ const ToggleControl = ({
   nodeId: string;
   nodeType: string;
   checkType: string;
-  fetcher: FetcherWithComponents<any>;
+  fetcher: FetcherWithComponents<ControlActionDta>;
 }) => {
   // TODO: should show loader indicator here
   if (fetcher.state !== 'idle') {
@@ -228,6 +233,8 @@ const ControlTable = ({
         return 'linux';
       case ComplianceScanNodeTypeEnum.kubernetes_cluster:
         return 'kubernetes';
+      case ComplianceScanNodeTypeEnum.aws_org:
+        return ComplianceScanNodeTypeEnum.aws;
       default:
         return nodeType;
     }


### PR DESCRIPTION
Fixes https://github.com/deepfence/enterprise-roadmap/issues/1930

Changes proposed in this pull request:
- send aws as node typ for listing of aws org
