### PR TITLE
Show only scanned assets in scan filters

### DIFF
--- a/deepfence_frontend/apps/dashboard/src/components/forms/SearchableContainerList.tsx
+++ b/deepfence_frontend/apps/dashboard/src/components/forms/SearchableContainerList.tsx
@@ -14,6 +14,9 @@ export type Props = {
   valueKey?: 'nodeId' | 'nodeName';
   active?: boolean;
   triggerVariant?: 'select' | 'button';
+  isScannedForVulnerabilities?: boolean;
+  isScannedForSecrets?: boolean;
+  isScannedForMalware?: boolean;
 };
 const PAGE_SIZE = 15;
 const SearchableContainer = ({
@@ -24,6 +27,9 @@ const SearchableContainer = ({
   valueKey = 'nodeId',
   active = true,
   triggerVariant,
+  isScannedForVulnerabilities,
+  isScannedForSecrets,
+  isScannedForMalware,
 }: Props) => {
   const [searchText, setSearchText] = useState('');
 
@@ -46,6 +52,9 @@ const SearchableContainer = ({
         size: PAGE_SIZE,
         searchText,
         active,
+        isScannedForVulnerabilities,
+        isScannedForSecrets,
+        isScannedForMalware,
         order: {
           sortBy: 'node_name',
           descending: false,

--- a/deepfence_frontend/apps/dashboard/src/components/forms/SearchableHostList.tsx
+++ b/deepfence_frontend/apps/dashboard/src/components/forms/SearchableHostList.tsx
@@ -18,6 +18,9 @@ export type SearchableHostListProps = {
   triggerVariant?: 'select' | 'button';
   helperText?: string;
   color?: 'error' | 'default';
+  isScannedForVulnerabilities?: boolean;
+  isScannedForSecrets?: boolean;
+  isScannedForMalware?: boolean;
 };
 
 const PAGE_SIZE = 15;
@@ -33,6 +36,9 @@ const SearchableHost = ({
   triggerVariant,
   helperText,
   color,
+  isScannedForVulnerabilities,
+  isScannedForSecrets,
+  isScannedForMalware,
 }: SearchableHostListProps) => {
   const [searchText, setSearchText] = useState('');
 
@@ -57,6 +63,9 @@ const SearchableHost = ({
         active,
         agentRunning,
         showOnlyKubernetesHosts,
+        isScannedForVulnerabilities,
+        isScannedForSecrets,
+        isScannedForMalware,
         order: {
           sortBy: 'host_name',
           descending: false,

--- a/deepfence_frontend/apps/dashboard/src/components/forms/SearchableImageList.tsx
+++ b/deepfence_frontend/apps/dashboard/src/components/forms/SearchableImageList.tsx
@@ -14,6 +14,9 @@ export type Props = {
   valueKey?: 'nodeId' | 'nodeName';
   active?: boolean;
   triggerVariant?: 'select' | 'button';
+  isScannedForVulnerabilities?: boolean;
+  isScannedForSecrets?: boolean;
+  isScannedForMalware?: boolean;
 };
 
 const PAGE_SIZE = 15;
@@ -25,6 +28,9 @@ const SearchableImage = ({
   valueKey = 'nodeId',
   active,
   triggerVariant,
+  isScannedForVulnerabilities,
+  isScannedForSecrets,
+  isScannedForMalware,
 }: Props) => {
   const [searchText, setSearchText] = useState('');
 
@@ -47,6 +53,9 @@ const SearchableImage = ({
         size: PAGE_SIZE,
         searchText,
         active,
+        isScannedForVulnerabilities,
+        isScannedForSecrets,
+        isScannedForMalware,
         order: {
           sortBy: 'node_name',
           descending: false,

--- a/deepfence_frontend/apps/dashboard/src/features/malwares/pages/MalwareScans.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/malwares/pages/MalwareScans.tsx
@@ -484,6 +484,7 @@ const Filters = () => {
         <SearchableImageList
           scanType={ScanTypeEnum.MalwareScan}
           defaultSelectedImages={searchParams.getAll('containerImages')}
+          isScannedForMalware
           onClearAll={() => {
             setSearchParams((prev) => {
               prev.delete('containerImages');
@@ -505,6 +506,7 @@ const Filters = () => {
         <SearchableContainerList
           scanType={ScanTypeEnum.MalwareScan}
           defaultSelectedContainers={searchParams.getAll('containers')}
+          isScannedForMalware
           onClearAll={() => {
             setSearchParams((prev) => {
               prev.delete('containers');
@@ -526,6 +528,7 @@ const Filters = () => {
         <SearchableHostList
           scanType={ScanTypeEnum.MalwareScan}
           defaultSelectedHosts={searchParams.getAll('hosts')}
+          isScannedForMalware
           onClearAll={() => {
             setSearchParams((prev) => {
               prev.delete('hosts');

--- a/deepfence_frontend/apps/dashboard/src/features/secrets/pages/SecretScans.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/secrets/pages/SecretScans.tsx
@@ -488,6 +488,7 @@ const Filters = () => {
         <SearchableImageList
           scanType={ScanTypeEnum.SecretScan}
           defaultSelectedImages={searchParams.getAll('containerImages')}
+          isScannedForSecrets
           onClearAll={() => {
             setSearchParams((prev) => {
               prev.delete('containerImages');
@@ -509,6 +510,7 @@ const Filters = () => {
         <SearchableContainerList
           scanType={ScanTypeEnum.SecretScan}
           defaultSelectedContainers={searchParams.getAll('containers')}
+          isScannedForSecrets
           onClearAll={() => {
             setSearchParams((prev) => {
               prev.delete('containers');
@@ -530,6 +532,7 @@ const Filters = () => {
         <SearchableHostList
           scanType={ScanTypeEnum.SecretScan}
           defaultSelectedHosts={searchParams.getAll('hosts')}
+          isScannedForSecrets
           onClearAll={() => {
             setSearchParams((prev) => {
               prev.delete('hosts');

--- a/deepfence_frontend/apps/dashboard/src/features/vulnerabilities/pages/VulnerabilityScans.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/vulnerabilities/pages/VulnerabilityScans.tsx
@@ -940,6 +940,7 @@ const Filters = () => {
         <SearchableImageList
           scanType={ScanTypeEnum.VulnerabilityScan}
           defaultSelectedImages={searchParams.getAll('containerImages')}
+          isScannedForVulnerabilities
           onClearAll={() => {
             setSearchParams((prev) => {
               prev.delete('containerImages');
@@ -961,6 +962,7 @@ const Filters = () => {
         <SearchableContainerList
           scanType={ScanTypeEnum.VulnerabilityScan}
           defaultSelectedContainers={searchParams.getAll('containers')}
+          isScannedForVulnerabilities
           onClearAll={() => {
             setSearchParams((prev) => {
               prev.delete('containers');
@@ -982,6 +984,7 @@ const Filters = () => {
         <SearchableHostList
           scanType={ScanTypeEnum.VulnerabilityScan}
           defaultSelectedHosts={searchParams.getAll('hosts')}
+          isScannedForVulnerabilities
           onClearAll={() => {
             setSearchParams((prev) => {
               prev.delete('hosts');

--- a/deepfence_frontend/apps/dashboard/src/queries/search.tsx
+++ b/deepfence_frontend/apps/dashboard/src/queries/search.tsx
@@ -27,6 +27,9 @@ export const searchQueries = createQueryKeys('search', {
       sortBy: string;
       descending: boolean;
     };
+    isScannedForVulnerabilities?: boolean;
+    isScannedForSecrets?: boolean;
+    isScannedForMalware?: boolean;
   }) => {
     return {
       queryKey: [{ filters }],
@@ -39,8 +42,17 @@ export const searchQueries = createQueryKeys('search', {
           nodeName: string;
         }[];
       }> => {
-        const { searchText, size, active, agentRunning, showOnlyKubernetesHosts, order } =
-          filters;
+        const {
+          searchText,
+          size,
+          active,
+          agentRunning,
+          showOnlyKubernetesHosts,
+          order,
+          isScannedForVulnerabilities,
+          isScannedForSecrets,
+          isScannedForMalware,
+        } = filters;
         const searchSearchNodeReq: SearchSearchNodeReq = {
           node_filter: {
             filters: {
@@ -97,6 +109,21 @@ export const searchQueries = createQueryKeys('search', {
           searchSearchNodeReq.node_filter.filters.not_contains_filter!.filter_in![
             'kubernetes_cluster_id'
           ] = [''];
+        }
+        if (isScannedForVulnerabilities) {
+          searchSearchNodeReq.node_filter.filters.not_contains_filter!.filter_in![
+            'vulnerability_scan_status'
+          ] = [...VULNERABILITY_SCAN_STATUS_GROUPS.neverScanned, ''];
+        }
+        if (isScannedForSecrets) {
+          searchSearchNodeReq.node_filter.filters.not_contains_filter!.filter_in![
+            'secret_scan_status'
+          ] = [...SECRET_SCAN_STATUS_GROUPS.neverScanned, ''];
+        }
+        if (isScannedForMalware) {
+          searchSearchNodeReq.node_filter.filters.not_contains_filter!.filter_in![
+            'malware_scan_status'
+          ] = [...MALWARE_SCAN_STATUS_GROUPS.neverScanned, ''];
         }
         const searchHostsApi = apiWrapper({
           fn: getSearchApiClient().searchHosts,
@@ -222,6 +249,9 @@ export const searchQueries = createQueryKeys('search', {
     searchText?: string;
     size: number;
     active?: boolean;
+    isScannedForVulnerabilities?: boolean;
+    isScannedForSecrets?: boolean;
+    isScannedForMalware?: boolean;
     order?: {
       sortBy: string;
       descending: boolean;
@@ -237,7 +267,15 @@ export const searchQueries = createQueryKeys('search', {
           nodeName: string;
         }[];
       }> => {
-        const { searchText, size, active, order } = filters;
+        const {
+          searchText,
+          size,
+          active,
+          order,
+          isScannedForVulnerabilities,
+          isScannedForSecrets,
+          isScannedForMalware,
+        } = filters;
         const matchFilter = { filter_in: {} };
         if (searchText?.length) {
           matchFilter.filter_in = {
@@ -257,6 +295,9 @@ export const searchQueries = createQueryKeys('search', {
                   pseudo: [false],
                   ...(active && { active: [active === true] }),
                 },
+              },
+              not_contains_filter: {
+                filter_in: {},
               },
               order_filter: {
                 order_fields: [
@@ -280,6 +321,22 @@ export const searchQueries = createQueryKeys('search', {
             size,
           },
         };
+
+        if (isScannedForVulnerabilities) {
+          scanRequestParams.node_filter.filters.not_contains_filter!.filter_in![
+            'vulnerability_scan_status'
+          ] = [...VULNERABILITY_SCAN_STATUS_GROUPS.neverScanned, ''];
+        }
+        if (isScannedForSecrets) {
+          scanRequestParams.node_filter.filters.not_contains_filter!.filter_in![
+            'secret_scan_status'
+          ] = [...SECRET_SCAN_STATUS_GROUPS.neverScanned, ''];
+        }
+        if (isScannedForMalware) {
+          scanRequestParams.node_filter.filters.not_contains_filter!.filter_in![
+            'malware_scan_status'
+          ] = [...MALWARE_SCAN_STATUS_GROUPS.neverScanned, ''];
+        }
         if (order) {
           scanRequestParams.node_filter.filters.order_filter.order_fields = [
             {
@@ -316,6 +373,9 @@ export const searchQueries = createQueryKeys('search', {
     searchText?: string;
     size: number;
     active?: boolean;
+    isScannedForVulnerabilities?: boolean;
+    isScannedForSecrets?: boolean;
+    isScannedForMalware?: boolean;
     order?: {
       sortBy: string;
       descending: boolean;
@@ -335,7 +395,16 @@ export const searchQueries = createQueryKeys('search', {
           tagList: string[];
         }[];
       }> => {
-        const { searchText, size, active, order, filter } = filters;
+        const {
+          searchText,
+          size,
+          active,
+          order,
+          filter,
+          isScannedForVulnerabilities,
+          isScannedForSecrets,
+          isScannedForMalware,
+        } = filters;
         const searchContainerImagesApi = apiWrapper({
           fn: getSearchApiClient().searchContainerImages,
         });
@@ -348,6 +417,9 @@ export const searchQueries = createQueryKeys('search', {
                   pseudo: [false],
                   ...(active !== undefined && { active: [active === true] }),
                 },
+              },
+              not_contains_filter: {
+                filter_in: {},
               },
               order_filter: {
                 order_fields: [
@@ -387,6 +459,22 @@ export const searchQueries = createQueryKeys('search', {
           scanRequestParams.node_filter.filters!.contains_filter!.filter_in![
             'docker_image_name'
           ] = [filter?.dockerImageName];
+        }
+
+        if (isScannedForVulnerabilities) {
+          scanRequestParams.node_filter.filters.not_contains_filter!.filter_in![
+            'vulnerability_scan_status'
+          ] = [...VULNERABILITY_SCAN_STATUS_GROUPS.neverScanned, ''];
+        }
+        if (isScannedForSecrets) {
+          scanRequestParams.node_filter.filters.not_contains_filter!.filter_in![
+            'secret_scan_status'
+          ] = [...SECRET_SCAN_STATUS_GROUPS.neverScanned, ''];
+        }
+        if (isScannedForMalware) {
+          scanRequestParams.node_filter.filters.not_contains_filter!.filter_in![
+            'malware_scan_status'
+          ] = [...MALWARE_SCAN_STATUS_GROUPS.neverScanned, ''];
         }
 
         if (order) {


### PR DESCRIPTION
Changes proposed in this pull request:
- Show only scanned assets in images, hosts and containers scan filters
