### PR TITLE
Add async job to bulk delete scan instead of http sync delete

### DIFF
--- a/deepfence_utils/utils/constants.go
+++ b/deepfence_utils/utils/constants.go
@@ -55,6 +55,7 @@ const (
 	StopVulnerabilityScanTask         = "task_stop_vulnerability_scan"
 	UpdateCloudResourceScanStatusTask = "update_cloud_resource_scan_status"
 	UpdatePodScanStatusTask           = "update_pod_scan_status"
+	BulkDeleteScans                   = "bulk_delete_scans"
 )
 
 const (
@@ -218,6 +219,10 @@ const (
 	ReportPDF  ReportType = "pdf"
 )
 
+// mask_global : This is to mask gobally. (same as previous mask_across_hosts_and_images flag)
+// mask_all_image_tag: This is to mask for all tags of an image.
+// mask_entity: This is to mask for an entity other than container/container image. E.g. Host.
+// mask_image_tag: This is to apply mask for an image and tag.
 const (
 	MASK_GLOBAL        = "mask_global"
 	MASK_ALL_IMAGE_TAG = "mask_all_image_tag"

--- a/deepfence_worker/processors/common.go
+++ b/deepfence_worker/processors/common.go
@@ -176,6 +176,7 @@ func StartKafkaConsumers(
 		kgo.ClientID(group),
 		kgo.FetchMinBytes(1e3),
 		kgo.WithLogger(kgoLogger),
+		kgo.ConsumeResetOffset(kgo.NewOffset().AtStart()),
 	}
 
 	kc, err := kgo.NewClient(opts...)

--- a/deepfence_worker/tasks/scans/bulk_delete.go
+++ b/deepfence_worker/tasks/scans/bulk_delete.go
@@ -1,0 +1,48 @@
+package scans
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/deepfence/ThreatMapper/deepfence_server/model"
+	reporters_scan "github.com/deepfence/ThreatMapper/deepfence_server/reporters/scan"
+	"github.com/deepfence/ThreatMapper/deepfence_utils/directory"
+	"github.com/deepfence/ThreatMapper/deepfence_utils/utils"
+
+	"github.com/hibiken/asynq"
+	"github.com/rs/zerolog/log"
+)
+
+func BulkDeleteScans(ctx context.Context, task *asynq.Task) error {
+
+	var req model.BulkDeleteScansRequest
+	err := json.Unmarshal(task.Payload(), &req)
+	if err != nil {
+		return err
+	}
+
+	scanType := utils.DetectedNodeScanType[req.ScanType]
+	scansList, err := reporters_scan.GetScansList(ctx, scanType, nil, req.Filters, model.FetchWindow{})
+	if err != nil {
+		return err
+	}
+
+	for _, s := range scansList.ScansInfo {
+		log.Info().Msgf("delete scan %s %s", req.ScanType, s.ScanId)
+		err = reporters_scan.DeleteScan(ctx, scanType, s.ScanId, []string{})
+		if err != nil {
+			log.Error().Err(err).Msgf("failed to delete scan id %s", s.ScanId)
+			continue
+		}
+	}
+
+	if len(scansList.ScansInfo) > 0 && (scanType == utils.NEO4J_COMPLIANCE_SCAN || scanType == utils.NEO4J_CLOUD_COMPLIANCE_SCAN) {
+		worker, err := directory.Worker(ctx)
+		if err != nil {
+			return err
+		}
+		return worker.Enqueue(utils.CachePostureProviders, []byte{}, utils.CritialTaskOpts()...)
+	}
+
+	return nil
+}

--- a/deepfence_worker/worker.go
+++ b/deepfence_worker/worker.go
@@ -216,5 +216,7 @@ func NewWorker(ns directory.NamespaceID, cfg config) (Worker, context.CancelFunc
 
 	worker.AddRetryableHandler(utils.UpdatePodScanStatusTask, scans.UpdatePodScanStatus)
 
+	worker.AddOneShotHandler(utils.BulkDeleteScans, scans.BulkDeleteScans)
+
 	return worker, cancel, nil
 }


### PR DESCRIPTION
Fixes https://github.com/deepfence/ThreatMapper/issues/1761

Changes proposed in this pull request:
- Add async job to bulk delete scan instead of http sync delete
-
-
