### PR TITLE
Fix incorrect behaviour of scan status filter on scan pages

### DIFF
--- a/deepfence_frontend/apps/dashboard/src/queries/malware.tsx
+++ b/deepfence_frontend/apps/dashboard/src/queries/malware.tsx
@@ -75,7 +75,6 @@ export const malwareQueries = createQueryKeys('malware', {
         const nodeFilters = {
           node_type: nodeTypes,
         } as {
-          status?: string[];
           node_type?: string[];
           host_name?: string[];
           node_id?: string[];
@@ -151,9 +150,9 @@ export const malwareQueries = createQueryKeys('malware', {
         }
         if (malwareScanStatus) {
           if (malwareScanStatus === MalwareScanGroupedStatus.neverScanned) {
-            scanRequestParams.node_filters.filters.not_contains_filter!.filter_in = {
-              ...scanRequestParams.node_filters.filters.not_contains_filter!.filter_in,
-              malware_scan_status: [
+            scanRequestParams.scan_filters.filters.not_contains_filter!.filter_in = {
+              ...scanRequestParams.scan_filters.filters.not_contains_filter!.filter_in,
+              status: [
                 ...MALWARE_SCAN_STATUS_GROUPS.complete,
                 ...MALWARE_SCAN_STATUS_GROUPS.error,
                 ...MALWARE_SCAN_STATUS_GROUPS.inProgress,
@@ -161,9 +160,9 @@ export const malwareQueries = createQueryKeys('malware', {
               ],
             };
           } else {
-            scanRequestParams.node_filters.filters.contains_filter.filter_in = {
-              ...scanRequestParams.node_filters.filters.contains_filter.filter_in,
-              malware_scan_status: MALWARE_SCAN_STATUS_GROUPS[malwareScanStatus],
+            scanRequestParams.scan_filters.filters.contains_filter.filter_in = {
+              ...scanRequestParams.scan_filters.filters.contains_filter.filter_in,
+              status: MALWARE_SCAN_STATUS_GROUPS[malwareScanStatus],
             };
           }
         }

--- a/deepfence_frontend/apps/dashboard/src/queries/malware.tsx
+++ b/deepfence_frontend/apps/dashboard/src/queries/malware.tsx
@@ -124,6 +124,9 @@ export const malwareQueries = createQueryKeys('malware', {
               order_filter: { order_fields: [] },
               contains_filter: { filter_in: { ...scanFilters } },
               compare_filter: null,
+              not_contains_filter: {
+                filter_in: {},
+              },
             },
             in_field_filter: null,
             window: {

--- a/deepfence_frontend/apps/dashboard/src/queries/secret.tsx
+++ b/deepfence_frontend/apps/dashboard/src/queries/secret.tsx
@@ -75,7 +75,6 @@ export const secretQueries = createQueryKeys('secret', {
         const nodeFilters = {
           node_type: nodeTypes,
         } as {
-          status?: string[];
           node_type?: string[];
           host_name?: string[];
           node_id?: string[];
@@ -151,9 +150,9 @@ export const secretQueries = createQueryKeys('secret', {
         }
         if (secretScanStatus) {
           if (secretScanStatus === SecretScanGroupedStatus.neverScanned) {
-            scanRequestParams.node_filters.filters.not_contains_filter!.filter_in = {
-              ...scanRequestParams.node_filters.filters.not_contains_filter!.filter_in,
-              secret_scan_status: [
+            scanRequestParams.scan_filters.filters.not_contains_filter!.filter_in = {
+              ...scanRequestParams.scan_filters.filters.not_contains_filter!.filter_in,
+              status: [
                 ...SECRET_SCAN_STATUS_GROUPS.complete,
                 ...SECRET_SCAN_STATUS_GROUPS.error,
                 ...SECRET_SCAN_STATUS_GROUPS.inProgress,
@@ -161,9 +160,9 @@ export const secretQueries = createQueryKeys('secret', {
               ],
             };
           } else {
-            scanRequestParams.node_filters.filters.contains_filter.filter_in = {
-              ...scanRequestParams.node_filters.filters.contains_filter.filter_in,
-              secret_scan_status: SECRET_SCAN_STATUS_GROUPS[secretScanStatus],
+            scanRequestParams.scan_filters.filters.contains_filter.filter_in = {
+              ...scanRequestParams.scan_filters.filters.contains_filter.filter_in,
+              status: SECRET_SCAN_STATUS_GROUPS[secretScanStatus],
             };
           }
         }

--- a/deepfence_frontend/apps/dashboard/src/queries/secret.tsx
+++ b/deepfence_frontend/apps/dashboard/src/queries/secret.tsx
@@ -124,6 +124,9 @@ export const secretQueries = createQueryKeys('secret', {
               order_filter: { order_fields: [] },
               contains_filter: { filter_in: { ...scanFilters } },
               compare_filter: null,
+              not_contains_filter: {
+                filter_in: {},
+              },
             },
             in_field_filter: null,
             window: {

--- a/deepfence_frontend/apps/dashboard/src/queries/vulnerability.tsx
+++ b/deepfence_frontend/apps/dashboard/src/queries/vulnerability.tsx
@@ -82,7 +82,6 @@ export const vulnerabilityQueries = createQueryKeys('vulnerability', {
         const nodeFilters = {
           node_type: nodeTypes,
         } as {
-          status?: string[];
           node_type?: string[];
           host_name?: string[];
           node_id?: string[];
@@ -178,9 +177,9 @@ export const vulnerabilityQueries = createQueryKeys('vulnerability', {
 
         if (vulnerabilityScanStatus) {
           if (vulnerabilityScanStatus === VulnerabilityScanGroupedStatus.neverScanned) {
-            scanRequestParams.node_filters.filters.not_contains_filter!.filter_in = {
-              ...scanRequestParams.node_filters.filters.not_contains_filter!.filter_in,
-              vulnerability_scan_status: [
+            scanRequestParams.scan_filters.filters.not_contains_filter!.filter_in = {
+              ...scanRequestParams.scan_filters.filters.not_contains_filter!.filter_in,
+              status: [
                 ...VULNERABILITY_SCAN_STATUS_GROUPS.complete,
                 ...VULNERABILITY_SCAN_STATUS_GROUPS.error,
                 ...VULNERABILITY_SCAN_STATUS_GROUPS.inProgress,
@@ -188,10 +187,9 @@ export const vulnerabilityQueries = createQueryKeys('vulnerability', {
               ],
             };
           } else {
-            scanRequestParams.node_filters.filters.contains_filter.filter_in = {
-              ...scanRequestParams.node_filters.filters.contains_filter.filter_in,
-              vulnerability_scan_status:
-                VULNERABILITY_SCAN_STATUS_GROUPS[vulnerabilityScanStatus],
+            scanRequestParams.scan_filters.filters.contains_filter.filter_in = {
+              ...scanRequestParams.scan_filters.filters.contains_filter.filter_in,
+              status: VULNERABILITY_SCAN_STATUS_GROUPS[vulnerabilityScanStatus],
             };
           }
         }

--- a/deepfence_frontend/apps/dashboard/src/queries/vulnerability.tsx
+++ b/deepfence_frontend/apps/dashboard/src/queries/vulnerability.tsx
@@ -140,16 +140,12 @@ export const vulnerabilityQueries = createQueryKeys('vulnerability', {
           scan_filters: {
             filters: {
               match_filter: { filter_in: {} },
-              order_filter: {
-                order_fields: [
-                  {
-                    descending: true,
-                    field_name: 'updated_at',
-                  },
-                ],
-              },
+              order_filter: { order_fields: [] },
               contains_filter: { filter_in: { ...scanFilters } },
               compare_filter: null,
+              not_contains_filter: {
+                filter_in: {},
+              },
             },
             in_field_filter: null,
             window: {


### PR DESCRIPTION


Fixes https://github.com/deepfence/enterprise-roadmap/issues/2079

Changes proposed in this pull request:
- Scan status filter behaves abnormal in some cases which is fixed by sending status in scan filters payload
