### PR TITLE
(feat): add api to compare vulnerability scan results

### DIFF
--- a/deepfence_server/apiDocs/docs.go
+++ b/deepfence_server/apiDocs/docs.go
@@ -31,6 +31,7 @@ const (
 	tagIntegration       = "Integration"
 	tagReports           = "Reports"
 	tagSettings          = "Settings"
+	tagScanCompare       = "Scan Compare"
 
 	securityName = "bearer_token"
 )

--- a/deepfence_server/apiDocs/docs.go
+++ b/deepfence_server/apiDocs/docs.go
@@ -31,7 +31,7 @@ const (
 	tagIntegration       = "Integration"
 	tagReports           = "Reports"
 	tagSettings          = "Settings"
-	tagScanCompare       = "Scan Compare"
+	tagDiffAdd           = "Diff Add"
 
 	securityName = "bearer_token"
 )

--- a/deepfence_server/apiDocs/operation.go
+++ b/deepfence_server/apiDocs/operation.go
@@ -751,3 +751,9 @@ func (d *OpenApiDocs) AddSettingsOperations() {
 		"Upload Vulnerability Database", "Upload Vulnerability Database for use in vulnerability scans",
 		http.StatusOK, []string{tagSettings}, bearerToken, new(vulnerability_db.DBUploadRequest), new(MessageResponse))
 }
+
+func (d *OpenApiDocs) AddScanCompareOperations() {
+	d.AddOperation("compareScans", http.MethodPost, "/deepfence/scan/results/compare",
+		"Compare Scans", "Compare scans between scan ids for a given scan type",
+		http.StatusOK, []string{tagScanCompare}, bearerToken, new(ScanCompareReq), new(ScanComparison))
+}

--- a/deepfence_server/apiDocs/operation.go
+++ b/deepfence_server/apiDocs/operation.go
@@ -752,8 +752,20 @@ func (d *OpenApiDocs) AddSettingsOperations() {
 		http.StatusOK, []string{tagSettings}, bearerToken, new(vulnerability_db.DBUploadRequest), new(MessageResponse))
 }
 
