### PR TITLE
change container_image to container image in dropdown list

### DIFF
--- a/deepfence_frontend/apps/dashboard/src/features/malwares/pages/MalwareScans.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/malwares/pages/MalwareScans.tsx
@@ -8,7 +8,6 @@ import {
   useFetcher,
   useSearchParams,
 } from 'react-router-dom';
-import { cn } from 'tailwind-preset';
 import {
   Badge,
   Breadcrumb,
@@ -372,7 +371,7 @@ const Filters = () => {
             .map((item) => {
               return (
                 <ComboboxOption key={item} value={item}>
-                  {capitalize(item)}
+                  {capitalize(item.replace('_', ' '))}
                 </ComboboxOption>
               );
             })}

--- a/deepfence_frontend/apps/dashboard/src/features/secrets/pages/SecretScans.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/secrets/pages/SecretScans.tsx
@@ -369,7 +369,7 @@ const Filters = () => {
             .map((item) => {
               return (
                 <ComboboxOption key={item} value={item}>
-                  {capitalize(item)}
+                  {capitalize(item.replace('_', ' '))}
                 </ComboboxOption>
               );
             })}

--- a/deepfence_frontend/apps/dashboard/src/features/vulnerabilities/pages/VulnerabilityScans.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/vulnerabilities/pages/VulnerabilityScans.tsx
@@ -842,7 +842,7 @@ const Filters = () => {
             .map((item) => {
               return (
                 <ComboboxOption key={item} value={item}>
-                  {capitalize(item)}
+                  {capitalize(item.replace('_', ' '))}
                 </ComboboxOption>
               );
             })}


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:
- change Container_image to Container image in dropdown list for vulnerability, secret & malware scans table
