### PR TITLE
Registry image listing for report creation and disabled dropdown item

### DIFF
--- a/deepfence_frontend/apps/dashboard/src/features/integrations/components/report-form/AdvanceFilter.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/integrations/components/report-form/AdvanceFilter.tsx
@@ -122,7 +122,7 @@ export const AdvancedFilter = ({
                     onClearAll={() => {
                       setImages([]);
                     }}
-                    active={false}
+                    active={!deadNodes}
                   />
                 </div>
               </>

--- a/deepfence_frontend/apps/dashboard/src/features/postures/pages/Accounts.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/postures/pages/Accounts.tsx
@@ -546,7 +546,7 @@ const ActionDropdown = ({
           <>
             <DropdownItem
               disabled={isScanInProgress(scanStatus) || isScanStopping(scanStatus)}
-              onClick={() => {
+              onSelect={() => {
                 if (!nodeId) {
                   throw new Error('Node id is required to start scan');
                 }
@@ -586,6 +586,7 @@ const ActionDropdown = ({
               <span
                 className={cn('flex items-center gap-x-2', {
                   'text-red-700 dark:text-status-error': scanId,
+                  'dark:text-df-gray-600': !scanId || !nodeType,
                 })}
               >
                 Delete latest scan

--- a/deepfence_frontend/apps/dashboard/src/features/vulnerabilities/pages/VulnerabilityScans.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/vulnerabilities/pages/VulnerabilityScans.tsx
@@ -9,6 +9,7 @@ import {
   useSearchParams,
 } from 'react-router-dom';
 import { toast } from 'sonner';
+import { cn } from 'tailwind-preset';
 import {
   Badge,
   Breadcrumb,
@@ -415,7 +416,11 @@ const ActionDropdown = ({
               }}
               disabled={isScanInProgress(scanStatus)}
             >
-              <span className="flex items-center text-red-700 dark:text-status-error">
+              <span
+                className={cn('flex items-center text-red-700 dark:text-status-error', {
+                  'dark:text-df-gray-600': isScanInProgress(scanStatus),
+                })}
+              >
                 Delete
               </span>
             </DropdownItem>


### PR DESCRIPTION
Fixes 
https://github.com/deepfence/ThreatMapper/issues/1757
https://github.com/deepfence/enterprise-roadmap/issues/2010

Changes proposed in this pull request:
- Fix listing registry images for non active images
- Fix disabled dropdown item was able to click
