### PR TITLE
Add to filter cloud resources by account id

### DIFF
--- a/deepfence_frontend/apps/dashboard/src/features/topology/data-components/tables/CloudResourcesTable.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/topology/data-components/tables/CloudResourcesTable.tsx
@@ -16,6 +16,7 @@ import {
 import { ModelCloudResource } from '@/api/generated';
 import { DFLink } from '@/components/DFLink';
 import { FilterBadge } from '@/components/filters/FilterBadge';
+import { SearchableCloudAccountsList } from '@/components/forms/SearchableCloudAccountsList';
 import { FilterIcon } from '@/components/icons/common/Filter';
 import { TimesIcon } from '@/components/icons/common/Times';
 import { ScanStatusBadge } from '@/components/ScanStatusBadge';
@@ -40,6 +41,9 @@ function useSearchCloudResourcesWithPagination() {
       order: getOrderFromSearchParams(searchParams),
       cloudProvider: searchParams.getAll('cloudProvider'),
       serviceType: searchParams.getAll('serviceType'),
+      awsAccountId: searchParams.getAll('aws_account_ids'),
+      gcpAccountId: searchParams.getAll('gcp_account_ids'),
+      azureAccountId: searchParams.getAll('azure_account_ids'),
     }),
     keepPreviousData: true,
   });
@@ -302,6 +306,9 @@ export const CloudResourcesTable = () => {
 const FILTER_SEARCHPARAMS: Record<string, string> = {
   cloudProvider: 'Cloud provider',
   serviceType: 'Service type',
+  aws_account_ids: 'AWS account',
+  gcp_account_ids: 'GCP account',
+  azure_account_ids: 'Azure account',
 };
 
 const CLOUD_PROVIDERS = [
@@ -395,6 +402,66 @@ function Filters() {
             );
           })}
         </Combobox>
+        <SearchableCloudAccountsList
+          cloudProvider="aws"
+          displayValue="AWS account"
+          defaultSelectedAccounts={searchParams.getAll('aws_account_ids')}
+          onClearAll={() => {
+            setSearchParams((prev) => {
+              prev.delete('aws_account_ids');
+              return prev;
+            });
+          }}
+          onChange={(value) => {
+            setSearchParams((prev) => {
+              prev.delete('aws_account_ids');
+              value.forEach((id) => {
+                prev.append('aws_account_ids', id);
+              });
+              return prev;
+            });
+          }}
+        />
+        <SearchableCloudAccountsList
+          cloudProvider="gcp"
+          displayValue="GCP account"
+          defaultSelectedAccounts={searchParams.getAll('gcp_account_ids')}
+          onClearAll={() => {
+            setSearchParams((prev) => {
+              prev.delete('gcp_account_ids');
+              return prev;
+            });
+          }}
+          onChange={(value) => {
+            setSearchParams((prev) => {
+              prev.delete('gcp_account_ids');
+              value.forEach((id) => {
+                prev.append('gcp_account_ids', id);
+              });
+              return prev;
+            });
+          }}
+        />
+        <SearchableCloudAccountsList
+          cloudProvider="azure"
+          displayValue="Azure account"
+          defaultSelectedAccounts={searchParams.getAll('azure_account_ids')}
+          onClearAll={() => {
+            setSearchParams((prev) => {
+              prev.delete('azure_account_ids');
+              return prev;
+            });
+          }}
+          onChange={(value) => {
+            setSearchParams((prev) => {
+              prev.delete('azure_account_ids');
+              value.forEach((id) => {
+                prev.append('azure_account_ids', id);
+              });
+              return prev;
+            });
+          }}
+        />
       </div>
       {appliedFilterCount > 0 ? (
         <div className="flex gap-2.5 mt-4 flex-wrap items-center">

--- a/deepfence_frontend/apps/dashboard/src/queries/search.tsx
+++ b/deepfence_frontend/apps/dashboard/src/queries/search.tsx
@@ -1278,21 +1278,23 @@ export const searchQueries = createQueryKeys('search', {
             'node_type'
           ] = serviceType;
         }
+
+        let accounts: string[] = [];
         if (awsAccountId?.length) {
-          searchSearchNodeReq.node_filter.filters.contains_filter.filter_in![
-            'account_id'
-          ] = awsAccountId;
+          accounts = [...accounts, ...awsAccountId];
         }
         if (gcpAccountId?.length) {
-          searchSearchNodeReq.node_filter.filters.contains_filter.filter_in![
-            'account_id'
-          ] = gcpAccountId;
+          accounts = [...accounts, ...gcpAccountId];
         }
         if (azureAccountId?.length) {
+          accounts = [...accounts, ...azureAccountId];
+        }
+        if (accounts.length) {
           searchSearchNodeReq.node_filter.filters.contains_filter.filter_in![
             'account_id'
-          ] = azureAccountId;
+          ] = accounts;
         }
+
         if (order) {
           searchSearchNodeReq.node_filter.filters.order_filter.order_fields?.push({
             field_name: order.sortBy,

--- a/deepfence_frontend/apps/dashboard/src/queries/search.tsx
+++ b/deepfence_frontend/apps/dashboard/src/queries/search.tsx
@@ -1213,6 +1213,9 @@ export const searchQueries = createQueryKeys('search', {
     cloudRegion?: string;
     cloudProvider?: string[];
     serviceType?: string[];
+    awsAccountId?: string[];
+    gcpAccountId?: string[];
+    azureAccountId?: string[];
     order?: {
       sortBy: string;
       descending: boolean;
@@ -1229,6 +1232,9 @@ export const searchQueries = createQueryKeys('search', {
           order,
           cloudProvider,
           serviceType,
+          awsAccountId,
+          gcpAccountId,
+          azureAccountId,
         } = filters;
         const searchSearchNodeReq: SearchSearchNodeReq = {
           node_filter: {
@@ -1271,6 +1277,21 @@ export const searchQueries = createQueryKeys('search', {
           searchSearchNodeReq.node_filter.filters.contains_filter.filter_in![
             'node_type'
           ] = serviceType;
+        }
+        if (awsAccountId?.length) {
+          searchSearchNodeReq.node_filter.filters.contains_filter.filter_in![
+            'account_id'
+          ] = awsAccountId;
+        }
+        if (gcpAccountId?.length) {
+          searchSearchNodeReq.node_filter.filters.contains_filter.filter_in![
+            'account_id'
+          ] = gcpAccountId;
+        }
+        if (azureAccountId?.length) {
+          searchSearchNodeReq.node_filter.filters.contains_filter.filter_in![
+            'account_id'
+          ] = azureAccountId;
         }
         if (order) {
           searchSearchNodeReq.node_filter.filters.order_filter.order_fields?.push({


### PR DESCRIPTION
Fixes https://github.com/deepfence/ThreatMapper/issues/1826

Changes proposed in this pull request:
- To filter cloud resources by account id
