### PR TITLE
Fix container image scan download issue

### DIFF
--- a/deepfence_frontend/apps/dashboard/src/features/common/data-component/downloadScanAction.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/common/data-component/downloadScanAction.tsx
@@ -15,12 +15,16 @@ import { download } from '@/utils/download';
 
 export const action = async ({ request }: ActionFunctionArgs): Promise<null> => {
   const formData = await request.formData();
-  const nodeType = formData.get('nodeType') as UtilsReportFiltersNodeTypeEnum;
+  let nodeType = formData.get('nodeType') as UtilsReportFiltersNodeTypeEnum | 'image';
   const scanId = formData.get('scanId')?.toString() ?? '';
   const scanType = formData.get('scanType') as UtilsReportFiltersScanTypeEnum;
 
   if (!nodeType) {
     throw new Error('Node Type is required');
+  }
+
+  if (nodeType === 'image') {
+    nodeType = UtilsReportFiltersNodeTypeEnum.ContainerImage;
   }
 
   const getReportIdApi = apiWrapper({


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix wrong node type when downloading container image scan results.

[issue](https://github.com/deepfence/enterprise-roadmap/issues/1966#issuecomment-1717744253)