### PR TITLE
Fix workload allocator semaphore

### DIFF
--- a/deepfence_utils/controls/workload_allocator.go
+++ b/deepfence_utils/controls/workload_allocator.go
@@ -15,15 +15,10 @@ type WorkloadAllocator struct {
 	access          sync.Mutex
 }
 
-func (wa *WorkloadAllocator) Reserve(delta int32) error {
+func (wa *WorkloadAllocator) Reserve(delta int32) {
 	wa.access.Lock()
 	defer wa.access.Unlock()
-	if wa.currentWorkload+delta <= wa.maxWorkload {
-		wa.currentWorkload += delta
-		return nil
-	}
-
-	return NotEnoughRoomError
+	wa.currentWorkload += delta
 }
 
 func (wa *WorkloadAllocator) Free() {
@@ -35,7 +30,11 @@ func (wa *WorkloadAllocator) Free() {
 func (wa *WorkloadAllocator) MaxAllocable() int32 {
 	wa.access.Lock()
 	defer wa.access.Unlock()
-	return wa.maxWorkload - wa.currentWorkload
+	delta := wa.maxWorkload - wa.currentWorkload
+	if delta < 0 {
+		return 0
+	}
+	return delta
 }
 
 func NewWorkloadAllocator(maxWorkload int32) *WorkloadAllocator {


### PR DESCRIPTION
Previously we were ignoring the "No enough room error"
This is not needed as long as we correctly update the number of running jobs and decrement the counter accordingly, as per semaphore usage.
This fix addresses that.