-func (d *OpenApiDocs) AddScanCompareOperations() {
-	d.AddOperation("compareScans", http.MethodPost, "/deepfence/scan/results/compare",
-		"Compare Scans", "Compare scans between scan ids for a given scan type",
-		http.StatusOK, []string{tagScanCompare}, bearerToken, new(ScanCompareReq), new(ScanComparison))
+func (d *OpenApiDocs) AddDiffAddOperations() {
+	d.AddOperation("addDiffAdd", http.MethodPost, "/deepfence/diff-add/vulnerability",
+		"Get Vulnerability Diff", "Get Vulnerability Diff between two scans",
+		http.StatusOK, []string{tagDiffAdd}, bearerToken, new(ScanCompareReq), new(ScanCompareRes[Vulnerability]))
+	d.AddOperation("addDiffAdd", http.MethodPost, "/deepfence/diff-add/secret",
+		"Get Secret Diff", "Get Secret Diff between two scans",
+		http.StatusOK, []string{tagDiffAdd}, bearerToken, new(ScanCompareReq), new(ScanCompareRes[Secret]))
+	d.AddOperation("addDiffAdd", http.MethodPost, "/deepfence/diff-add/compliance",
+		"Get Compliance Diff", "Get Compliance Diff between two scans",
+		http.StatusOK, []string{tagDiffAdd}, bearerToken, new(ScanCompareReq), new(ScanCompareRes[Compliance]))
+	d.AddOperation("addDiffAdd", http.MethodPost, "/deepfence/diff-add/malware",
+		"Get Malware Diff", "Get Malware Diff between two scans",
+		http.StatusOK, []string{tagDiffAdd}, bearerToken, new(ScanCompareReq), new(ScanCompareRes[Malware]))
+	d.AddOperation("addDiffAdd", http.MethodPost, "/deepfence/diff-add/cloud-compliance",
+		"Get Cloud Compliance Diff", "Get Cloud Compliance Diff between two scans",
+		http.StatusOK, []string{tagDiffAdd}, bearerToken, new(ScanCompareReq), new(ScanCompareRes[CloudCompliance]))
 }

--- a/deepfence_server/handler/scan_reports.go
+++ b/deepfence_server/handler/scan_reports.go
@@ -1461,81 +1461,70 @@ func getScanResults(ctx context.Context, scanId, scanType string) (model.Downloa
 // where A and B are scan IDs
 // @returns ScanComparison (new:s1-s2, deleted:s2-s1)
 func compareScanResults(ctx context.Context, s1, s2, scanType string, ff reporters.FieldsFilters, fw model.FetchWindow) (compared model.ScanComparison, err error) {
-	// req.FieldsFilter, req.Window
 	switch scanType {
 	case "VulnerabilityScan":
-		added, err := reporters_scan.GetScanResultDiff[model.Vulnerability](ctx, utils.NEO4J_VULNERABILITY_SCAN, s1, s2, ff, fw)
+		compared.New, err = reporters_scan.GetScanResultDiff[model.Vulnerability](ctx, utils.NEO4J_VULNERABILITY_SCAN, s1, s2, ff, fw)
 		if err != nil {
 			return compared, err
 		}
 
-		removed, err := reporters_scan.GetScanResultDiff[model.Vulnerability](ctx, utils.NEO4J_VULNERABILITY_SCAN, s2, s1, ff, fw)
+		compared.Deleted, err = reporters_scan.GetScanResultDiff[model.Vulnerability](ctx, utils.NEO4J_VULNERABILITY_SCAN, s2, s1, ff, fw)
 		if err != nil {
 			return compared, err
 		}
 
-		compared.New = added
-		compared.Deleted = removed
 		return compared, nil
 
 	case "SecretScan":
-		added, err := reporters_scan.GetScanResultDiff[model.Secret](ctx, utils.NEO4J_SECRET_SCAN, s1, s2, ff, fw)
+		compared.New, err = reporters_scan.GetScanResultDiff[model.Secret](ctx, utils.NEO4J_SECRET_SCAN, s1, s2, ff, fw)
 		if err != nil {
 			return compared, err
 		}
 
-		removed, err := reporters_scan.GetScanResultDiff[model.Secret](ctx, utils.NEO4J_SECRET_SCAN, s2, s1, ff, fw)
+		compared.Deleted, err = reporters_scan.GetScanResultDiff[model.Secret](ctx, utils.NEO4J_SECRET_SCAN, s2, s1, ff, fw)
 		if err != nil {
 			return compared, err
 		}
 
-		compared.New = added
-		compared.Deleted = removed
 		return compared, nil
 
 	case "MalwareScan":
-		added, err := reporters_scan.GetScanResultDiff[model.Malware](ctx, utils.NEO4J_MALWARE_SCAN, s1, s2, ff, fw)
+		compared.New, err = reporters_scan.GetScanResultDiff[model.Malware](ctx, utils.NEO4J_MALWARE_SCAN, s1, s2, ff, fw)
 		if err != nil {
 			return compared, err
 		}
 
-		removed, err := reporters_scan.GetScanResultDiff[model.Malware](ctx, utils.NEO4J_MALWARE_SCAN, s2, s1, ff, fw)
+		compared.Deleted, err = reporters_scan.GetScanResultDiff[model.Malware](ctx, utils.NEO4J_MALWARE_SCAN, s2, s1, ff, fw)
 		if err != nil {
 			return compared, err
 		}
 
-		compared.New = added
-		compared.Deleted = removed
 		return compared, nil
 
 	case "ComplianceScan":
-		added, err := reporters_scan.GetScanResultDiff[model.Compliance](ctx, utils.NEO4J_COMPLIANCE_SCAN, s1, s2, ff, fw)
+		compared.New, err = reporters_scan.GetScanResultDiff[model.Compliance](ctx, utils.NEO4J_COMPLIANCE_SCAN, s1, s2, ff, fw)
 		if err != nil {
 			return compared, err
 		}
 
-		removed, err := reporters_scan.GetScanResultDiff[model.Compliance](ctx, utils.NEO4J_COMPLIANCE_SCAN, s2, s1, ff, fw)
+		compared.Deleted, err = reporters_scan.GetScanResultDiff[model.Compliance](ctx, utils.NEO4J_COMPLIANCE_SCAN, s2, s1, ff, fw)
 		if err != nil {
 			return compared, err
 		}
 
-		compared.New = added
-		compared.Deleted = removed
 		return compared, nil
 
 	case "CloudComplianceScan":
-		added, err := reporters_scan.GetScanResultDiff[model.CloudCompliance](ctx, utils.NEO4J_CLOUD_COMPLIANCE_SCAN, s1, s2, ff, fw)
+		compared.New, err = reporters_scan.GetScanResultDiff[model.CloudCompliance](ctx, utils.NEO4J_CLOUD_COMPLIANCE_SCAN, s1, s2, ff, fw)
 		if err != nil {
 			return compared, err
 		}
 
-		removed, err := reporters_scan.GetScanResultDiff[model.CloudCompliance](ctx, utils.NEO4J_CLOUD_COMPLIANCE_SCAN, s2, s1, ff, fw)
+		compared.Deleted, err = reporters_scan.GetScanResultDiff[model.CloudCompliance](ctx, utils.NEO4J_CLOUD_COMPLIANCE_SCAN, s2, s1, ff, fw)
 		if err != nil {
 			return compared, err
 		}
 
-		compared.New = added
-		compared.Deleted = removed
 		return compared, nil
 
 	default:
@@ -2149,18 +2138,4 @@ func startMultiComplianceScan(ctx context.Context, reqs []model.NodeIdentifier, 
 		scanIds = append(scanIds, scanId)
 	}
 	return scanIds, bulkId, nil
-}
-
-// (A-B)
-// use this function to compare between two scan results, A and B
-// to get new vulnerabilities GetDifferenceBetweenVulnerabilitiesScanResults(ctx, A, B)
-// to get deleted vulnerabilities GetDifferenceBetweenVulnerabilitiesScanResults(ctx, B, A)
-// where A and B are scan IDs
-func GetDifferenceBetweenVulnerabilitiesScanResults(ctx context.Context, a, b string) ([]model.Vulnerability, error) {
-	entries, err := reporters_scan.GetScanResultDiff[model.Vulnerability](ctx, utils.NEO4J_VULNERABILITY_SCAN, a, b, reporters.FieldsFilters{}, model.FetchWindow{})
-	if err != nil {
-		return []model.Vulnerability{}, err
-	}
-
-	return entries, nil
 }

--- a/deepfence_server/handler/scan_reports.go
+++ b/deepfence_server/handler/scan_reports.go
@@ -257,16 +257,16 @@ func (h *Handler) CompareScanHandler(w http.ResponseWriter, r *http.Request) {
 	err := httpext.DecodeJSON(r, httpext.NoQueryParams, MaxPostRequestSize, &req)
 	if err != nil {
 		log.Error().Msgf("%v", err)
-		respondError(&BadDecoding{err}, w)
+		h.respondError(&BadDecoding{err}, w)
 	}
 	if req.ScanType == "" {
-		respondError(incorrectScanTypeError, w)
+		h.respondError(incorrectScanTypeError, w)
 		return
 	}
 
 	if len(req.ScanIds) != 2 {
 		log.Error().Msgf("invalid scan ids: %s", req.ScanIds)
-		respondError(errors.New("could not compare, invalid scan ids"), w)
+		h.respondError(errors.New("could not compare, invalid scan ids"), w)
 		return
 	}
 
@@ -275,7 +275,7 @@ func (h *Handler) CompareScanHandler(w http.ResponseWriter, r *http.Request) {
 
 	res, err := compareScanResults(r.Context(), currentScanId, previousScanId, req.ScanType, req.FieldsFilter, req.Window)
 	if err != nil {
-		respondError(err, w)
+		h.respondError(err, w)
 		return
 	}
 	httpext.JSON(w, http.StatusOK, res)

--- a/deepfence_server/handler/scan_reports.go
+++ b/deepfence_server/handler/scan_reports.go
@@ -264,16 +264,7 @@ func (h *Handler) CompareScanHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if len(req.ScanIds) != 2 {
-		log.Error().Msgf("invalid scan ids: %s", req.ScanIds)
-		h.respondError(errors.New("could not compare, invalid scan ids"), w)
-		return
-	}
-
-	currentScanId := req.ScanIds[0]
-	previousScanId := req.ScanIds[1]
-
-	res, err := compareScanResults(r.Context(), currentScanId, previousScanId, req.ScanType, req.FieldsFilter, req.Window)
+	res, err := compareScanResults(r.Context(), req.BaseScanID, req.ToScanID, req.ScanType, req.FieldsFilter, req.Window)
 	if err != nil {
 		h.respondError(err, w)
 		return

--- a/deepfence_server/handler/scan_reports.go
+++ b/deepfence_server/handler/scan_reports.go
@@ -251,8 +251,14 @@ func (h *Handler) StartVulnerabilityScanHandler(w http.ResponseWriter, r *http.R
 	}
 }
 
-// /scan/results/vulnerability/compare?scanIds=scanId1,scanId2
-func (h *Handler) GetVulnerabilitiesScanComparisionReport(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) CompareScanHandler(w http.ResponseWriter, r *http.Request) {
+	// Get scan type from the params
+	scanType := r.URL.Query().Get("scanType")
+	if scanType == "" {
+		respondError(incorrectScanTypeError, w)
+		return
+	}
+
 	// Get the scan ids from the params
 	scanIds := r.URL.Query().Get("scanIds")
 	scanIdsArr := strings.Split(scanIds, ",")
@@ -265,24 +271,12 @@ func (h *Handler) GetVulnerabilitiesScanComparisionReport(w http.ResponseWriter,
 	currentScanId := scanIdsArr[0]
 	previousScanId := scanIdsArr[1]
 
-	// added vulnerabilities
-	added, err := GetDifferenceBetweenVulnerabilitiesScanResults(r.Context(), currentScanId, previousScanId)
+	res, err := compareScanResults(r.Context(), currentScanId, previousScanId, scanType)
 	if err != nil {
 		respondError(err, w)
 		return
 	}
-
-	// removed vulnerabilities
-	removed, err := GetDifferenceBetweenVulnerabilitiesScanResults(r.Context(), previousScanId, currentScanId)
-	if err != nil {
-		respondError(err, w)
-		return
-	}
-
-	httpext.JSON(w, http.StatusOK, model.VulnerabilityComparison{
-		New:     added,
-		Deleted: removed,
-	})
+	httpext.JSON(w, http.StatusOK, res)
 }
 
 func (h *Handler) StartSecretScanHandler(w http.ResponseWriter, r *http.Request) {
@@ -1470,6 +1464,91 @@ func getScanResults(ctx context.Context, scanId, scanType string) (model.Downloa
 	}
 }
 
+// use this function to compare between two scan results, s1 and s2
+// where A and B are scan IDs
+// @returns ScanComparison (new:s1-s2, deleted:s2-s1)
+func compareScanResults(ctx context.Context, s1, s2, scanType string) (compared model.ScanComparison, err error) {
+	switch scanType {
+	case "VulnerabilityScan":
+		added, err := reporters_scan.GetScanResultDiff[model.Vulnerability](ctx, utils.NEO4J_VULNERABILITY_SCAN, s1, s2, reporters.FieldsFilters{}, model.FetchWindow{})
+		if err != nil {
+			return compared, err
+		}
+
+		removed, err := reporters_scan.GetScanResultDiff[model.Vulnerability](ctx, utils.NEO4J_VULNERABILITY_SCAN, s2, s1, reporters.FieldsFilters{}, model.FetchWindow{})
+		if err != nil {
+			return compared, err
+		}
+
+		compared.New = added
+		compared.Deleted = removed
+		return compared, nil
+
+	case "SecretScan":
+		added, err := reporters_scan.GetScanResultDiff[model.Secret](ctx, utils.NEO4J_SECRET_SCAN, s1, s2, reporters.FieldsFilters{}, model.FetchWindow{})
+		if err != nil {
+			return compared, err
+		}
+
+		removed, err := reporters_scan.GetScanResultDiff[model.Secret](ctx, utils.NEO4J_SECRET_SCAN, s2, s1, reporters.FieldsFilters{}, model.FetchWindow{})
+		if err != nil {
+			return compared, err
+		}
+
+		compared.New = added
+		compared.Deleted = removed
+		return compared, nil
+
+	case "MalwareScan":
+		added, err := reporters_scan.GetScanResultDiff[model.Malware](ctx, utils.NEO4J_MALWARE_SCAN, s1, s2, reporters.FieldsFilters{}, model.FetchWindow{})
+		if err != nil {
+			return compared, err
+		}
+
+		removed, err := reporters_scan.GetScanResultDiff[model.Malware](ctx, utils.NEO4J_MALWARE_SCAN, s2, s1, reporters.FieldsFilters{}, model.FetchWindow{})
+		if err != nil {
+			return compared, err
+		}
+
+		compared.New = added
+		compared.Deleted = removed
+		return compared, nil
+
+	case "ComplianceScan":
+		added, err := reporters_scan.GetScanResultDiff[model.Compliance](ctx, utils.NEO4J_COMPLIANCE_SCAN, s1, s2, reporters.FieldsFilters{}, model.FetchWindow{})
+		if err != nil {
+			return compared, err
+		}
+
+		removed, err := reporters_scan.GetScanResultDiff[model.Compliance](ctx, utils.NEO4J_COMPLIANCE_SCAN, s2, s1, reporters.FieldsFilters{}, model.FetchWindow{})
+		if err != nil {
+			return compared, err
+		}
+
+		compared.New = added
+		compared.Deleted = removed
+		return compared, nil
+
+	case "CloudComplianceScan":
+		added, err := reporters_scan.GetScanResultDiff[model.CloudCompliance](ctx, utils.NEO4J_CLOUD_COMPLIANCE_SCAN, s1, s2, reporters.FieldsFilters{}, model.FetchWindow{})
+		if err != nil {
+			return compared, err
+		}
+
+		removed, err := reporters_scan.GetScanResultDiff[model.CloudCompliance](ctx, utils.NEO4J_CLOUD_COMPLIANCE_SCAN, s2, s1, reporters.FieldsFilters{}, model.FetchWindow{})
+		if err != nil {
+			return compared, err
+		}
+
+		compared.New = added
+		compared.Deleted = removed
+		return compared, nil
+
+	default:
+		return compared, incorrectScanTypeError
+	}
+}
+
 func (h *Handler) scanIdActionHandler(w http.ResponseWriter, r *http.Request, action string) {
 	req := model.ScanActionRequest{
 		ScanID:   chi.URLParam(r, "scan_id"),
@@ -2076,46 +2155,6 @@ func startMultiComplianceScan(ctx context.Context, reqs []model.NodeIdentifier, 
 		scanIds = append(scanIds, scanId)
 	}
 	return scanIds, bulkId, nil
-}
-
-func GetVulnerabilitiesScanResults(ctx context.Context, scanId string) ([]model.Vulnerability, error) {
-	entries, _, err := reporters_scan.GetScanResults[model.Vulnerability](ctx, utils.NEO4J_VULNERABILITY_SCAN, scanId, reporters.FieldsFilters{}, model.FetchWindow{})
-	if err != nil {
-		return nil, err
-	}
-	return entries, nil
-}
-
-func CompareVulnerabilitiesScanResults(r1, r2 []model.Vulnerability) (model.VulnerabilityComparison, error) {
-	res := model.VulnerabilityComparison{
-		New:     []model.Vulnerability{},
-		Deleted: []model.Vulnerability{},
-	}
-
-	r1Map := make(map[string]model.Vulnerability)
-	r2Map := make(map[string]model.Vulnerability)
-
-	for i := range r1 {
-		r1Map[r1[i].Cve_id] = r1[i]
-	}
-
-	for i := range r2 {
-		r2Map[r2[i].Cve_id] = r2[i]
-	}
-
-	for k, v := range r1Map {
-		if _, ok := r2Map[k]; !ok {
-			res.Deleted = append(res.Deleted, v)
-		}
-	}
-
-	for k, v := range r2Map {
-		if _, ok := r1Map[k]; !ok {
-			res.New = append(res.New, v)
-		}
-	}
-
-	return res, nil
 }
 
 // (A-B)

--- a/deepfence_server/handler/scan_reports.go
+++ b/deepfence_server/handler/scan_reports.go
@@ -265,27 +265,24 @@ func (h *Handler) GetVulnerabilitiesScanComparisionReport(w http.ResponseWriter,
 	currentScanId := scanIdsArr[0]
 	previousScanId := scanIdsArr[1]
 
-	// Get the scan results for the scan ids
-	currentScanResults, err := GetVulnerabilitiesScanResults(r.Context(), currentScanId)
+	// added vulnerabilities
+	added, err := GetDifferenceBetweenVulnerabilitiesScanResults(r.Context(), currentScanId, previousScanId)
 	if err != nil {
 		respondError(err, w)
 		return
 	}
 
-	previousScanResults, err := GetVulnerabilitiesScanResults(r.Context(), previousScanId)
+	// removed vulnerabilities
+	removed, err := GetDifferenceBetweenVulnerabilitiesScanResults(r.Context(), previousScanId, currentScanId)
 	if err != nil {
 		respondError(err, w)
 		return
 	}
 
-	// Compare the scan results
-	comparedScanResults, err := CompareVulnerabilitiesScanResults(currentScanResults, previousScanResults)
-	if err != nil {
-		respondError(err, w)
-		return
-	}
-
-	httpext.JSON(w, http.StatusOK, comparedScanResults)
+	httpext.JSON(w, http.StatusOK, model.VulnerabilityComparison{
+		New:     added,
+		Deleted: removed,
+	})
 }
 
 func (h *Handler) StartSecretScanHandler(w http.ResponseWriter, r *http.Request) {
@@ -2119,4 +2116,18 @@ func CompareVulnerabilitiesScanResults(r1, r2 []model.Vulnerability) (model.Vuln
 	}
 
 	return res, nil
+}
+
+// (A-B)
+// use this function to compare between two scan results, A and B
+// to get new vulnerabilities GetDifferenceBetweenVulnerabilitiesScanResults(ctx, A, B)
+// to get deleted vulnerabilities GetDifferenceBetweenVulnerabilitiesScanResults(ctx, B, A)
+// where A and B are scan IDs
+func GetDifferenceBetweenVulnerabilitiesScanResults(ctx context.Context, a, b string) ([]model.Vulnerability, error) {
+	entries, err := reporters_scan.GetScanResultDiff[model.Vulnerability](ctx, utils.NEO4J_VULNERABILITY_SCAN, a, b, reporters.FieldsFilters{}, model.FetchWindow{})
+	if err != nil {
+		return []model.Vulnerability{}, err
+	}
+
+	return entries, nil
 }

--- a/deepfence_server/main.go
+++ b/deepfence_server/main.go
@@ -339,7 +339,7 @@ func initializeOpenApiDocs(openApiDocs *apiDocs.OpenApiDocs) {
 	openApiDocs.AddIntegrationOperations()
 	openApiDocs.AddReportsOperations()
 	openApiDocs.AddSettingsOperations()
-	openApiDocs.AddScanCompareOperations()
+	openApiDocs.AddDiffAddOperations()
 }
 
 func initializeInternalOpenApiDocs(openApiDocs *apiDocs.OpenApiDocs) {

--- a/deepfence_server/main.go
+++ b/deepfence_server/main.go
@@ -339,6 +339,7 @@ func initializeOpenApiDocs(openApiDocs *apiDocs.OpenApiDocs) {
 	openApiDocs.AddIntegrationOperations()
 	openApiDocs.AddReportsOperations()
 	openApiDocs.AddSettingsOperations()
+	openApiDocs.AddScanCompareOperations()
 }
 
 func initializeInternalOpenApiDocs(openApiDocs *apiDocs.OpenApiDocs) {

--- a/deepfence_server/model/scans.go
+++ b/deepfence_server/model/scans.go
@@ -558,8 +558,8 @@ func (CloudCompliance) GetJsonCategory() string {
 	return "severity"
 }
 
-type VulnerabilityComparison struct {
-	New     []Vulnerability `json:"new" required:"true"`
-	Updated []Vulnerability `json:"updated" required:"true"`
-	Deleted []Vulnerability `json:"deleted" required:"true"`
+type ScanComparison struct {
+	New     interface{} `json:"new" required:"true"`
+	Updated interface{} `json:"updated" required:"true"`
+	Deleted interface{} `json:"deleted" required:"true"`
 }

--- a/deepfence_server/model/scans.go
+++ b/deepfence_server/model/scans.go
@@ -34,11 +34,13 @@ type ComplianceScanTriggerReq struct {
 type ScanCompareReq struct {
 	BaseScanID   string                  `json:"base_scan_id" required:"true"`
 	ToScanID     string                  `json:"to_scan_id" required:"true"`
-	ScanType     string                  `json:"scan_type" validate:"required,oneof=SecretScan VulnerabilityScan MalwareScan ComplianceScan CloudComplianceScan" required:"true" enum:"SecretScan,VulnerabilityScan,MalwareScan,ComplianceScan,CloudComplianceScan"`
 	FieldsFilter reporters.FieldsFilters `json:"fields_filter" required:"true"`
 	Window       FetchWindow             `json:"window"  required:"true"`
 }
 
+type ScanCompareRes[T any] struct {
+	New []T `json:"new" required:"true"`
+}
 type ScanFilter struct {
 	ImageScanFilter             reporters.ContainsFilter `json:"image_scan_filter" required:"true"`
 	ContainerScanFilter         reporters.ContainsFilter `json:"container_scan_filter" required:"true"`
@@ -564,9 +566,4 @@ func (v CloudCompliance) GetCategory() string {
 
 func (CloudCompliance) GetJsonCategory() string {
 	return "severity"
-}
-
-type ScanComparison struct {
-	New     interface{} `json:"new" required:"true"`
-	Deleted interface{} `json:"deleted" required:"true"`
 }

--- a/deepfence_server/model/scans.go
+++ b/deepfence_server/model/scans.go
@@ -32,7 +32,8 @@ type ComplianceScanTriggerReq struct {
 }
 
 type ScanCompareReq struct {
-	ScanIds      []string                `json:"scan_ids" required:"true"`
+	BaseScanID   string                  `json:"base_scan_id" required:"true"`
+	ToScanID     string                  `json:"to_scan_id" required:"true"`
 	ScanType     string                  `json:"scan_type" validate:"required,oneof=SecretScan VulnerabilityScan MalwareScan ComplianceScan CloudComplianceScan" required:"true" enum:"SecretScan,VulnerabilityScan,MalwareScan,ComplianceScan,CloudComplianceScan"`
 	FieldsFilter reporters.FieldsFilters `json:"fields_filter" required:"true"`
 	Window       FetchWindow             `json:"window"  required:"true"`

--- a/deepfence_server/model/scans.go
+++ b/deepfence_server/model/scans.go
@@ -33,7 +33,7 @@ type ComplianceScanTriggerReq struct {
 
 type ScanCompareReq struct {
 	ScanIds      []string                `json:"scan_ids" required:"true"`
-	ScanType     string                  `json:"scan_type" required:"true" enum:"SecretScan VulnerabilityScan MalwareScan ComplianceScan CloudComplianceScan"`
+	ScanType     string                  `json:"scan_type" validate:"required,oneof=SecretScan VulnerabilityScan MalwareScan ComplianceScan CloudComplianceScan" required:"true" enum:"SecretScan,VulnerabilityScan,MalwareScan,ComplianceScan,CloudComplianceScan"`
 	FieldsFilter reporters.FieldsFilters `json:"fields_filter" required:"true"`
 	Window       FetchWindow             `json:"window"  required:"true"`
 }

--- a/deepfence_server/model/scans.go
+++ b/deepfence_server/model/scans.go
@@ -557,3 +557,9 @@ func (v CloudCompliance) GetCategory() string {
 func (CloudCompliance) GetJsonCategory() string {
 	return "severity"
 }
+
+type VulnerabilityComparison struct {
+	New     []Vulnerability `json:"new" required:"true"`
+	Updated []Vulnerability `json:"updated" required:"true"`
+	Deleted []Vulnerability `json:"deleted" required:"true"`
+}

--- a/deepfence_server/model/scans.go
+++ b/deepfence_server/model/scans.go
@@ -567,6 +567,5 @@ func (CloudCompliance) GetJsonCategory() string {
 
 type ScanComparison struct {
 	New     interface{} `json:"new" required:"true"`
-	Updated interface{} `json:"updated" required:"true"`
 	Deleted interface{} `json:"deleted" required:"true"`
 }

--- a/deepfence_server/model/scans.go
+++ b/deepfence_server/model/scans.go
@@ -31,6 +31,13 @@ type ComplianceScanTriggerReq struct {
 	ComplianceBenchmarkTypes
 }
 
+type ScanCompareReq struct {
+	ScanIds      []string                `json:"scan_ids" required:"true"`
+	ScanType     string                  `json:"scan_type" required:"true" enum:"SecretScan VulnerabilityScan MalwareScan ComplianceScan CloudComplianceScan"`
+	FieldsFilter reporters.FieldsFilters `json:"fields_filter" required:"true"`
+	Window       FetchWindow             `json:"window"  required:"true"`
+}
+
 type ScanFilter struct {
 	ImageScanFilter             reporters.ContainsFilter `json:"image_scan_filter" required:"true"`
 	ContainerScanFilter         reporters.ContainsFilter `json:"container_scan_filter" required:"true"`

--- a/deepfence_server/reporters/scan/scan_reporters.go
+++ b/deepfence_server/reporters/scan/scan_reporters.go
@@ -622,10 +622,10 @@ func GetScanResultDiff[T any](ctx context.Context, scan_type utils.Neo4jScanType
 	}
 
 	query = `
-	match (n:` + string(scan_type) + `{node_id: $base_scan_id}) -[r:DETECTED]-> (d)
-	where not exists {match (m:` + string(scan_type) + `{node_id: $compare_to_scan_id}) -[:DETECTED]-> (d)}
-	optional match (d) -[:IS]-> (e)
-	with apoc.map.merge( e{.*}, d{.*, masked: coalesce(d.masked or r.masked, false), name: coalesce(e.name, d.name, '')}) as d` +
+	MATCH (n:` + string(scan_type) + `{node_id: $base_scan_id}) -[r:DETECTED]-> (d)
+	WHERE NOT EXISTS {MATCH (m:` + string(scan_type) + `{node_id: $compare_to_scan_id}) -[:DETECTED]-> (d)}
+	OPTIONAL MATCH (d) -[:IS]-> (e)
+	WITH apoc.map.merge( e{.*}, d{.*, masked: coalesce(d.masked or r.masked, false), name: coalesce(e.name, d.name, '')}) AS d` +
 		reporters.ParseFieldFilters2CypherWhereConditions("d", mo.Some(ff), true) +
 		ffCondition + ` RETURN d ` +
 		fw.FetchWindow2CypherQuery()

--- a/deepfence_server/router/router.go
+++ b/deepfence_server/router/router.go
@@ -369,7 +369,6 @@ func SetupRoutes(r *chi.Mux, serverPort string, serveOpenapiDocs bool, ingestC c
 			r.Route("/scan/results", func(r chi.Router) {
 				r.Route("/vulnerability", func(r chi.Router) {
 					r.Post("/", dfHandler.AuthHandler(ResourceScanReport, PermissionRead, dfHandler.ListVulnerabilityScanResultsHandler))
-					r.Get("/compare", dfHandler.AuthHandler(ResourceScanReport, PermissionRead, dfHandler.GetVulnerabilitiesScanComparisionReport))
 				})
 
 				r.Route("/secret", func(r chi.Router) {
@@ -400,6 +399,8 @@ func SetupRoutes(r *chi.Mux, serverPort string, serveOpenapiDocs bool, ingestC c
 						})
 					})
 				})
+
+				r.Get("/compare", dfHandler.AuthHandler(ResourceScanReport, PermissionRead, dfHandler.CompareScanHandler))
 			})
 
 			r.Route("/filters", func(r chi.Router) {

--- a/deepfence_server/router/router.go
+++ b/deepfence_server/router/router.go
@@ -367,7 +367,10 @@ func SetupRoutes(r *chi.Mux, serverPort string, serveOpenapiDocs bool, ingestC c
 				r.Post("/cloud-compliance", dfHandler.AuthHandler(ResourceScanReport, PermissionRead, dfHandler.ListCloudComplianceScansHandler))
 			})
 			r.Route("/scan/results", func(r chi.Router) {
-				r.Post("/vulnerability", dfHandler.AuthHandler(ResourceScanReport, PermissionRead, dfHandler.ListVulnerabilityScanResultsHandler))
+				r.Route("/vulnerability", func(r chi.Router) {
+					r.Post("/", dfHandler.AuthHandler(ResourceScanReport, PermissionRead, dfHandler.ListVulnerabilityScanResultsHandler))
+					r.Get("/compare", dfHandler.AuthHandler(ResourceScanReport, PermissionRead, dfHandler.GetVulnerabilitiesScanComparisionReport))
+				})
 
 				r.Route("/secret", func(r chi.Router) {
 					r.Post("/", dfHandler.AuthHandler(ResourceScanReport, PermissionRead, dfHandler.ListSecretScanResultsHandler))

--- a/deepfence_server/router/router.go
+++ b/deepfence_server/router/router.go
@@ -397,8 +397,14 @@ func SetupRoutes(r *chi.Mux, serverPort string, serveOpenapiDocs bool, ingestC c
 						})
 					})
 				})
+			})
 
-				r.Post("/compare", dfHandler.AuthHandler(ResourceScanReport, PermissionRead, dfHandler.CompareScanHandler))
+			r.Route("/diff-add", func(r chi.Router) {
+				r.Post("/vulnerability", dfHandler.AuthHandler(ResourceScanReport, PermissionRead, dfHandler.DiffAddVulnerabilityScan))
+				r.Post("/secret", dfHandler.AuthHandler(ResourceScanReport, PermissionRead, dfHandler.DiffAddSecretScan))
+				r.Post("/compliance", dfHandler.AuthHandler(ResourceScanReport, PermissionRead, dfHandler.DiffAddComplianceScan))
+				r.Post("/malware", dfHandler.AuthHandler(ResourceScanReport, PermissionRead, dfHandler.DiffAddMalwareScan))
+				r.Post("/cloud-compliance", dfHandler.AuthHandler(ResourceScanReport, PermissionRead, dfHandler.DiffAddCloudComplianceScan))
 			})
 
 			r.Route("/filters", func(r chi.Router) {

--- a/deepfence_server/router/router.go
+++ b/deepfence_server/router/router.go
@@ -367,9 +367,7 @@ func SetupRoutes(r *chi.Mux, serverPort string, serveOpenapiDocs bool, ingestC c
 				r.Post("/cloud-compliance", dfHandler.AuthHandler(ResourceScanReport, PermissionRead, dfHandler.ListCloudComplianceScansHandler))
 			})
 			r.Route("/scan/results", func(r chi.Router) {
-				r.Route("/vulnerability", func(r chi.Router) {
-					r.Post("/", dfHandler.AuthHandler(ResourceScanReport, PermissionRead, dfHandler.ListVulnerabilityScanResultsHandler))
-				})
+				r.Post("/vulnerability", dfHandler.AuthHandler(ResourceScanReport, PermissionRead, dfHandler.ListVulnerabilityScanResultsHandler))
 
 				r.Route("/secret", func(r chi.Router) {
 					r.Post("/", dfHandler.AuthHandler(ResourceScanReport, PermissionRead, dfHandler.ListSecretScanResultsHandler))

--- a/deepfence_server/router/router.go
+++ b/deepfence_server/router/router.go
@@ -400,7 +400,7 @@ func SetupRoutes(r *chi.Mux, serverPort string, serveOpenapiDocs bool, ingestC c
 					})
 				})
 
-				r.Get("/compare", dfHandler.AuthHandler(ResourceScanReport, PermissionRead, dfHandler.CompareScanHandler))
+				r.Post("/compare", dfHandler.AuthHandler(ResourceScanReport, PermissionRead, dfHandler.CompareScanHandler))
 			})
 
 			r.Route("/filters", func(r chi.Router) {


### PR DESCRIPTION
ref: https://github.com/deepfence/ThreatMapper/issues/1501

I added 5 new apis for diff/compare scan results (add)
- `/deepfence/diff-add/vulnerability`
- `/deepfence/diff-add/vulnerability`
- `/deepfence/diff-add/secrets`
- `/deepfence/diff-add/malware`
- `/deepfence/diff-add/cloud-compliance` 

request payload will look like this
```json
{
  "base_scan_id": "b0d1d657e583d8d415db536b21d7d031f6f964418c92d123fcf5944c4d80b442-1693572604",
  "to_scan_id": "b0d1d657e583d8d415db536b21d7d031f6f964418c92d123fcf5944c4d80b442-1690986732",
  "fields_filter": {},
  "window": {
    "offset": 0,
    "size": 10
  }
}
```

response will look like this:
```json
{
    "new": [{},{},...]
}
```

these api only return added difference, i.e. you need to interchange base_scan_id and to_scan_id and do two different request to get added and deleted items(cve, secrets, etc.)

example:
if a is the latest scan_id for vulnerability and b is any historical scan_id of same resource, and we need to find out what was added and deleted.
for added
```
{
  "base_scan_id": "a",
  "to_scan_id": "b",
  "fields_filter": {},
  "window": {
    "offset": 0,
    "size": 10
  }
}
```
for deleted
```
{
  "base_scan_id": "b",
  "to_scan_id": "a",
  "fields_filter": {},
  "window": {
    "offset": 0,
    "size": 10
  }
}
```

Note: filters, window works. There wouldn't be any count api for these.

I rewrote and broke `/compare` into multiple apis. Underneath we still call the same function to get the list.(using go generics!!)
Rewriting is fun, until I have to write the UT too. 