### PR TITLE
feat: Option to specify queues processed by worker

### DIFF
--- a/deepfence_worker/controls/controls.go
+++ b/deepfence_worker/controls/controls.go
@@ -107,7 +107,7 @@ func GetRegisterControlFunc[T ctl.StartVulnerabilityScanRequest | ctl.StartSecre
 
 	controlFunc := func(ctx context.Context, req T) error {
 		BinArgs := ctl.GetBinArgs(req)
-		log.Info().Msgf("%s payload: %+v", task, BinArgs)
+		log.Info().Msgf("enqueue %s payload: %+v", task, BinArgs)
 		data, err := json.Marshal(BinArgs)
 		if err != nil {
 			log.Error().Msg(err.Error())

--- a/deepfence_worker/main.go
+++ b/deepfence_worker/main.go
@@ -40,6 +40,7 @@ type config struct {
 	RedisPort             string   `default:"6379" split_words:"true"`
 	RedisPassword         string   `default:"" split_words:"true"`
 	TasksConcurrency      int      `default:"50" split_words:"true"`
+	ProcessQueues         []string `split_words:"true"`
 }
 
 // build info

--- a/deepfence_worker/worker.go
+++ b/deepfence_worker/worker.go
@@ -22,6 +22,14 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 )
 
+var (
+	DefaultQueues = map[string]int{
+		utils.Q_CRITICAL: 6,
+		utils.Q_DEFAULT:  3,
+		utils.Q_LOW:      1,
+	}
+)
+
 type Worker struct {
 	cfg       config
 	mux       *asynq.ServeMux
@@ -104,29 +112,43 @@ func NewWorker(ns directory.NamespaceID, cfg config) (Worker, context.CancelFunc
 	ingestC := make(chan *kgo.Record, 10000)
 	go utils.StartKafkaProducer(kafkaCtx, cfg.KafkaBrokers, ingestC)
 
+	// worker config
+	qCfg := asynq.Config{
+		StrictPriority: true,
+		Concurrency:    cfg.TasksConcurrency,
+		ErrorHandler: asynq.ErrorHandlerFunc(func(ctx context.Context, task *asynq.Task, err error) {
+			retried, _ := asynq.GetRetryCount(ctx)
+			maxRetry, _ := asynq.GetMaxRetry(ctx)
+			if retried >= maxRetry {
+				err = fmt.Errorf("retry exhausted for task %s: %w", task.Type(), err)
+			}
+			log.Error().Err(err).Msgf("worker task %s, payload: %s", task.Type(), task.Payload())
+		}),
+	}
+
+	if len(cfg.ProcessQueues) > 0 {
+		log.Info().Msgf("process mesages from queues %s", cfg.ProcessQueues)
+		processQueues := map[string]int{}
+		for _, qName := range cfg.ProcessQueues {
+			if val, found := DefaultQueues[qName]; found {
+				processQueues[qName] = val
+			} else {
+				log.Error().Msgf("unknown queue name %s", qName)
+			}
+		}
+		qCfg.Queues = processQueues
+	} else {
+		log.Info().Msg("process messages from all queues")
+		qCfg.Queues = DefaultQueues
+	}
+
 	srv := asynq.NewServer(
 		asynq.RedisClientOpt{
 			Addr:     fmt.Sprintf("%s:%s", cfg.RedisHost, cfg.RedisPort),
 			DB:       cfg.RedisDbNumber,
 			Password: cfg.RedisPassword,
 		},
-		asynq.Config{
-			StrictPriority: true,
-			Concurrency:    cfg.TasksConcurrency,
-			Queues: map[string]int{
-				utils.Q_CRITICAL: 6,
-				utils.Q_DEFAULT:  3,
-				utils.Q_LOW:      1,
-			},
-			ErrorHandler: asynq.ErrorHandlerFunc(func(ctx context.Context, task *asynq.Task, err error) {
-				retried, _ := asynq.GetRetryCount(ctx)
-				maxRetry, _ := asynq.GetMaxRetry(ctx)
-				if retried >= maxRetry {
-					err = fmt.Errorf("retry exhausted for task %s: %w", task.Type(), err)
-				}
-				log.Error().Err(err).Msgf("worker task %s, payload: %s", task.Type(), task.Payload())
-			}),
-		},
+		qCfg,
 	)
 
 	mux := asynq.NewServeMux()


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:
- Option to specify queues processed by worker

example 
setting env var `DEEPFENCE_PROCESS_QUEUES: "low" ` worker will process messages only from queue named low
