### PR TITLE
Use warn status in threat graph for posture count

### DIFF
--- a/deepfence_frontend/apps/dashboard/api-spec.json
+++ b/deepfence_frontend/apps/dashboard/api-spec.json
@@ -11640,16 +11640,20 @@
           "vulnerability_count",
           "secrets_count",
           "compliance_count",
-          "cloud_compliance_count"
+          "cloud_compliance_count",
+          "warn_alarm_count",
+          "cloud_warn_alarm_count"
         ],
         "type": "object",
         "properties": {
           "cloud_compliance_count": { "type": "integer" },
+          "cloud_warn_alarm_count": { "type": "integer" },
           "compliance_count": { "type": "integer" },
           "name": { "type": "string" },
           "node_id": { "type": "string" },
           "secrets_count": { "type": "integer" },
-          "vulnerability_count": { "type": "integer" }
+          "vulnerability_count": { "type": "integer" },
+          "warn_alarm_count": { "type": "integer" }
         }
       },
       "GraphProviderThreatGraph": {
@@ -11658,11 +11662,14 @@
           "compliance_count",
           "secrets_count",
           "vulnerability_count",
-          "cloud_compliance_count"
+          "cloud_compliance_count",
+          "warn_alarm_count",
+          "cloud_warn_alarm_count"
         ],
         "type": "object",
         "properties": {
           "cloud_compliance_count": { "type": "integer" },
+          "cloud_warn_alarm_count": { "type": "integer" },
           "compliance_count": { "type": "integer" },
           "resources": {
             "type": "array",
@@ -11670,7 +11677,8 @@
             "nullable": true
           },
           "secrets_count": { "type": "integer" },
-          "vulnerability_count": { "type": "integer" }
+          "vulnerability_count": { "type": "integer" },
+          "warn_alarm_count": { "type": "integer" }
         }
       },
       "GraphThreatFilters": {
@@ -11717,6 +11725,8 @@
           "compliance_count",
           "cloud_compliance_count",
           "count",
+          "warn_alarm_count",
+          "cloud_warn_alarm_count",
           "node_type",
           "attack_path"
         ],
@@ -11728,6 +11738,7 @@
             "nullable": true
           },
           "cloud_compliance_count": { "type": "integer" },
+          "cloud_warn_alarm_count": { "type": "integer" },
           "compliance_count": { "type": "integer" },
           "count": { "type": "integer" },
           "id": { "type": "string" },
@@ -11739,7 +11750,8 @@
             "nullable": true
           },
           "secrets_count": { "type": "integer" },
-          "vulnerability_count": { "type": "integer" }
+          "vulnerability_count": { "type": "integer" },
+          "warn_alarm_count": { "type": "integer" }
         }
       },
       "GraphTopologyFilters": {
@@ -13252,6 +13264,8 @@
           "compliances_count",
           "compliance_scan_status",
           "compliance_latest_scan_id",
+          "warn_alarm_count",
+          "cloud_warn_alarm_count",
           "inbound_connections",
           "outbound_connections"
         ],
@@ -13262,6 +13276,7 @@
           "cloud_account_id": { "type": "string" },
           "cloud_provider": { "type": "string" },
           "cloud_region": { "type": "string" },
+          "cloud_warn_alarm_count": { "type": "integer" },
           "compliance_latest_scan_id": { "type": "string" },
           "compliance_scan_status": { "type": "string" },
           "compliances_count": { "type": "integer" },
@@ -13323,7 +13338,8 @@
           "version": { "type": "string" },
           "vulnerabilities_count": { "type": "integer" },
           "vulnerability_latest_scan_id": { "type": "string" },
