### PR TITLE
update node type column data for schedule jobs

### DIFF
--- a/deepfence_frontend/apps/dashboard/src/features/settings/pages/ScheduledJobs.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/settings/pages/ScheduledJobs.tsx
@@ -243,12 +243,23 @@ const getFormattedNodeType = (column: PostgresqlDbScheduler) => {
     node_type: string;
   }[] = column.payload?.node_ids ?? [];
 
-  const nodes = nodeIds
-    .map((node) => {
-      return upperFirst(node.node_type);
+  if (nodeIds.length === 1) {
+    return upperFirst(nodeIds[0].node_type);
+  }
+  const nodeTypeMap: Record<string, number> = {};
+  nodeIds.forEach((node) => {
+    if (nodeTypeMap[node.node_type] !== undefined) {
+      nodeTypeMap[node.node_type] = nodeTypeMap[node.node_type] + 1;
+    } else {
+      nodeTypeMap[node.node_type] = 1;
+    }
+  });
+  const nodes = Object.keys(nodeTypeMap)
+    .map((key) => {
+      const value = nodeTypeMap[key];
+      return `${value} ${upperFirst(key)}`;
     })
     .join(', ');
-
   return nodes;
 };
 


### PR DESCRIPTION
Fixes 
Repeated node type being shown.

Changes proposed in this pull request:
- update node type column data for schedule jobs eg (2 Image, 2 Container, 1 host.
