### PR TITLE
fix(1482): start scan to send node type of image for container image …

### DIFF
--- a/deepfence_frontend/apps/dashboard/src/components/scan-configure-forms/MalwareScanConfigureForm.tsx
+++ b/deepfence_frontend/apps/dashboard/src/components/scan-configure-forms/MalwareScanConfigureForm.tsx
@@ -58,8 +58,8 @@ export const scanMalwareApiAction = async ({
   let filter_in = null;
   let _nodeType = nodeType;
 
-  if (nodeType === MalwareScanNodeTypeEnum.imageTag) {
-    _nodeType = 'image';
+  if (nodeType === MalwareScanNodeTypeEnum.imageTag || nodeType === 'container_image') {
+    _nodeType = MalwareScanNodeTypeEnum.image;
   } else if (nodeType === MalwareScanNodeTypeEnum.kubernetes_cluster) {
     _nodeType = 'cluster';
   } else if (nodeType === MalwareScanNodeTypeEnum.image) {

--- a/deepfence_frontend/apps/dashboard/src/components/scan-configure-forms/SecretScanConfigureForm.tsx
+++ b/deepfence_frontend/apps/dashboard/src/components/scan-configure-forms/SecretScanConfigureForm.tsx
@@ -58,8 +58,8 @@ export const scanSecretApiAction = async ({
   let filter_in = null;
   let _nodeType = nodeType;
 
-  if (nodeType === SecretScanNodeTypeEnum.imageTag) {
-    _nodeType = 'image';
+  if (nodeType === SecretScanNodeTypeEnum.imageTag || nodeType === 'container_image') {
+    _nodeType = SecretScanNodeTypeEnum.image;
   } else if (nodeType === SecretScanNodeTypeEnum.kubernetes_cluster) {
     _nodeType = 'cluster';
   } else if (nodeType === SecretScanNodeTypeEnum.image) {

--- a/deepfence_frontend/apps/dashboard/src/components/scan-configure-forms/VulnerabilityScanConfigureForm.tsx
+++ b/deepfence_frontend/apps/dashboard/src/components/scan-configure-forms/VulnerabilityScanConfigureForm.tsx
@@ -127,8 +127,11 @@ export const scanVulnerabilityApiAction = async ({
   let filter_in = null;
   let _nodeType = nodeType;
 
-  if (nodeType === VulnerabilityScanNodeTypeEnum.imageTag) {
-    _nodeType = 'image';
+  if (
+    nodeType === VulnerabilityScanNodeTypeEnum.imageTag ||
+    nodeType === 'container_image'
+  ) {
+    _nodeType = VulnerabilityScanNodeTypeEnum.image;
   } else if (nodeType === VulnerabilityScanNodeTypeEnum.kubernetes_cluster) {
     _nodeType = 'cluster';
   } else if (nodeType === VulnerabilityScanNodeTypeEnum.image) {

--- a/deepfence_frontend/apps/dashboard/src/features/settings/pages/ScanHistoryAndDbManagement.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/settings/pages/ScanHistoryAndDbManagement.tsx
@@ -68,7 +68,7 @@ const action = async ({ request }: ActionFunctionArgs): Promise<ActionReturnType
         {
           field_name: 'updated_at',
           field_value: `${Date.now() - duration}`,
-          greater_than: false,
+          greater_than: true,
         },
       ];
     }


### PR DESCRIPTION
Fixes https://github.com/deepfence/ThreatMapper/issues/1482

Changes proposed in this pull request:
- start scan to send node type of image for container image scan for vulnerability, secret and malware
