### PR TITLE
Posture counts

### DIFF
--- a/deepfence_worker/cronjobs/cloud_compliance.go
+++ b/deepfence_worker/cronjobs/cloud_compliance.go
@@ -238,7 +238,7 @@ func CachePostureProviders(ctx context.Context, task *asynq.Task) error {
 
 			scan_count_query = `
 			MATCH (n:` + string(neo4jNodeType) + `)
-			WHERE n.pseudo=false
+			WHERE n.pseudo=false and n.agent_running=true
 			MATCH (n) <-[:SCANNED]- (m:` + string(utils.NEO4J_COMPLIANCE_SCAN) + `)
 			RETURN count(distinct n)`
 

--- a/deepfence_worker/cronjobs/cloud_compliance.go
+++ b/deepfence_worker/cronjobs/cloud_compliance.go
@@ -185,6 +185,7 @@ func AddCloudControls(ctx context.Context, task *asynq.Task) error {
 
 func CachePostureProviders(ctx context.Context, task *asynq.Task) error {
 	log.Info().Msgf("Caching Posture Providers")
+	defer log.Info().Msgf("Caching Posture Providers - Done")
 	driver, err := directory.Neo4jClient(ctx)
 	if err != nil {
 		return err
@@ -237,9 +238,9 @@ func CachePostureProviders(ctx context.Context, task *asynq.Task) error {
 
 			scan_count_query = `
 			MATCH (n:` + string(neo4jNodeType) + `)
-			WHERE n.pseudo=false and n.active=true and n.agent_running=true
+			WHERE n.pseudo=false
 			MATCH (n) <-[:SCANNED]- (m:` + string(utils.NEO4J_COMPLIANCE_SCAN) + `)
-			RETURN count(distinct m)`
+			RETURN count(distinct n)`
 
 			success_count_query = `
 			MATCH (n:` + string(neo4jNodeType) + `)
@@ -274,10 +275,9 @@ func CachePostureProviders(ctx context.Context, task *asynq.Task) error {
 
 			scan_count_query = `
 			MATCH (o:` + string(neo4jNodeType) + `{cloud_provider:$cloud_provider+'_org'}) -[:IS_CHILD]-> (m:` + string(neo4jNodeType) + `)
-			WHERE o.active=true
 			AND m.organization_id IS NOT NULL
 			MATCH (n:` + string(utils.NEO4J_CLOUD_COMPLIANCE_SCAN) + `)-[:SCANNED]->(m)
-			RETURN count(distinct n)`
+			RETURN count(distinct m)`
 
 			success_count_query = `
 			MATCH (o:` + string(neo4jNodeType) + `{cloud_provider:$cloud_provider+'_org'}) -[:IS_CHILD]-> (m:` + string(neo4jNodeType) + `)
@@ -307,9 +307,8 @@ func CachePostureProviders(ctx context.Context, task *asynq.Task) error {
 
 			scan_count_query = `
 			MATCH (m:` + string(neo4jNodeType) + `{cloud_provider: $cloud_provider})
-			WHERE m.active=true
 			MATCH (n:` + string(utils.NEO4J_CLOUD_COMPLIANCE_SCAN) + `)-[:SCANNED]->(m)
-			RETURN count(distinct n)`
+			RETURN count(distinct m)`
 
 			success_count_query = `
 			MATCH (m:` + string(neo4jNodeType) + `{cloud_provider: $cloud_provider})

--- a/deepfence_worker/ingesters/common.go
+++ b/deepfence_worker/ingesters/common.go
@@ -120,14 +120,28 @@ func statusesToMaps[T any](data []T) []map[string]interface{} {
 	statusBuff := map[string]map[string]interface{}{}
 	for _, i := range data {
 		new := ToMap(i)
-		scan_id := new["scan_id"].(string)
-		new_status := new["scan_status"].(string)
+
+		scan_id, ok := new["scan_id"].(string)
+		if !ok {
+			log.Error().Msgf("failed to convert scan_id to string, data: %v", new)
+			continue
+		}
+
+		new_status, ok := new["scan_status"].(string)
+		if !ok {
+			log.Error().Msgf("failed to convert scan_status to string, data: %v", new)
+			continue
+		}
 
 		old, found := statusBuff[scan_id]
 		if !found {
 			statusBuff[scan_id] = new
 		} else {
-			old_status := old["scan_status"].(string)
+			old_status, ok := old["scan_status"].(string)
+			if !ok {
+				log.Error().Msgf("failed to convert scan_status to string, data: %v", old)
+				continue
+			}
 			if new_status != old_status {
 				if new_status == utils.SCAN_STATUS_SUCCESS ||
 					new_status == utils.SCAN_STATUS_FAILED || new_status == utils.SCAN_STATUS_CANCELLED {
@@ -149,7 +163,13 @@ func splitInprogressStatus(data []map[string]interface{}) ([]map[string]interfac
 	others := []map[string]interface{}{}
 
 	for i := range data {
-		if data[i]["scan_status"].(string) == utils.SCAN_STATUS_INPROGRESS {
+		status, ok := data[i]["scan_status"].(string)
+		if !ok {
+			log.Error().Msgf("failed to convert scan_status to string, data: %v", data[i])
+			continue
+		}
+
+		if status == utils.SCAN_STATUS_INPROGRESS {
 			in_progress = append(in_progress, data[i])
 		} else {
 			others = append(others, data[i])
@@ -173,7 +193,13 @@ func anyCompleted(data []map[string]interface{}) bool {
 	complete := false
 
 	for i := range data {
-		if data[i]["scan_status"].(string) == utils.SCAN_STATUS_SUCCESS {
+		status, ok := data[i]["scan_status"].(string)
+		if !ok {
+			log.Error().Msgf("failed to convert scan_status to string, data: %v", data[i])
+			continue
+		}
+
+		if status == utils.SCAN_STATUS_SUCCESS {
 			complete = true
 			break
 		}


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:
- `scan_count` should be number of accounts which are scanned irrespective of active or inactive accounts 
- trigger `CachePostureProviders` task on detecting compliance scan success, this fixes the delay in sync of cached posture counts
-
