### PR TITLE
Remove never scanned from scans

### DIFF
--- a/deepfence_frontend/apps/dashboard/src/features/malwares/pages/MalwareScans.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/malwares/pages/MalwareScans.tsx
@@ -443,6 +443,9 @@ const Filters = () => {
           getDisplayValue={() => FILTER_SEARCHPARAMS['malwareScanStatus']}
         >
           {SCAN_STATUS_GROUPS.filter((item) => {
+            if (item.value === 'neverScanned') {
+              return false;
+            }
             if (!malwareScanStatusSearchText.length) return true;
             return item.label
               .toLowerCase()

--- a/deepfence_frontend/apps/dashboard/src/features/postures/pages/PostureCloudScanResults.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/postures/pages/PostureCloudScanResults.tsx
@@ -1570,7 +1570,7 @@ const StatusesCount = ({
 }) => {
   return (
     <div className="col-span-6">
-      <div className="gap-24 flex justify-center">
+      <div className="flex justify-evenly gap-8">
         {Object.keys(statusCounts)?.map((key: string) => {
           return (
             <div key={key} className="col-span-2 dark:text-text-text-and-icon">

--- a/deepfence_frontend/apps/dashboard/src/features/postures/pages/PostureScanResults.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/postures/pages/PostureScanResults.tsx
@@ -1523,7 +1523,7 @@ const StatusesCount = ({
 }) => {
   return (
     <div className="col-span-6">
-      <div className="gap-24 flex justify-center">
+      <div className="flex justify-evenly gap-8">
         {Object.keys(statusCounts)?.map((key: string) => {
           return (
             <div key={key} className="col-span-2 dark:text-text-text-and-icon">

--- a/deepfence_frontend/apps/dashboard/src/features/secrets/pages/SecretScans.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/secrets/pages/SecretScans.tsx
@@ -444,6 +444,9 @@ const Filters = () => {
           getDisplayValue={() => FILTER_SEARCHPARAMS['secretScanStatus']}
         >
           {SCAN_STATUS_GROUPS.filter((item) => {
+            if (item.value === 'neverScanned') {
+              return false;
+            }
             if (!secretScanStatusSearchText.length) return true;
             return item.label
               .toLowerCase()

--- a/deepfence_frontend/apps/dashboard/src/features/vulnerabilities/pages/VulnerabilityScans.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/vulnerabilities/pages/VulnerabilityScans.tsx
@@ -946,6 +946,9 @@ const Filters = () => {
           getDisplayValue={() => FILTER_SEARCHPARAMS['vulnerabilityScanStatus']}
         >
           {SCAN_STATUS_GROUPS.filter((item) => {
+            if (item.value === 'neverScanned') {
+              return false;
+            }
             if (!vulnerabilityScanStatusSearchText.length) return true;
             return item.label
               .toLowerCase()


### PR DESCRIPTION
Fixes
https://github.com/deepfence/enterprise-roadmap/issues/2029
https://github.com/deepfence/ThreatMapper/issues/1752

Changes proposed in this pull request:
- Adjust vertical separator in compliance and cloud compliance scan result
- Remove scan status never from vulnerability, secret and malware
