### PR TITLE
Compile fluent-bit plugins with go1.20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ bootstrap:
 alpine_builder:
 	docker build --tag=$(IMAGE_REPOSITORY)/deepfence_builder_ce:$(DF_IMG_TAG) -f docker_builders/Dockerfile-alpine .
 
+.PHONY: go1_20_builder
+go1_20_builder:
+	docker build --tag=$(IMAGE_REPOSITORY)/deepfence_go_builder_ce:$(DF_IMG_TAG) -f docker_builders/Dockerfile-debianfluent-bit .
+
 .PHONY: debian_builder
 debian_builder:
 	docker build --build-arg DF_IMG_TAG=${DF_IMG_TAG} --build-arg IMAGE_REPOSITORY=${IMAGE_REPOSITORY} --tag=$(IMAGE_REPOSITORY)/deepfence_glibc_builder_ce:$(DF_IMG_TAG) -f docker_builders/Dockerfile-debian .
@@ -44,7 +48,7 @@ bootstrap-agent-plugins:
 	(cd $(MALWARE_SCANNER_DIR) && bash bootstrap.sh)
 
 .PHONY: agent
-agent: debian_builder deepfenced console_plugins
+agent: go1_20_builder debian_builder deepfenced console_plugins
 	(cd $(DEEPFENCE_AGENT_DIR) &&\
 	IMAGE_REPOSITORY="$(IMAGE_REPOSITORY)" DF_IMG_TAG="$(DF_IMG_TAG)" bash build.sh)
 

