### PR TITLE
Check scan status or account activeness before performing actions on scans or account

### DIFF
--- a/deepfence_frontend/apps/dashboard/src/features/malwares/pages/MalwareScans.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/malwares/pages/MalwareScans.tsx
@@ -245,28 +245,10 @@ const DeleteConfirmationModal = ({
 
 const ActionDropdown = ({
   trigger,
-  scanId,
-  nodeId,
-  scanStatus,
-  nodeType,
-  setShowDeleteDialog,
-  setScanIdToDelete,
-  setStartScanInfo,
+  row,
 }: {
   trigger: React.ReactNode;
-  scanId: string;
-  nodeId: string;
-  scanStatus: string;
-  nodeType: string;
-  setShowDeleteDialog: React.Dispatch<React.SetStateAction<boolean>>;
-  setScanIdToDelete: React.Dispatch<React.SetStateAction<string>>;
-  setStartScanInfo: React.Dispatch<
-    React.SetStateAction<{
-      start: boolean;
-      nodeId: string;
-      nodeType: string;
-    }>
-  >;
+  row: ModelScanInfo;
 }) => {
   const fetcher = useFetcher();
   const [open, setOpen] = useState(false);
@@ -275,7 +257,19 @@ const ActionDropdown = ({
     setIsSubmitting(state === 'submitting');
   });
   const [openStopScanModal, setOpenStopScanModal] = useState(false);
-
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const {
+    scan_id: scanId,
+    node_id: nodeId,
+    node_type: nodeType,
+    node_name: nodeName,
+    status: scanStatus,
+  } = row;
+  const [startScanInfo, setStartScanInfo] = useState({
+    start: false,
+    nodeId: '',
+    nodeType: '',
+  });
   const onDownloadAction = useCallback(() => {
     downloadScan({
       scanId,
@@ -299,6 +293,42 @@ const ActionDropdown = ({
         />
       )}
 
+      {showDeleteDialog && (
+        <DeleteConfirmationModal
+          showDialog={showDeleteDialog}
+          scanIds={[scanId]}
+          setShowDialog={setShowDeleteDialog}
+          onDeleteSuccess={() => {
+            //
+          }}
+        />
+      )}
+      {startScanInfo.start && (
+        <ConfigureScanModal
+          open={true}
+          onOpenChange={() =>
+            setStartScanInfo({
+              start: false,
+              nodeId: '',
+              nodeType: '',
+            })
+          }
+          scanOptions={
+            {
+              showAdvancedOptions: true,
+              scanType: ScanTypeEnum.MalwareScan,
+              data: {
+                nodes: [
+                  {
+                    nodeId: startScanInfo.nodeId,
+                    nodeType: startScanInfo.nodeType,
+                  },
+                ],
+              },
+            } as ConfigureScanModalProps['scanOptions']
+          }
+        />
+      )}
       <Dropdown
         triggerAsChild
         align="start"
@@ -332,25 +362,23 @@ const ActionDropdown = ({
             >
               <span className="flex items-center">Start scan</span>
             </DropdownItem>
-            {isScanInProgress(scanStatus) && (
-              <DropdownItem
-                onClick={(e) => {
-                  e.preventDefault();
-                  setOpenStopScanModal(true);
-                }}
-                disabled={!isScanInProgress(scanStatus)}
-              >
-                <span className="flex items-center">Cancel scan</span>
-              </DropdownItem>
-            )}
+            <DropdownItem
+              onSelect={(e) => {
+                e.preventDefault();
+                setOpenStopScanModal(true);
+              }}
+              disabled={!isScanInProgress(scanStatus)}
+            >
+              <span className="flex items-center">Cancel scan</span>
+            </DropdownItem>
             <DropdownItem
               onClick={() => {
-                setScanIdToDelete(scanId);
+                if (!scanId || !nodeType) return;
                 setShowDeleteDialog(true);
               }}
             >
               <span className="text-red-700 dark:text-status-error dark:hover:text-[#C45268]">
-                Delete
+                Delete Scan
               </span>
             </DropdownItem>
           </>
@@ -627,13 +655,6 @@ const ScansTable = ({
     keepPreviousData: true,
   });
   const [sort, setSort] = useSortingState();
-  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
-  const [scanIdToDelete, setScanIdToDelete] = useState('');
-  const [startScanInfo, setStartScanInfo] = useState({
-    start: false,
-    nodeId: '',
-    nodeType: '',
-  });
 
   const columnHelper = createColumnHelper<ScanResult>();
 
@@ -649,13 +670,7 @@ const ScansTable = ({
         enableSorting: false,
         cell: (cell) => (
           <ActionDropdown
-            scanId={cell.row.original.scan_id}
-            nodeId={cell.row.original.node_id}
-            nodeType={cell.row.original.node_type}
-            scanStatus={cell.row.original.status}
-            setScanIdToDelete={setScanIdToDelete}
-            setShowDeleteDialog={setShowDeleteDialog}
-            setStartScanInfo={setStartScanInfo}
+            row={cell.row.original}
             trigger={
               <button className="p-1 flex">
                 <span className="block h-4 w-4 dark:text-text-text-and-icon rotate-90 shrink-0">
@@ -888,42 +903,6 @@ const ScansTable = ({
 
   return (
     <>
-      {showDeleteDialog && (
-        <DeleteConfirmationModal
-          showDialog={showDeleteDialog}
-          scanIds={[scanIdToDelete]}
-          setShowDialog={setShowDeleteDialog}
-          onDeleteSuccess={() => {
-            //
-          }}
-        />
-      )}
-      {startScanInfo.start && (
-        <ConfigureScanModal
-          open={true}
-          onOpenChange={() =>
-            setStartScanInfo({
-              start: false,
-              nodeId: '',
-              nodeType: '',
-            })
-          }
-          scanOptions={
-            {
-              showAdvancedOptions: true,
-              scanType: ScanTypeEnum.MalwareScan,
-              data: {
-                nodes: [
-                  {
-                    nodeId: startScanInfo.nodeId,
-                    nodeType: startScanInfo.nodeType,
-                  },
-                ],
-              },
-            } as ConfigureScanModalProps['scanOptions']
-          }
-        />
-      )}
       <Table
         data={data.scans}
         columns={columns}
@@ -936,6 +915,7 @@ const ScansTable = ({
             nodeId: row.node_id,
             nodeType: row.node_type,
             updatedAt: row.updated_at,
+            scanStatus: row.status,
           });
         }}
         enablePagination
@@ -997,22 +977,47 @@ const ScansTable = ({
 
 const BulkActions = ({
   selectedRows,
-  setIdsToDelete,
-  setShowDeleteDialog,
-  setShowCancelScanDialog,
   setRowSelectionState,
 }: {
   selectedRows: {
     scanId: string;
     nodeId: string;
     nodeType: string;
+    scanStatus: string;
   }[];
-  setIdsToDelete: React.Dispatch<React.SetStateAction<string[]>>;
-  setShowDeleteDialog: React.Dispatch<React.SetStateAction<boolean>>;
-  setShowCancelScanDialog: React.Dispatch<React.SetStateAction<boolean>>;
   setRowSelectionState: React.Dispatch<React.SetStateAction<RowSelectionState>>;
 }) => {
   const [openStartScan, setOpenStartScan] = useState<boolean>(false);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [showCancelScanDialog, setShowCancelScanDialog] = useState(false);
+  const nodesToStartScan = useMemo(() => {
+    return selectedRows
+      .filter(
+        (row) => !isScanInProgress(row.scanStatus) && !isScanStopping(row.scanStatus),
+      )
+      .map((row) => {
+        return {
+          nodeId: row.nodeId,
+          nodeType: row.nodeType,
+        };
+      });
+  }, [selectedRows]);
+
+  const scanIdsToCancelScan = useMemo(() => {
+    return selectedRows
+      .filter((row) => isScanInProgress(row.scanStatus))
+      .map((row) => row.scanId);
+  }, [selectedRows]);
+
+  const scanIdsToDeleteScan = useMemo(() => {
+    return selectedRows
+      .filter((row) => !isNeverScanned(row.scanStatus))
+      .map((row) => row.scanId);
+  }, [selectedRows]);
+  console.log('nodesToStartScan', nodesToStartScan);
+  console.log('scanIdsToCancelScan', scanIdsToCancelScan);
+  console.log('scanIdsToDeleteScan', scanIdsToDeleteScan);
+
   return (
     <>
       {openStartScan && (
@@ -1025,23 +1030,38 @@ const BulkActions = ({
               showAdvancedOptions: true,
               scanType: ScanTypeEnum.MalwareScan,
               data: {
-                nodes: selectedRows.map((row) => {
-                  return {
-                    nodeId: row.nodeId,
-                    nodeType: row.nodeType,
-                  };
-                }),
+                nodes: nodesToStartScan,
               },
             } as ConfigureScanModalProps['scanOptions']
           }
         />
       )}
-
+      {showDeleteDialog && (
+        <DeleteConfirmationModal
+          showDialog={showDeleteDialog}
+          scanIds={scanIdsToDeleteScan}
+          setShowDialog={setShowDeleteDialog}
+          onDeleteSuccess={() => {
+            setRowSelectionState({});
+          }}
+        />
+      )}
+      {showCancelScanDialog ? (
+        <StopScanForm
+          open={showCancelScanDialog}
+          closeModal={setShowCancelScanDialog}
+          scanIds={scanIdsToCancelScan}
+          scanType={ScanTypeEnum.MalwareScan}
+          onCancelScanSuccess={() => {
+            setRowSelectionState({});
+          }}
+        />
+      ) : null}
       <Button
         color="default"
         variant="flat"
         size="sm"
-        disabled={!selectedRows.length}
+        disabled={nodesToStartScan.length == 0}
         onClick={() => {
           setOpenStartScan(true);
         }}
@@ -1052,7 +1072,7 @@ const BulkActions = ({
         color="default"
         variant="flat"
         size="sm"
-        disabled={!selectedRows.length}
+        disabled={scanIdsToCancelScan.length === 0}
         onClick={() => setShowCancelScanDialog(true)}
       >
         Cancel Scan
@@ -1062,17 +1082,12 @@ const BulkActions = ({
         variant="flat"
         startIcon={<TrashLineIcon />}
         size="sm"
-        disabled={!selectedRows.length}
+        disabled={scanIdsToDeleteScan.length === 0}
         onClick={() => {
-          setIdsToDelete(
-            selectedRows.map((row) => {
-              return row.scanId;
-            }),
-          );
           setShowDeleteDialog(true);
         }}
       >
-        Delete
+        Delete Scan
       </Button>
     </>
   );
@@ -1086,15 +1101,13 @@ const MalwareScans = () => {
   const [filtersExpanded, setFiltersExpanded] = useState(false);
 
   const [rowSelectionState, setRowSelectionState] = useState<RowSelectionState>({});
-  const [idsToDelete, setIdsToDelete] = useState<string[]>([]);
-  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
-  const [showCancelScanDialog, setShowCancelScanDialog] = useState(false);
 
   const selectedRows = useMemo<
     {
       scanId: string;
       nodeId: string;
       nodeType: string;
+      scanStatus: string;
     }[]
   >(() => {
     return Object.keys(rowSelectionState).map((item) => {
@@ -1125,9 +1138,6 @@ const MalwareScans = () => {
         <div className="h-12 flex items-center">
           <BulkActions
             selectedRows={selectedRows}
-            setIdsToDelete={setIdsToDelete}
-            setShowDeleteDialog={setShowDeleteDialog}
-            setShowCancelScanDialog={setShowCancelScanDialog}
             setRowSelectionState={setRowSelectionState}
           />
           <Button
@@ -1159,27 +1169,6 @@ const MalwareScans = () => {
             setRowSelectionState={setRowSelectionState}
           />
         </Suspense>
-        {showDeleteDialog && (
-          <DeleteConfirmationModal
-            showDialog={showDeleteDialog}
-            scanIds={idsToDelete}
-            setShowDialog={setShowDeleteDialog}
-            onDeleteSuccess={() => {
-              setRowSelectionState({});
-            }}
-          />
-        )}
-        {showCancelScanDialog ? (
-          <StopScanForm
-            open={showCancelScanDialog}
-            closeModal={setShowCancelScanDialog}
-            scanIds={selectedRows.map((row) => row.scanId)}
-            scanType={ScanTypeEnum.MalwareScan}
-            onCancelScanSuccess={() => {
-              setRowSelectionState({});
-            }}
-          />
-        ) : null}
       </div>
     </div>
   );

--- a/deepfence_frontend/apps/dashboard/src/features/malwares/pages/MalwareScans.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/malwares/pages/MalwareScans.tsx
@@ -262,14 +262,9 @@ const ActionDropdown = ({
     scan_id: scanId,
     node_id: nodeId,
     node_type: nodeType,
-    node_name: nodeName,
     status: scanStatus,
   } = row;
-  const [startScanInfo, setStartScanInfo] = useState({
-    start: false,
-    nodeId: '',
-    nodeType: '',
-  });
+  const [showStartScan, setShowStartScan] = useState(false);
   const onDownloadAction = useCallback(() => {
     downloadScan({
       scanId,
@@ -303,16 +298,10 @@ const ActionDropdown = ({
           }}
         />
       )}
-      {startScanInfo.start && (
+      {showStartScan && (
         <ConfigureScanModal
           open={true}
-          onOpenChange={() =>
-            setStartScanInfo({
-              start: false,
-              nodeId: '',
-              nodeType: '',
-            })
-          }
+          onOpenChange={() => setShowStartScan(false)}
           scanOptions={
             {
               showAdvancedOptions: true,
@@ -320,8 +309,8 @@ const ActionDropdown = ({
               data: {
                 nodes: [
                   {
-                    nodeId: startScanInfo.nodeId,
-                    nodeType: startScanInfo.nodeType,
+                    nodeId,
+                    nodeType,
                   },
                 ],
               },
@@ -352,11 +341,7 @@ const ActionDropdown = ({
               onClick={(e) => {
                 e.preventDefault();
                 if (isScanInProgress(scanStatus)) return;
-                setStartScanInfo({
-                  start: true,
-                  nodeId,
-                  nodeType,
-                });
+                setShowStartScan(true);
               }}
               disabled={isScanInProgress(scanStatus) || isScanStopping(scanStatus)}
             >
@@ -1014,9 +999,6 @@ const BulkActions = ({
       .filter((row) => !isNeverScanned(row.scanStatus))
       .map((row) => row.scanId);
   }, [selectedRows]);
-  console.log('nodesToStartScan', nodesToStartScan);
-  console.log('scanIdsToCancelScan', scanIdsToCancelScan);
-  console.log('scanIdsToDeleteScan', scanIdsToDeleteScan);
 
   return (
     <>

--- a/deepfence_frontend/apps/dashboard/src/features/secrets/pages/SecretScans.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/secrets/pages/SecretScans.tsx
@@ -262,14 +262,9 @@ const ActionDropdown = ({
     scan_id: scanId,
     node_id: nodeId,
     node_type: nodeType,
-    node_name: nodeName,
     status: scanStatus,
   } = row;
-  const [startScanInfo, setStartScanInfo] = useState({
-    start: false,
-    nodeId: '',
-    nodeType: '',
-  });
+  const [showStartScan, setShowStartScan] = useState(false);
 
   const onDownloadAction = useCallback(() => {
     downloadScan({
@@ -305,16 +300,10 @@ const ActionDropdown = ({
         />
       )}
 
-      {startScanInfo.start && (
+      {showStartScan && (
         <ConfigureScanModal
           open={true}
-          onOpenChange={() =>
-            setStartScanInfo({
-              start: false,
-              nodeId: '',
-              nodeType: '',
-            })
-          }
+          onOpenChange={() => setShowStartScan(false)}
           scanOptions={
             {
               showAdvancedOptions: true,
@@ -322,8 +311,8 @@ const ActionDropdown = ({
               data: {
                 nodes: [
                   {
-                    nodeId: startScanInfo.nodeId,
-                    nodeType: startScanInfo.nodeType,
+                    nodeId,
+                    nodeType,
                   },
                 ],
               },
@@ -355,11 +344,7 @@ const ActionDropdown = ({
               onClick={(e) => {
                 e.preventDefault();
                 if (isScanInProgress(scanStatus)) return;
-                setStartScanInfo({
-                  start: true,
-                  nodeId,
-                  nodeType,
-                });
+                setShowStartScan(true);
               }}
               disabled={isScanInProgress(scanStatus) || isScanStopping(scanStatus)}
             >
@@ -1018,9 +1003,7 @@ const BulkActions = ({
       .filter((row) => !isNeverScanned(row.scanStatus))
       .map((row) => row.scanId);
   }, [selectedRows]);
-  console.log('nodesToStartScan', nodesToStartScan);
-  console.log('scanIdsToCancelScan', scanIdsToCancelScan);
-  console.log('scanIdsToDeleteScan', scanIdsToDeleteScan);
+
   return (
     <>
       {openStartScan && (

--- a/deepfence_frontend/apps/dashboard/src/features/vulnerabilities/pages/VulnerabilityScans.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/vulnerabilities/pages/VulnerabilityScans.tsx
@@ -289,11 +289,7 @@ const ActionDropdown = ({
     status: scanStatus,
   } = row;
 
-  const [startScanInfo, setStartScanInfo] = useState({
-    start: false,
-    nodeId: '',
-    nodeType: '',
-  });
+  const [showStartScan, setShowStartScan] = useState(false);
 
   const [selectedNode, setSelectedNode] = useState<{
     nodeName: string;
@@ -351,16 +347,10 @@ const ActionDropdown = ({
         />
       )}
 
-      {startScanInfo.start && (
+      {showStartScan && (
         <ConfigureScanModal
           open={true}
-          onOpenChange={() =>
-            setStartScanInfo({
-              start: false,
-              nodeId: '',
-              nodeType: '',
-            })
-          }
+          onOpenChange={() => setShowStartScan(false)}
           scanOptions={
             {
               showAdvancedOptions: true,
@@ -368,8 +358,8 @@ const ActionDropdown = ({
               data: {
                 nodes: [
                   {
-                    nodeId: startScanInfo.nodeId,
-                    nodeType: startScanInfo.nodeType,
+                    nodeId,
+                    nodeType,
                   },
                 ],
               },
@@ -434,11 +424,7 @@ const ActionDropdown = ({
               onClick={(e) => {
                 e.preventDefault();
                 if (isScanInProgress(scanStatus)) return;
-                setStartScanInfo({
-                  start: true,
-                  nodeId,
-                  nodeType,
-                });
+                setShowStartScan(true);
               }}
               disabled={isScanInProgress(scanStatus) || isScanStopping(scanStatus)}
             >
@@ -1123,9 +1109,6 @@ const BulkActions = ({
       .map((row) => row.scanId);
   }, [selectedRows]);
 
-  console.log('nodesToStartScan', nodesToStartScan);
-  console.log('scanIdsToCancelScan', scanIdsToCancelScan);
-  console.log('scanIdsToDeleteScan', scanIdsToDeleteScan);
   return (
     <>
       {openStartScan && (

--- a/deepfence_frontend/apps/dashboard/src/features/vulnerabilities/pages/VulnerabilityScans.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/vulnerabilities/pages/VulnerabilityScans.tsx
@@ -32,6 +32,7 @@ import {
 import { getScanResultsApiClient, getVulnerabilityApiClient } from '@/api/api';
 import {
   ModelBulkDeleteScansRequestScanTypeEnum,
+  ModelScanInfo,
   UtilsReportFiltersNodeTypeEnum,
   UtilsReportFiltersScanTypeEnum,
 } from '@/api/generated';
@@ -270,42 +271,35 @@ const DeleteConfirmationModal = ({
 
 const ActionDropdown = ({
   trigger,
-  scanId,
-  nodeId,
-  nodeName,
-  scanStatus,
-  nodeType,
-  setShowDeleteDialog,
-  setScanIdToDelete,
-  setSelectedNode,
-  setStartScanInfo,
+  row,
 }: {
   trigger: React.ReactNode;
-  scanId: string;
-  nodeId: string;
-  nodeName?: string;
-  nodeType: string;
-  scanStatus: string;
-  setShowDeleteDialog: React.Dispatch<React.SetStateAction<boolean>>;
-  setScanIdToDelete: React.Dispatch<React.SetStateAction<string>>;
-  setSelectedNode: React.Dispatch<
-    React.SetStateAction<{
-      nodeName: string;
-      scanId: string;
-    } | null>
-  >;
-  setStartScanInfo: React.Dispatch<
-    React.SetStateAction<{
-      start: boolean;
-      nodeId: string;
-      nodeType: string;
-    }>
-  >;
+  row: ModelScanInfo;
 }) => {
   const fetcher = useFetcher();
   const [open, setOpen] = useState(false);
   const [openStopScanModal, setOpenStopScanModal] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const {
+    scan_id: scanId,
+    node_id: nodeId,
+    node_type: nodeType,
+    node_name: nodeName,
+    status: scanStatus,
+  } = row;
+
+  const [startScanInfo, setStartScanInfo] = useState({
+    start: false,
+    nodeId: '',
+    nodeType: '',
+  });
+
+  const [selectedNode, setSelectedNode] = useState<{
+    nodeName: string;
+    scanId: string;
+  } | null>(null);
+
   const { downloadScan } = useDownloadScan((state) => {
     setIsSubmitting(state === 'submitting');
   });
@@ -345,6 +339,54 @@ const ActionDropdown = ({
           scanType={ScanTypeEnum.VulnerabilityScan}
         />
       )}
+
+      {showDeleteDialog && (
+        <DeleteConfirmationModal
+          showDialog={showDeleteDialog}
+          scanIds={[scanId]}
+          setShowDialog={setShowDeleteDialog}
+          onDeleteSuccess={() => {
+            //
+          }}
+        />
+      )}
+
+      {startScanInfo.start && (
+        <ConfigureScanModal
+          open={true}
+          onOpenChange={() =>
+            setStartScanInfo({
+              start: false,
+              nodeId: '',
+              nodeType: '',
+            })
+          }
+          scanOptions={
+            {
+              showAdvancedOptions: true,
+              scanType: ScanTypeEnum.VulnerabilityScan,
+              data: {
+                nodes: [
+                  {
+                    nodeId: startScanInfo.nodeId,
+                    nodeType: startScanInfo.nodeType,
+                  },
+                ],
+              },
+            } as ConfigureScanModalProps['scanOptions']
+          }
+        />
+      )}
+
+      {selectedNode ? (
+        <SbomModal
+          scanId={selectedNode.scanId}
+          nodeName={selectedNode.nodeName}
+          onClose={() => {
+            setSelectedNode(null);
+          }}
+        />
+      ) : null}
 
       <Dropdown
         triggerAsChild
@@ -402,31 +444,29 @@ const ActionDropdown = ({
             >
               <span className="flex items-center">Start scan</span>
             </DropdownItem>
-            {isScanInProgress(scanStatus) && (
-              <DropdownItem
-                onClick={(e) => {
-                  e.preventDefault();
-                  setOpenStopScanModal(true);
-                }}
-                disabled={!isScanInProgress(scanStatus)}
-              >
-                <span className="flex items-center">Cancel scan</span>
-              </DropdownItem>
-            )}
+            <DropdownItem
+              onSelect={(e) => {
+                e.preventDefault();
+                setOpenStopScanModal(true);
+              }}
+              disabled={!isScanInProgress(scanStatus)}
+            >
+              <span className="flex items-center">Cancel scan</span>
+            </DropdownItem>
 
             <DropdownItem
               onClick={() => {
-                setScanIdToDelete(scanId);
+                if (!scanId || !nodeType) return;
                 setShowDeleteDialog(true);
               }}
-              disabled={isScanInProgress(scanStatus)}
+              disabled={!scanId || !nodeType}
             >
               <span
                 className={cn('flex items-center text-red-700 dark:text-status-error', {
                   'dark:text-df-gray-600': isScanInProgress(scanStatus),
                 })}
               >
-                Delete
+                Delete scan
               </span>
             </DropdownItem>
           </>
@@ -466,18 +506,6 @@ const ScansTable = ({
     keepPreviousData: true,
   });
   const [sort, setSort] = useSortingState();
-  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
-  const [startScanInfo, setStartScanInfo] = useState({
-    start: false,
-    nodeId: '',
-    nodeType: '',
-  });
-  const [scanIdToDelete, setScanIdToDelete] = useState('');
-
-  const [selectedNode, setSelectedNode] = useState<{
-    nodeName: string;
-    scanId: string;
-  } | null>(null);
 
   const columnHelper = createColumnHelper<NonNullable<typeof data>['scans'][number]>();
 
@@ -493,15 +521,7 @@ const ScansTable = ({
         enableSorting: false,
         cell: (cell) => (
           <ActionDropdown
-            scanId={cell.row.original.scan_id}
-            nodeId={cell.row.original.node_id}
-            nodeType={cell.row.original.node_type}
-            nodeName={cell.row.original.node_name}
-            scanStatus={cell.row.original.status}
-            setScanIdToDelete={setScanIdToDelete}
-            setShowDeleteDialog={setShowDeleteDialog}
-            setSelectedNode={setSelectedNode}
-            setStartScanInfo={setStartScanInfo}
+            row={cell.row.original}
             trigger={
               <button className="p-1 flex">
                 <span className="block h-4 w-4 dark:text-text-text-and-icon rotate-90 shrink-0">
@@ -751,53 +771,6 @@ const ScansTable = ({
 
   return (
     <>
-      {showDeleteDialog && (
-        <DeleteConfirmationModal
-          showDialog={showDeleteDialog}
-          scanIds={[scanIdToDelete]}
-          setShowDialog={setShowDeleteDialog}
-          onDeleteSuccess={() => {
-            //
-          }}
-        />
-      )}
-      {startScanInfo.start && (
-        <ConfigureScanModal
-          open={true}
-          onOpenChange={() =>
-            setStartScanInfo({
-              start: false,
-              nodeId: '',
-              nodeType: '',
-            })
-          }
-          scanOptions={
-            {
-              showAdvancedOptions: true,
-              scanType: ScanTypeEnum.VulnerabilityScan,
-              data: {
-                nodes: [
-                  {
-                    nodeId: startScanInfo.nodeId,
-                    nodeType: startScanInfo.nodeType,
-                  },
-                ],
-              },
-            } as ConfigureScanModalProps['scanOptions']
-          }
-        />
-      )}
-
-      {selectedNode ? (
-        <SbomModal
-          scanId={selectedNode.scanId}
-          nodeName={selectedNode.nodeName}
-          onClose={() => {
-            setSelectedNode(null);
-          }}
-        />
-      ) : null}
-
       <Table
         data={data.scans}
         columns={columns}
@@ -810,6 +783,7 @@ const ScansTable = ({
             nodeId: row.node_id,
             nodeType: row.node_type,
             updatedAt: row.updated_at,
+            scanStatus: row.status,
           });
         }}
         enablePagination
@@ -1111,22 +1085,47 @@ const Filters = () => {
 
 const BulkActions = ({
   selectedRows,
-  setIdsToDelete,
-  setShowDeleteDialog,
-  setShowCancelScanDialog,
   setRowSelectionState,
 }: {
   selectedRows: {
     scanId: string;
     nodeId: string;
     nodeType: string;
+    scanStatus: string;
   }[];
-  setIdsToDelete: React.Dispatch<React.SetStateAction<string[]>>;
-  setShowDeleteDialog: React.Dispatch<React.SetStateAction<boolean>>;
-  setShowCancelScanDialog: React.Dispatch<React.SetStateAction<boolean>>;
   setRowSelectionState: React.Dispatch<React.SetStateAction<RowSelectionState>>;
 }) => {
   const [openStartScan, setOpenStartScan] = useState<boolean>(false);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [showCancelScanDialog, setShowCancelScanDialog] = useState(false);
+  const nodesToStartScan = useMemo(() => {
+    return selectedRows
+      .filter(
+        (row) => !isScanInProgress(row.scanStatus) && !isScanStopping(row.scanStatus),
+      )
+      .map((row) => {
+        return {
+          nodeId: row.nodeId,
+          nodeType: row.nodeType,
+        };
+      });
+  }, [selectedRows]);
+
+  const scanIdsToCancelScan = useMemo(() => {
+    return selectedRows
+      .filter((row) => isScanInProgress(row.scanStatus))
+      .map((row) => row.scanId);
+  }, [selectedRows]);
+
+  const scanIdsToDeleteScan = useMemo(() => {
+    return selectedRows
+      .filter((row) => !isNeverScanned(row.scanStatus))
+      .map((row) => row.scanId);
+  }, [selectedRows]);
+
+  console.log('nodesToStartScan', nodesToStartScan);
+  console.log('scanIdsToCancelScan', scanIdsToCancelScan);
+  console.log('scanIdsToDeleteScan', scanIdsToDeleteScan);
   return (
     <>
       {openStartScan && (
@@ -1143,23 +1142,40 @@ const BulkActions = ({
               showAdvancedOptions: true,
               scanType: ScanTypeEnum.VulnerabilityScan,
               data: {
-                nodes: selectedRows.map((row) => {
-                  return {
-                    nodeId: row.nodeId,
-                    nodeType: row.nodeType,
-                  };
-                }),
+                nodes: nodesToStartScan,
               },
             } as ConfigureScanModalProps['scanOptions']
           }
         />
       )}
 
+      {showDeleteDialog && (
+        <DeleteConfirmationModal
+          showDialog={showDeleteDialog}
+          scanIds={scanIdsToDeleteScan}
+          setShowDialog={setShowDeleteDialog}
+          onDeleteSuccess={() => {
+            setRowSelectionState({});
+          }}
+        />
+      )}
+      {showCancelScanDialog ? (
+        <StopScanForm
+          open={showCancelScanDialog}
+          closeModal={setShowCancelScanDialog}
+          scanIds={scanIdsToCancelScan}
+          scanType={ScanTypeEnum.VulnerabilityScan}
+          onCancelScanSuccess={() => {
+            setRowSelectionState({});
+          }}
+        />
+      ) : null}
+
       <Button
         color="default"
         variant="flat"
         size="sm"
-        disabled={!selectedRows.length}
+        disabled={nodesToStartScan.length == 0}
         onClick={() => {
           setOpenStartScan(true);
         }}
@@ -1170,7 +1186,7 @@ const BulkActions = ({
         color="default"
         variant="flat"
         size="sm"
-        disabled={!selectedRows.length}
+        disabled={scanIdsToCancelScan.length === 0}
         onClick={() => {
           setShowCancelScanDialog(true);
         }}
@@ -1182,17 +1198,12 @@ const BulkActions = ({
         variant="flat"
         startIcon={<TrashLineIcon />}
         size="sm"
-        disabled={!selectedRows.length}
+        disabled={scanIdsToDeleteScan.length === 0}
         onClick={() => {
-          setIdsToDelete(
-            selectedRows.map((row) => {
-              return row.scanId;
-            }),
-          );
           setShowDeleteDialog(true);
         }}
       >
-        Delete
+        Delete Scan
       </Button>
     </>
   );
@@ -1206,15 +1217,12 @@ const VulnerabilityScans = () => {
   const [searchParams] = useSearchParams();
 
   const [rowSelectionState, setRowSelectionState] = useState<RowSelectionState>({});
-  const [idsToDelete, setIdsToDelete] = useState<string[]>([]);
-  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
-  const [showCancelScanDialog, setShowCancelScanDialog] = useState(false);
-
   const selectedRows = useMemo<
     {
       scanId: string;
       nodeId: string;
       nodeType: string;
+      scanStatus: string;
     }[]
   >(() => {
     return Object.keys(rowSelectionState).map((item) => {
@@ -1244,9 +1252,6 @@ const VulnerabilityScans = () => {
         <div className="h-12 flex items-center">
           <BulkActions
             selectedRows={selectedRows}
-            setIdsToDelete={setIdsToDelete}
-            setShowDeleteDialog={setShowDeleteDialog}
-            setShowCancelScanDialog={setShowCancelScanDialog}
             setRowSelectionState={setRowSelectionState}
           />
           <Button
@@ -1278,27 +1283,6 @@ const VulnerabilityScans = () => {
             setRowSelectionState={setRowSelectionState}
           />
         </Suspense>
-        {showDeleteDialog && (
-          <DeleteConfirmationModal
-            showDialog={showDeleteDialog}
-            scanIds={idsToDelete}
-            setShowDialog={setShowDeleteDialog}
-            onDeleteSuccess={() => {
-              setRowSelectionState({});
-            }}
-          />
-        )}
-        {showCancelScanDialog ? (
-          <StopScanForm
-            open={showCancelScanDialog}
-            closeModal={setShowCancelScanDialog}
-            scanIds={selectedRows.map((row) => row.scanId)}
-            scanType={ScanTypeEnum.VulnerabilityScan}
-            onCancelScanSuccess={() => {
-              setRowSelectionState({});
-            }}
-          />
-        ) : null}
       </div>
     </div>
   );


### PR DESCRIPTION


Fixes https://github.com/deepfence/enterprise-roadmap/issues/2076

Changes proposed in this pull request:
- Check scan status or account activeness before performing actions on scans or account considering statuses of scan
- Deletion of scan is allowed in all scan status except for never scanned case in posture.