-          "vulnerability_scan_status": { "type": "string" }
+          "vulnerability_scan_status": { "type": "string" },
+          "warn_alarm_count": { "type": "integer" }
         }
       },
       "ModelImageStub": {

--- a/deepfence_frontend/apps/dashboard/src/api/generated/models/GraphNodeInfo.ts
+++ b/deepfence_frontend/apps/dashboard/src/api/generated/models/GraphNodeInfo.ts
@@ -30,6 +30,12 @@ export interface GraphNodeInfo {
      * @type {number}
      * @memberof GraphNodeInfo
      */
+    cloud_warn_alarm_count: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof GraphNodeInfo
+     */
     compliance_count: number;
     /**
      * 
@@ -55,6 +61,12 @@ export interface GraphNodeInfo {
      * @memberof GraphNodeInfo
      */
     vulnerability_count: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof GraphNodeInfo
+     */
+    warn_alarm_count: number;
 }
 
 /**
@@ -63,11 +75,13 @@ export interface GraphNodeInfo {
 export function instanceOfGraphNodeInfo(value: object): boolean {
     let isInstance = true;
     isInstance = isInstance && "cloud_compliance_count" in value;
+    isInstance = isInstance && "cloud_warn_alarm_count" in value;
     isInstance = isInstance && "compliance_count" in value;
     isInstance = isInstance && "name" in value;
     isInstance = isInstance && "node_id" in value;
     isInstance = isInstance && "secrets_count" in value;
     isInstance = isInstance && "vulnerability_count" in value;
+    isInstance = isInstance && "warn_alarm_count" in value;
 
     return isInstance;
 }
@@ -83,11 +97,13 @@ export function GraphNodeInfoFromJSONTyped(json: any, ignoreDiscriminator: boole
     return {
         
         'cloud_compliance_count': json['cloud_compliance_count'],
+        'cloud_warn_alarm_count': json['cloud_warn_alarm_count'],
         'compliance_count': json['compliance_count'],
         'name': json['name'],
         'node_id': json['node_id'],
         'secrets_count': json['secrets_count'],
         'vulnerability_count': json['vulnerability_count'],
+        'warn_alarm_count': json['warn_alarm_count'],
     };
 }
 
@@ -101,11 +117,13 @@ export function GraphNodeInfoToJSON(value?: GraphNodeInfo | null): any {
     return {
         
         'cloud_compliance_count': value.cloud_compliance_count,
+        'cloud_warn_alarm_count': value.cloud_warn_alarm_count,
         'compliance_count': value.compliance_count,
         'name': value.name,
         'node_id': value.node_id,
         'secrets_count': value.secrets_count,
         'vulnerability_count': value.vulnerability_count,
+        'warn_alarm_count': value.warn_alarm_count,
     };
 }
 

--- a/deepfence_frontend/apps/dashboard/src/api/generated/models/GraphProviderThreatGraph.ts
+++ b/deepfence_frontend/apps/dashboard/src/api/generated/models/GraphProviderThreatGraph.ts
@@ -37,6 +37,12 @@ export interface GraphProviderThreatGraph {
      * @type {number}
      * @memberof GraphProviderThreatGraph
      */
+    cloud_warn_alarm_count: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof GraphProviderThreatGraph
+     */
     compliance_count: number;
     /**
      * 
@@ -56,6 +62,12 @@ export interface GraphProviderThreatGraph {
      * @memberof GraphProviderThreatGraph
      */
     vulnerability_count: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof GraphProviderThreatGraph
+     */
+    warn_alarm_count: number;
 }
 
 /**
@@ -64,10 +76,12 @@ export interface GraphProviderThreatGraph {
 export function instanceOfGraphProviderThreatGraph(value: object): boolean {
     let isInstance = true;
     isInstance = isInstance && "cloud_compliance_count" in value;
+    isInstance = isInstance && "cloud_warn_alarm_count" in value;
     isInstance = isInstance && "compliance_count" in value;
     isInstance = isInstance && "resources" in value;
     isInstance = isInstance && "secrets_count" in value;
     isInstance = isInstance && "vulnerability_count" in value;
+    isInstance = isInstance && "warn_alarm_count" in value;
 
     return isInstance;
 }
@@ -83,10 +97,12 @@ export function GraphProviderThreatGraphFromJSONTyped(json: any, ignoreDiscrimin
     return {
         
         'cloud_compliance_count': json['cloud_compliance_count'],
+        'cloud_warn_alarm_count': json['cloud_warn_alarm_count'],
         'compliance_count': json['compliance_count'],
         'resources': (json['resources'] === null ? null : (json['resources'] as Array<any>).map(GraphThreatNodeInfoFromJSON)),
         'secrets_count': json['secrets_count'],
         'vulnerability_count': json['vulnerability_count'],
+        'warn_alarm_count': json['warn_alarm_count'],
     };
 }
 
@@ -100,10 +116,12 @@ export function GraphProviderThreatGraphToJSON(value?: GraphProviderThreatGraph 
     return {
         
         'cloud_compliance_count': value.cloud_compliance_count,
+        'cloud_warn_alarm_count': value.cloud_warn_alarm_count,
         'compliance_count': value.compliance_count,
         'resources': (value.resources === null ? null : (value.resources as Array<any>).map(GraphThreatNodeInfoToJSON)),
         'secrets_count': value.secrets_count,
         'vulnerability_count': value.vulnerability_count,
+        'warn_alarm_count': value.warn_alarm_count,
     };
 }
 

--- a/deepfence_frontend/apps/dashboard/src/api/generated/models/GraphThreatNodeInfo.ts
+++ b/deepfence_frontend/apps/dashboard/src/api/generated/models/GraphThreatNodeInfo.ts
@@ -43,6 +43,12 @@ export interface GraphThreatNodeInfo {
      * @type {number}
      * @memberof GraphThreatNodeInfo
      */
