### PR TITLE
fix: make kafka broker metadataloader less verbose

### DIFF
--- a/deepfence_kafka/kafka-broker-Dockerfile
+++ b/deepfence_kafka/kafka-broker-Dockerfile
@@ -24,7 +24,8 @@ ENV KAFKA_BROKER_ID=1 \
     KAFKA_LOG_RETENTION_MS=86400000 \
     KAFKA_LOG_RETENTION_BYTES=-1 \
     KAFKA_MESSAGE_MAX_BYTES=52428800 \
-    KAFKA_AUTO_CREATE_TOPICS_ENABLE='false'
+    KAFKA_AUTO_CREATE_TOPICS_ENABLE='false' \
+    KAFKA_LOG4J_LOGGERS='org.apache.kafka.image.loader.MetadataLoader=WARN'
 
 COPY kafka_update_run.sh /home/appuser/kafka_update_run.sh
 CMD ["bash","-c", "/home/appuser/kafka_update_run.sh" ]


### PR DESCRIPTION
Fixes #

kafka broker generates below continuously, this changes log level for metadata loader to warn
```
handleSnapshot: generated a metadata delta from a snapshot at offset 66640 in 26 us
```

