### PR TITLE
Base64 encode the api token

### DIFF
--- a/deepfence_server/handler/auth.go
+++ b/deepfence_server/handler/auth.go
@@ -34,6 +34,7 @@ func (h *Handler) APIAuthHandler(w http.ResponseWriter, r *http.Request) {
 		h.respondError(&BadDecoding{err}, w)
 		return
 	}
+	apiAuthRequest.APIToken, _ = utils.Base64RawDecode(apiAuthRequest.APIToken)
 	err = h.Validator.Struct(apiAuthRequest)
 	if err != nil {
 		h.respondError(&ValidatorError{err: err}, w)

--- a/deepfence_server/model/user.go
+++ b/deepfence_server/model/user.go
@@ -52,7 +52,7 @@ type APITokenResponse struct {
 }
 
 func GetAPIToken(namespace string, apiToken uuid.UUID) string {
-	return namespace + ":" + apiToken.String()
+	return utils.Base64RawEncode(namespace + ":" + apiToken.String())
 }
 
 type APIToken struct {

--- a/deepfence_utils/utils/utils.go
+++ b/deepfence_utils/utils/utils.go
@@ -256,6 +256,18 @@ func ToMap[T any](c T) map[string]interface{} {
 	return bb
 }
 
+func Base64RawDecode(s string) (string, error) {
+	decodedStr, err := base64.RawStdEncoding.DecodeString(s)
+	if err != nil {
+		return s, err
+	}
+	return string(decodedStr), nil
+}
+
+func Base64RawEncode(s string) string {
+	return base64.RawStdEncoding.EncodeToString([]byte(s))
+}
+
 // FromMap Convert map[string]interface{} into structs
 // e.g:
 //


### PR DESCRIPTION
Sometimes users skip copying the namespace which is part of the api token, because it looks unusual