+    cloud_warn_alarm_count: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof GraphThreatNodeInfo
+     */
     compliance_count: number;
     /**
      * 
@@ -86,6 +92,12 @@ export interface GraphThreatNodeInfo {
      * @memberof GraphThreatNodeInfo
      */
     vulnerability_count: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof GraphThreatNodeInfo
+     */
+    warn_alarm_count: number;
 }
 
 /**
@@ -95,6 +107,7 @@ export function instanceOfGraphThreatNodeInfo(value: object): boolean {
     let isInstance = true;
     isInstance = isInstance && "attack_path" in value;
     isInstance = isInstance && "cloud_compliance_count" in value;
+    isInstance = isInstance && "cloud_warn_alarm_count" in value;
     isInstance = isInstance && "compliance_count" in value;
     isInstance = isInstance && "count" in value;
     isInstance = isInstance && "id" in value;
@@ -103,6 +116,7 @@ export function instanceOfGraphThreatNodeInfo(value: object): boolean {
     isInstance = isInstance && "nodes" in value;
     isInstance = isInstance && "secrets_count" in value;
     isInstance = isInstance && "vulnerability_count" in value;
+    isInstance = isInstance && "warn_alarm_count" in value;
 
     return isInstance;
 }
@@ -119,6 +133,7 @@ export function GraphThreatNodeInfoFromJSONTyped(json: any, ignoreDiscriminator:
         
         'attack_path': json['attack_path'],
         'cloud_compliance_count': json['cloud_compliance_count'],
+        'cloud_warn_alarm_count': json['cloud_warn_alarm_count'],
         'compliance_count': json['compliance_count'],
         'count': json['count'],
         'id': json['id'],
@@ -127,6 +142,7 @@ export function GraphThreatNodeInfoFromJSONTyped(json: any, ignoreDiscriminator:
         'nodes': (json['nodes'] === null ? null : mapValues(json['nodes'], GraphNodeInfoFromJSON)),
         'secrets_count': json['secrets_count'],
         'vulnerability_count': json['vulnerability_count'],
+        'warn_alarm_count': json['warn_alarm_count'],
     };
 }
 
@@ -141,6 +157,7 @@ export function GraphThreatNodeInfoToJSON(value?: GraphThreatNodeInfo | null): a
         
         'attack_path': value.attack_path,
         'cloud_compliance_count': value.cloud_compliance_count,
+        'cloud_warn_alarm_count': value.cloud_warn_alarm_count,
         'compliance_count': value.compliance_count,
         'count': value.count,
         'id': value.id,
@@ -149,6 +166,7 @@ export function GraphThreatNodeInfoToJSON(value?: GraphThreatNodeInfo | null): a
         'nodes': (value.nodes === null ? null : mapValues(value.nodes, GraphNodeInfoToJSON)),
         'secrets_count': value.secrets_count,
         'vulnerability_count': value.vulnerability_count,
+        'warn_alarm_count': value.warn_alarm_count,
     };
 }
 

--- a/deepfence_frontend/apps/dashboard/src/api/generated/models/ModelHost.ts
+++ b/deepfence_frontend/apps/dashboard/src/api/generated/models/ModelHost.ts
@@ -82,6 +82,12 @@ export interface ModelHost {
     cloud_region: string;
     /**
      * 
+     * @type {number}
+     * @memberof ModelHost
+     */
+    cloud_warn_alarm_count: number;
+    /**
+     * 
      * @type {string}
      * @memberof ModelHost
      */
