### PR TITLE
Change delete scan history message

### DIFF
--- a/deepfence_frontend/apps/dashboard/src/features/settings/pages/ScanHistoryAndDbManagement.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/settings/pages/ScanHistoryAndDbManagement.tsx
@@ -214,7 +214,7 @@ const DeleteConfirmationModal = ({
           )}
         </div>
       ) : (
-        <SuccessModalContent text="Successfully deleted" />
+        <SuccessModalContent text="Delete requested successfully" />
       )}
     </Modal>
   );


### PR DESCRIPTION
Changes proposed in this pull request:
- Scan history deletion is now async, this change updates the success message upon scan history deletion accordingly.