### PR TITLE
fix: convert unix time to utc time string in xlsx reports

### DIFF
--- a/deepfence_worker/tasks/reports/xlsx.go
+++ b/deepfence_worker/tasks/reports/xlsx.go
@@ -145,13 +145,14 @@ func vulnerabilityXLSX(ctx context.Context, params utils.ReportParams) (string, 
 
 	offset := 0
 	for _, nodeScanData := range data.NodeWiseData.ScanData {
+		updatedAt := time.UnixMilli(nodeScanData.ScanInfo.UpdatedAt).String()
 		for i, v := range nodeScanData.ScanResults {
 			cellName, err := excelize.CoordinatesToCellName(1, offset+i+2)
 			if err != nil {
 				log.Error().Err(err).Msg("error generating cell name")
 			}
 			value := []interface{}{
-				time.UnixMilli(nodeScanData.ScanInfo.UpdatedAt).String(),
+				updatedAt,
 				v.Cve_attack_vector,
 				v.Cve_caused_by_package,
 				nodeScanData.ScanInfo.NodeName,
@@ -290,13 +291,14 @@ func complianceXLSX(ctx context.Context, params utils.ReportParams) (string, err
 
 	offset := 0
 	for _, nodeScanData := range data.NodeWiseData.ScanData {
+		updatedAt := time.UnixMilli(nodeScanData.ScanInfo.UpdatedAt).String()
 		for i, c := range nodeScanData.ScanResults {
 			cellName, err := excelize.CoordinatesToCellName(1, offset+i+2)
 			if err != nil {
 				log.Error().Err(err).Msg("error generating cell name")
 			}
 			value := []interface{}{
-				time.UnixMilli(nodeScanData.ScanInfo.UpdatedAt).String(),
+				updatedAt,
 				c.ComplianceCheckType,
 				"",
 				"",
@@ -340,13 +342,14 @@ func cloudComplianceXLSX(ctx context.Context, params utils.ReportParams) (string
 	xlsxSetHeader(xlsx, "Sheet1", complianceHeader)
 
 	for _, data := range data.NodeWiseData.ScanData {
+		updatedAt := time.UnixMilli(data.ScanInfo.UpdatedAt).String()
 		for i, c := range data.ScanResults {
 			cellName, err := excelize.CoordinatesToCellName(1, i+2)
 			if err != nil {
 				log.Error().Err(err).Msg("error generating cell name")
 			}
 			value := []interface{}{
-				time.UnixMilli(data.ScanInfo.UpdatedAt).String(),
+				updatedAt,
 				c.ComplianceCheckType,
 				"",
 				"",

--- a/deepfence_worker/tasks/reports/xlsx.go
+++ b/deepfence_worker/tasks/reports/xlsx.go
@@ -3,6 +3,7 @@ package reports
 import (
 	"context"
 	"os"
+	"time"
 
 	"github.com/deepfence/ThreatMapper/deepfence_utils/log"
 	"github.com/deepfence/ThreatMapper/deepfence_utils/utils"
@@ -150,7 +151,7 @@ func vulnerabilityXLSX(ctx context.Context, params utils.ReportParams) (string, 
 				log.Error().Err(err).Msg("error generating cell name")
 			}
 			value := []interface{}{
-				nodeScanData.ScanInfo.UpdatedAt,
+				time.UnixMilli(nodeScanData.ScanInfo.UpdatedAt).String(),
 				v.Cve_attack_vector,
 				v.Cve_caused_by_package,
 				nodeScanData.ScanInfo.NodeName,
@@ -295,7 +296,7 @@ func complianceXLSX(ctx context.Context, params utils.ReportParams) (string, err
 				log.Error().Err(err).Msg("error generating cell name")
 			}
 			value := []interface{}{
-				nodeScanData.ScanInfo.UpdatedAt,
+				time.UnixMilli(nodeScanData.ScanInfo.UpdatedAt).String(),
 				c.ComplianceCheckType,
 				"",
 				"",
@@ -345,7 +346,7 @@ func cloudComplianceXLSX(ctx context.Context, params utils.ReportParams) (string
 				log.Error().Err(err).Msg("error generating cell name")
 			}
 			value := []interface{}{
-				data.ScanInfo.UpdatedAt,
+				time.UnixMilli(data.ScanInfo.UpdatedAt).String(),
 				c.ComplianceCheckType,
 				"",
 				"",


### PR DESCRIPTION
Fixes #
- convert unix time to utc time string in xlsx reports timestamp columns 