@@ -308,6 +314,12 @@ export interface ModelHost {
      * @memberof ModelHost
      */
     vulnerability_scan_status: string;
+    /**
+     * 
+     * @type {number}
+     * @memberof ModelHost
+     */
+    warn_alarm_count: number;
 }
 
 /**
@@ -320,6 +332,7 @@ export function instanceOfModelHost(value: object): boolean {
     isInstance = isInstance && "cloud_account_id" in value;
     isInstance = isInstance && "cloud_provider" in value;
     isInstance = isInstance && "cloud_region" in value;
+    isInstance = isInstance && "cloud_warn_alarm_count" in value;
     isInstance = isInstance && "compliance_latest_scan_id" in value;
     isInstance = isInstance && "compliance_scan_status" in value;
     isInstance = isInstance && "compliances_count" in value;
@@ -358,6 +371,7 @@ export function instanceOfModelHost(value: object): boolean {
     isInstance = isInstance && "vulnerabilities_count" in value;
     isInstance = isInstance && "vulnerability_latest_scan_id" in value;
     isInstance = isInstance && "vulnerability_scan_status" in value;
+    isInstance = isInstance && "warn_alarm_count" in value;
 
     return isInstance;
 }
@@ -377,6 +391,7 @@ export function ModelHostFromJSONTyped(json: any, ignoreDiscriminator: boolean):
         'cloud_account_id': json['cloud_account_id'],
         'cloud_provider': json['cloud_provider'],
         'cloud_region': json['cloud_region'],
+        'cloud_warn_alarm_count': json['cloud_warn_alarm_count'],
         'compliance_latest_scan_id': json['compliance_latest_scan_id'],
         'compliance_scan_status': json['compliance_scan_status'],
         'compliances_count': json['compliances_count'],
@@ -415,6 +430,7 @@ export function ModelHostFromJSONTyped(json: any, ignoreDiscriminator: boolean):
         'vulnerabilities_count': json['vulnerabilities_count'],
         'vulnerability_latest_scan_id': json['vulnerability_latest_scan_id'],
         'vulnerability_scan_status': json['vulnerability_scan_status'],
+        'warn_alarm_count': json['warn_alarm_count'],
     };
 }
 
@@ -432,6 +448,7 @@ export function ModelHostToJSON(value?: ModelHost | null): any {
         'cloud_account_id': value.cloud_account_id,
         'cloud_provider': value.cloud_provider,
         'cloud_region': value.cloud_region,
+        'cloud_warn_alarm_count': value.cloud_warn_alarm_count,
         'compliance_latest_scan_id': value.compliance_latest_scan_id,
         'compliance_scan_status': value.compliance_scan_status,
         'compliances_count': value.compliances_count,
@@ -470,6 +487,7 @@ export function ModelHostToJSON(value?: ModelHost | null): any {
         'vulnerabilities_count': value.vulnerabilities_count,
         'vulnerability_latest_scan_id': value.vulnerability_latest_scan_id,
         'vulnerability_scan_status': value.vulnerability_scan_status,
+        'warn_alarm_count': value.warn_alarm_count,
     };
 }
 

--- a/deepfence_frontend/apps/dashboard/src/features/threat-graph/components/ThreatGraph.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/threat-graph/components/ThreatGraph.tsx
@@ -228,10 +228,10 @@ function getGraphData(data: { [key: string]: GraphProviderThreatGraph }): G6Grap
               singleGraph.count ? ` (${singleGraph.count})` : ''
             }`,
             issuesCount:
-              singleGraph.compliance_count +
+              singleGraph.warn_alarm_count +
               singleGraph.secrets_count +
               singleGraph.vulnerability_count +
-              singleGraph.cloud_compliance_count,
+              singleGraph.cloud_warn_alarm_count,
             nodeType: singleGraph.node_type,
             icon: {
               show: true,

--- a/deepfence_frontend/apps/dashboard/src/features/threat-graph/data-components/DetailsModal.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/threat-graph/data-components/DetailsModal.tsx
@@ -135,7 +135,7 @@ const ModalContent = ({
             latest_secret_scan_id: (nodeData as ModelHost)?.secret_latest_scan_id,
             secrets_count: (nodeData as ModelHost)?.secrets_count,
             latest_compliance_scan_id: (nodeData as ModelHost)?.compliance_latest_scan_id,
-            compliance_count: (nodeData as ModelHost)?.compliances_count,
+            compliance_count: (nodeData as ModelHost)?.warn_alarm_count,
             latest_cloud_compliance_scan_id: undefined,
           };
         }
@@ -144,8 +144,7 @@ const ModalContent = ({
           ...node,
           latest_cloud_compliance_scan_id: (nodeData as ModelCloudResource)
             ?.cloud_compliance_latest_scan_id,
-          cloud_compliance_count: (nodeData as ModelCloudResource)
-            ?.cloud_compliances_count,
+          cloud_compliance_count: (nodeData as ModelHost)?.cloud_warn_alarm_count,
           latest_vulnerability_scan_id: undefined,
           latest_secret_scan_id: undefined,
           latest_compliance_scan_id: undefined,


### PR DESCRIPTION
Fixes https://github.com/deepfence/enterprise-roadmap/issues/2012
Related: https://github.com/deepfence/ThreatMapper/pull/1845

Changes proposed in this pull request:
- posture issue count consider only warn status in threat graph
