### PR TITLE
Upgrade neo4j DB to 4.4.25 & change restart policies

### DIFF
--- a/deepfence_neo4j/Dockerfile
+++ b/deepfence_neo4j/Dockerfile
@@ -1,4 +1,4 @@
-FROM neo4j:4.4.21
+FROM neo4j:4.4.25
 RUN apt update && apt install rclone -y
 COPY df.sh /startup
 ENTRYPOINT ["tini", "-g", "--", "/startup/df.sh"]

--- a/deployment-scripts/docker-compose.yml
+++ b/deployment-scripts/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     image: ${IMAGE_REPOSITORY:-deepfenceio}/deepfence_postgres_ce:${DF_IMG_TAG:-2.0.0}
     ulimits:
       core: 0
-    restart: on-failure
+    restart: unless-stopped
     networks:
       - deepfence_net
     volumes:
@@ -48,7 +48,7 @@ services:
     image: ${IMAGE_REPOSITORY:-deepfenceio}/deepfence_redis_ce:${DF_IMG_TAG:-2.0.0}
     ulimits:
       core: 0
-    restart: on-failure
+    restart: unless-stopped
     networks:
       - deepfence_net
     volumes:
@@ -64,7 +64,7 @@ services:
 
     ulimits:
       core: 0
-    restart: on-failure
+    restart: unless-stopped
     tmpfs:
       - /tmp
     networks:
@@ -98,7 +98,7 @@ services:
       resources:
         limits:
           cpus: ".2"
-    restart: on-failure
+    restart: unless-stopped
     environment:
       - MGMT_CONSOLE_URL_INTERNAL=127.0.0.1
       - MGMT_CONSOLE_PORT_INTERNAL=8081
@@ -127,7 +127,7 @@ services:
       core: 0
     networks:
       - deepfence_net
-    restart: always
+    restart: unless-stopped
     environment:
       FORCE_HTTPS_REDIRECT: "true"
       KAFKA_REST_PROXY: "deepfence-rest-proxy:8082"
@@ -148,7 +148,7 @@ services:
       core: 0
     networks:
       - deepfence_net
-    restart: always
+    restart: unless-stopped
     ports:
       - "127.0.0.1:9000:9000"
       - "127.0.0.1:9333:9333"
@@ -187,14 +187,14 @@ services:
       driver: "json-file"
       options:
         max-size: "200m"
-    restart: on-failure
+    restart: unless-stopped
 
   deepfence-worker:
     container_name: deepfence-worker
     image: ${IMAGE_REPOSITORY:-deepfenceio}/deepfence_worker_ce:${DF_IMG_TAG:-2.0.0}
     ulimits:
       core: 0
-    restart: on-failure
+    restart: unless-stopped
     networks:
       - deepfence_net
     depends_on:
@@ -216,7 +216,7 @@ services:
   #   image: ${IMAGE_REPOSITORY:-deepfenceio}/deepfence_worker_ce:${DF_IMG_TAG:-2.0.0}
   #   ulimits:
   #     core: 0
-  #   restart: on-failure
+  #   restart: unless-stopped
   #   networks:
   #     - deepfence_net
   #   depends_on:
@@ -237,7 +237,7 @@ services:
   #   image: ${IMAGE_REPOSITORY:-deepfenceio}/deepfence_worker_ce:${DF_IMG_TAG:-2.0.0}
   #   ulimits:
   #     core: 0
-  #   restart: on-failure
+  #   restart: unless-stopped
   #   networks:
   #     - deepfence_net
   #   depends_on:
@@ -258,7 +258,7 @@ services:
     image: ${IMAGE_REPOSITORY:-deepfenceio}/deepfence_worker_ce:${DF_IMG_TAG:-2.0.0}
     ulimits:
       core: 0
-    restart: on-failure
+    restart: unless-stopped
     environment:
       <<: *common-creds
       DEEPFENCE_MODE: scheduler
@@ -282,7 +282,7 @@ services:
       core: 0
     networks:
       - deepfence_net
-    restart: on-failure
+    restart: unless-stopped
     depends_on:
       - deepfence-server
     logging:
@@ -307,6 +307,7 @@ services:
       driver: "json-file"
       options:
         max-size: "50m"
+    restart: unless-stopped
 
   deepfence-ingester:
     image: ${IMAGE_REPOSITORY:-deepfenceio}/deepfence_worker_ce:${DF_IMG_TAG:-2.0.0}
@@ -325,6 +326,7 @@ services:
       driver: "json-file"
       options:
         max-size: "200m"
+    restart: unless-stopped
 
   deepfence-telemetry:
     image: jaegertracing/all-in-one:1.42


### PR DESCRIPTION
Move neo4j to 4.4.25 after discovering a leak issue.
Change restart policies so that essential containers restart if they exit.