### PR TITLE
Fix missing yara rules

### DIFF
--- a/deepfence_bootstrapper/assets/config.ini
+++ b/deepfence_bootstrapper/assets/config.ini
@@ -27,7 +27,7 @@ autostart=true
 autorestart=true
 
 [process:malware_scanner]
-command=/bin/bash -c "rm -f /tmp/yara-hunter.sock && $DF_INSTALL_DIR/home/deepfence/bin/yara-hunter/YaraHunter --config-path $DF_INSTALL_DIR/home/deepfence/bin/yara-hunter --rules-path $DF_INSTALL_DIR/home/deepfence/bin/yara-hunter --socket-path=/tmp/yara-hunter.sock --http-port=8012 --enable-updater=false"
+command=/bin/bash -c "rm -f /tmp/yara-hunter.sock && $DF_INSTALL_DIR/home/deepfence/bin/yara-hunter/YaraHunter --config-path $DF_INSTALL_DIR/home/deepfence/bin/yara-hunter --rules-path $DF_INSTALL_DIR/home/deepfence/bin/yara-hunter/yara-rules --socket-path=/tmp/yara-hunter.sock --http-port=8012 --enable-updater=false"
 path=$DF_INSTALL_DIR/home/deepfence/bin/yara-hunter/YaraHunter
 autostart=true
 autorestart=true


### PR DESCRIPTION
Qualification:
```
sh-5.1# tail -f /var/log/deepfenced/malware_scanner.log
INFO[2023-09-26T01:54:43Z] yara.go:71 including yara rule file /home/deepfence/bin/yara-hunter/yara-rules/malware.yar
WARN[2023-09-26T01:54:47Z] yara.go:91 YARA compiler warning in %s ruleset: %s:%d %sfile/home/deepfence/bin/yara-hunter/yara-rules/malware.yar18526expression always false - requesting 5 of 3.
INFO[2023-09-26T01:54:47Z] grpc.go:184 main: server listening at /tmp/yara-hunter.sock
```