--- a/deepfence_agent/build.sh
+++ b/deepfence_agent/build.sh
@@ -16,7 +16,7 @@ building_image(){
     fi
 
     echo "Prepare Fluentbit"
-    docker run --rm --workdir /go/src/github.com/deepfence/deepfence_agent  -v $(pwd)/../golang_deepfence_sdk:/go/src/github.com/deepfence/golang_deepfence_sdk -v $(pwd)/../deepfence_utils:/go/src/github.com/deepfence/deepfence_utils -v $(pwd):/go/src/github.com/deepfence/deepfence_agent:rw --net=host $IMAGE_REPOSITORY/deepfence_glibc_builder_ce:$DF_IMG_TAG bash -c "\
+    docker run --rm --workdir /go/src/github.com/deepfence/deepfence_agent  -v $(pwd)/../golang_deepfence_sdk:/go/src/github.com/deepfence/golang_deepfence_sdk -v $(pwd)/../deepfence_utils:/go/src/github.com/deepfence/deepfence_utils -v $(pwd):/go/src/github.com/deepfence/deepfence_agent:rw --net=host $IMAGE_REPOSITORY/deepfence_go_builder_ce:$DF_IMG_TAG bash -c "\
         mkdir -p plugins/fluent-bit/build && \
         cd plugins/fluent-bit/build && \
         cmake \
@@ -41,7 +41,7 @@ building_image(){
     fi
 
     echo "Building Fluentbit deepfence output plugin"
-    docker run --rm --workdir /go/src/github.com/deepfence/deepfence_agent  -v $(pwd)/../golang_deepfence_sdk:/go/src/github.com/deepfence/golang_deepfence_sdk -v $(pwd)/../deepfence_utils:/go/src/github.com/deepfence/deepfence_utils -v $(pwd):/go/src/github.com/deepfence/deepfence_agent:rw --net=host $IMAGE_REPOSITORY/deepfence_glibc_builder_ce:$DF_IMG_TAG bash -c "cd plugins/fluent-bit/plugins/out_deepfence && make out_deepfence.a"
+    docker run --rm --workdir /go/src/github.com/deepfence/deepfence_agent  -v $(pwd)/../golang_deepfence_sdk:/go/src/github.com/deepfence/golang_deepfence_sdk -v $(pwd)/../deepfence_utils:/go/src/github.com/deepfence/deepfence_utils -v $(pwd):/go/src/github.com/deepfence/deepfence_agent:rw --net=host $IMAGE_REPOSITORY/deepfence_go_builder_ce:$DF_IMG_TAG bash -c "cd plugins/fluent-bit/plugins/out_deepfence && make out_deepfence.a"
     build_result=$?
     if [ $build_result -ne 0 ]
     then
@@ -50,7 +50,7 @@ building_image(){
     fi
 
     echo "Building Fluentbit"
-    docker run --rm --workdir /go/src/github.com/deepfence/deepfence_agent  -v $(pwd)/../golang_deepfence_sdk:/go/src/github.com/deepfence/golang_deepfence_sdk -v $(pwd)/../deepfence_utils:/go/src/github.com/deepfence/deepfence_utils -v $(pwd):/go/src/github.com/deepfence/deepfence_agent:rw --net=host $IMAGE_REPOSITORY/deepfence_glibc_builder_ce:$DF_IMG_TAG bash -c "cd plugins/fluent-bit/build \
+    docker run --rm --workdir /go/src/github.com/deepfence/deepfence_agent  -v $(pwd)/../golang_deepfence_sdk:/go/src/github.com/deepfence/golang_deepfence_sdk -v $(pwd)/../deepfence_utils:/go/src/github.com/deepfence/deepfence_utils -v $(pwd):/go/src/github.com/deepfence/deepfence_agent:rw --net=host $IMAGE_REPOSITORY/deepfence_go_builder_ce:$DF_IMG_TAG bash -c "cd plugins/fluent-bit/build \
         && make flb-plugin-out_deepfence\
         && cp ../plugins/out_deepfence/out_deepfence.a ./library/libflb-plugin-out_deepfence.a\
         && make"

--- a/docker_builders/Dockerfile-debianfluent-bit
+++ b/docker_builders/Dockerfile-debianfluent-bit
@@ -1,0 +1,43 @@
+ARG VECTORSCAN_IMG_TAG=latest
+ARG VECTORSCAN_IMAGE_REPOSITORY=deepfenceio
+FROM $VECTORSCAN_IMAGE_REPOSITORY/deepfence_vectorscan_build:$VECTORSCAN_IMG_TAG AS vectorscan
+
+ARG DF_IMG_TAG=latest
+ARG IMAGE_REPOSITORY=deepfenceio
+
+FROM golang:1.21-bookworm
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update
+RUN apt-get install -y
+RUN apt-get -qq -y --no-install-recommends install \
+    build-essential automake libtool make gcc pkg-config libssl-dev git protoc-gen-go \
+    bash make git gcc libc-dev lsb-release software-properties-common libz-dev apt-utils\
+    protobuf-compiler ca-certificates libpcap-dev time file shellcheck curl \
+    libjansson-dev libmagic-dev \
+    cmake flex bison libyaml-dev
+
+RUN cd /root  \
+    && wget https://github.com/VirusTotal/yara/archive/refs/tags/v4.3.2.tar.gz \
+    && tar -zxf v4.3.2.tar.gz \
+    && cd yara-4.3.2 \
+    && ./bootstrap.sh \
+    && ./configure --prefix=/usr/local/yara --disable-dotnet --enable-magic --enable-cuckoo \
+    && make \
+    && make install \
+    && cd /usr/local/ \
+    && tar -czf yara.tar.gz yara
+
+COPY --from=vectorscan /vectorscan.tar.bz2 /
+RUN tar -xjf /vectorscan.tar.bz2 -C / && rm /vectorscan.tar.bz2
+
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.30.0
+RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3.0
+
+RUN mkdir /home/deepfence
+COPY deepfence_agent/build_scripts/*.sh /home/deepfence/
+
+ARG DF_AGENT_SRC=/go/src/github.com/deepfence/deepfence_agent
+WORKDIR $DF_AGENT_SRC
+
+ENV GOWORK=off


### PR DESCRIPTION
Following issue on https://github.com/golang/go/issues/62440 we cannot use go 1.21 yet to compile fluent-bit plugins.
This temporary fix add go1.20 builder specifically for fluentbit compilation.
