### PR TITLE
Add .log suffix in deepfenced logs

### DIFF
--- a/deepfence_agent/etc/fenced_logrotate.conf
+++ b/deepfence_agent/etc/fenced_logrotate.conf
@@ -72,7 +72,7 @@ su root root
     copytruncate
     rotate 1
 }
-/var/log/deepfenced/* {
+/var/log/deepfenced/*.log {
     missingok
     notifempty
     compress

--- a/deepfence_bootstrapper/supervisor/process.go
+++ b/deepfence_bootstrapper/supervisor/process.go
@@ -75,7 +75,7 @@ func NewProcHandler(name, path, command, env string, autorestart bool, cgroup st
 }
 
 func startLogging(name string, cmd *exec.Cmd) {
-	f, err := os.Create(log_root + name)
+	f, err := os.Create(log_root + name + ".log")
 	if err != nil {
 		log.Error().Msgf("Cannot start logging: %v", err)
 		return


### PR DESCRIPTION
Logrotate will otherwise not filter out already rotated logs
