### PR TITLE
use redis to track workload allocator counts

### DIFF
--- a/deepfence_utils/controls/workload_allocator.go
+++ b/deepfence_utils/controls/workload_allocator.go
@@ -6,6 +6,9 @@ import (
 )
 
 var ErrNotEnoughRoom = errors.New("not enough room")
+var ErrCtxAllocatorNotFound = errors.New("error allocator context key not found")
+
+const ContextAllocatorKey = "scan-workload-allocator"
 
 type WorkloadAllocator struct {
 	currentWorkload int32

--- a/deepfence_utils/controls/workload_allocator_redis.go
+++ b/deepfence_utils/controls/workload_allocator_redis.go
@@ -26,10 +26,12 @@ func (rwa *RedisWorkloadAllocator) Reserve(delta int64) {
 }
 
 func (rwa *RedisWorkloadAllocator) Free() {
+
 	var (
-		current int64 = 0
+		current int64
 		err     error
 	)
+
 	result := rwa.rdb.Get(context.Background(), CurrentWorkloadCounter)
 	if result.Err() != nil {
 		log.Error().Err(result.Err()).Msgf("failed to get current allocator for ns %s", string(rwa.namespace))

--- a/deepfence_utils/controls/workload_allocator_redis.go
+++ b/deepfence_utils/controls/workload_allocator_redis.go
@@ -1,0 +1,84 @@
+package controls
+
+import (
+	"context"
+
+	"github.com/deepfence/ThreatMapper/deepfence_utils/directory"
+	"github.com/deepfence/ThreatMapper/deepfence_utils/log"
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	CurrentWorkloadCounter = "current-workload-counter"
+)
+
+type RedisWorkloadAllocator struct {
+	maxWorkload int64
+	namespace   directory.NamespaceID
+	rdb         *redis.Client
+}
+
+func (rwa *RedisWorkloadAllocator) Reserve(delta int64) {
+	result := rwa.rdb.IncrBy(context.Background(), CurrentWorkloadCounter, delta)
+	if result.Err() != nil {
+		log.Error().Err(result.Err()).Msgf("failed to reserve allocator count for ns %s", string(rwa.namespace))
+	}
+}
+
+func (rwa *RedisWorkloadAllocator) Free() {
+	var (
+		current int64 = 0
+		err     error
+	)
+	result := rwa.rdb.Get(context.Background(), CurrentWorkloadCounter)
+	if result.Err() != nil {
+		log.Error().Err(result.Err()).Msgf("failed to get current allocator for ns %s", string(rwa.namespace))
+	}
+	current, err = result.Int64()
+	if err != nil {
+		log.Error().Err(result.Err()).Msgf("failed to convert allocator to int64 for ns %s", string(rwa.namespace))
+	}
+	if current < 0 {
+		// check if counter is already negative
+		result := rwa.rdb.Set(context.Background(), CurrentWorkloadCounter, 0, 0)
+		if result.Err() != nil {
+			log.Error().Err(result.Err()).Msgf("failed to set allocator to 0 for ns %s", string(rwa.namespace))
+		}
+	} else {
+		result := rwa.rdb.Decr(context.Background(), CurrentWorkloadCounter)
+		if result.Err() != nil {
+			log.Error().Err(result.Err()).Msgf("failed to decr allocator for ns %s", string(rwa.namespace))
+		}
+	}
+}
+
+func (rwa *RedisWorkloadAllocator) MaxAllocable() int64 {
+	result := rwa.rdb.Get(context.Background(), CurrentWorkloadCounter)
+	if result.Err() != nil {
+		log.Error().Err(result.Err()).Msgf("failed to get current allocator for ns %s", string(rwa.namespace))
+	}
+	current, err := result.Int64()
+	if err != nil {
+		current = 0
+	}
+	delta := rwa.maxWorkload - current
+	if delta < 0 {
+		return 0
+	}
+	return delta
+}
+
+func NewRedisWorkloadAllocator(maxWorkload int64, namespace directory.NamespaceID, config *directory.RedisConfig) *RedisWorkloadAllocator {
+	return &RedisWorkloadAllocator{
+		maxWorkload: maxWorkload,
+		namespace:   namespace,
+		rdb: redis.NewClient(
+			&redis.Options{
+				Addr:     config.Endpoint,
+				Password: config.Password,
+				DB:       config.Database,
+				PoolSize: 5,
+			},
+		),
+	}
+}

--- a/deepfence_worker/ingester.go
+++ b/deepfence_worker/ingester.go
@@ -11,10 +11,11 @@ import (
 	"github.com/deepfence/ThreatMapper/deepfence_utils/log"
 	"github.com/deepfence/ThreatMapper/deepfence_utils/utils"
 	"github.com/deepfence/ThreatMapper/deepfence_worker/processors"
+	wtils "github.com/deepfence/ThreatMapper/deepfence_worker/utils"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-func startIngester(cfg config) error {
+func startIngester(cfg wtils.Config) error {
 
 	ctx, cancel := signal.NotifyContext(context.Background(),
 		os.Interrupt, syscall.SIGTERM)

--- a/deepfence_worker/main.go
+++ b/deepfence_worker/main.go
@@ -7,6 +7,9 @@ import (
 	"path"
 	"time"
 
+	"net/http"
+	_ "net/http/pprof"
+
 	"github.com/deepfence/ThreatMapper/deepfence_utils/directory"
 	"github.com/deepfence/ThreatMapper/deepfence_utils/log"
 	"github.com/deepfence/ThreatMapper/deepfence_utils/utils"
@@ -23,25 +26,8 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 	"go.opentelemetry.io/otel/trace"
 
-	"net/http"
-	_ "net/http/pprof"
+	wtils "github.com/deepfence/ThreatMapper/deepfence_worker/utils"
 )
-
-type config struct {
-	Debug                 bool     `default:"false"`
-	Mode                  string   `default:"worker" required:"true"`
-	MetricsPort           string   `default:"8181" split_words:"true"`
-	KafkaBrokers          []string `default:"deepfence-kafka-broker:9092" required:"true" split_words:"true"`
-	KafkaTopicPartitions  int32    `default:"1" split_words:"true"`
-	KafkaTopicReplicas    int16    `default:"1" split_words:"true"`
-	KafkaTopicRetentionMs string   `default:"86400000" split_words:"true"`
-	RedisHost             string   `default:"deepfence-redis" required:"true" split_words:"true"`
-	RedisDbNumber         int      `default:"0" split_words:"true"`
-	RedisPort             string   `default:"6379" split_words:"true"`
-	RedisPassword         string   `default:"" split_words:"true"`
-	TasksConcurrency      int      `default:"50" split_words:"true"`
-	ProcessQueues         []string `split_words:"true"`
-}
 
 // build info
 var (
@@ -55,7 +41,7 @@ func main() {
 	log.Info().Msgf("\n version: %s\n commit: %s\n build-time: %s\n",
 		Version, Commit, BuildTime)
 
-	var cfg config
+	var cfg wtils.Config
 	var err error
 	err = envconfig.Process("DEEPFENCE", &cfg)
 	if err != nil {

--- a/deepfence_worker/processors/audit.go
+++ b/deepfence_worker/processors/audit.go
@@ -30,15 +30,17 @@ func processAuditLog(ctx context.Context, auditC chan *kgo.Record) {
 
 			spanCtx, span := otel.Tracer("audit-log").Start(ctx, "ingest-audit-log")
 
-			pgClient, err := directory.PostgresClient(directory.NewContextWithNameSpace(directory.NamespaceID(getNamespace(record.Headers))))
+			namespace := getNamespace(record.Headers)
+
+			pgClient, err := directory.PostgresClient(directory.NewContextWithNameSpace(directory.NamespaceID(namespace)))
 			if err != nil {
-				log.Error().Err(err).Msg("failed to get db connection")
+				log.Error().Str("namespace", namespace).Err(err).Msg("failed to get db connection")
 			}
 
 			var params postgresql_db.CreateAuditLogParams
 
 			if err := json.Unmarshal(record.Value, &params); err != nil {
-				log.Error().Err(err).Msg("failed to unmarshal audit log")
+				log.Error().Err(err).Str("namespace", namespace).Msg("failed to unmarshal audit log")
 				span.RecordError(err)
 				span.SetStatus(codes.Error, err.Error())
 				span.End()
@@ -46,7 +48,7 @@ func processAuditLog(ctx context.Context, auditC chan *kgo.Record) {
 			}
 
 			if err := pgClient.CreateAuditLog(spanCtx, params); err != nil {
-				log.Error().Err(err).Msgf("failed to insert audit log params: %+v", params)
+				log.Error().Err(err).Str("namespace", namespace).Msgf("failed to insert audit log params: %+v", params)
 				span.RecordError(err)
 				span.SetStatus(codes.Error, err.Error())
 				span.End()

--- a/deepfence_worker/tasks/malwarescan/malwarescan.go
+++ b/deepfence_worker/tasks/malwarescan/malwarescan.go
@@ -14,8 +14,7 @@ import (
 	"github.com/deepfence/golang_deepfence_sdk/utils/tasks"
 	"github.com/hibiken/asynq"
 
-	utils_ctl "github.com/deepfence/ThreatMapper/deepfence_utils/controls"
-	"github.com/deepfence/ThreatMapper/deepfence_worker/cronjobs"
+	utilsCtl "github.com/deepfence/ThreatMapper/deepfence_utils/controls"
 	workerUtils "github.com/deepfence/ThreatMapper/deepfence_worker/utils"
 	malwareScanConstants "github.com/deepfence/YaraHunter/constants"
 	malwareConfig "github.com/deepfence/YaraHunter/pkg/config"
@@ -54,39 +53,10 @@ func NewMalwareScanner(ingest chan *kgo.Record) MalwareScan {
 }
 
 func (s MalwareScan) StopMalwareScan(ctx context.Context, task *asynq.Task) error {
-	if allocator := ctx.Value(cronjobs.ContextAllocatorKey); allocator != nil {
-		defer allocator.(*utils_ctl.RedisWorkloadAllocator).Free()
-	}
-
-	var params utils.MalwareScanParameters
-
-	log.Info().Msgf("StopMalwareScan, payload: %s ", string(task.Payload()))
-
-	if err := json.Unmarshal(task.Payload(), &params); err != nil {
-		log.Error().Msgf("StopMalwareScan, error in Unmarshal: %s", err.Error())
-		return nil
-	}
-
-	scanID := params.ScanID
-
-	obj, found := ScanMap.Load(scanID)
-	if !found {
-		log.Error().Msgf("Failed to Stop scan, may be already completed or errored out, ScanID: %s", scanID)
-		return nil
-	}
-
-	scanner := obj.(*tasks.ScanContext)
-	scanner.StopTriggered.Store(true)
-	scanner.Cancel()
-	log.Error().Msgf("Stop request submitted, ScanID: %s", scanID)
-
-	return nil
-
-}
-
-func (s MalwareScan) StartMalwareScan(ctx context.Context, task *asynq.Task) error {
-	if allocator := ctx.Value(cronjobs.ContextAllocatorKey); allocator != nil {
-		defer allocator.(*utils_ctl.RedisWorkloadAllocator).Free()
+	if allocator := ctx.Value(utilsCtl.ContextAllocatorKey); allocator != nil {
+		defer allocator.(*utilsCtl.RedisWorkloadAllocator).Free()
+	} else {
+		return utilsCtl.ErrCtxAllocatorNotFound
 	}
 
 	var err error
@@ -94,9 +64,47 @@ func (s MalwareScan) StartMalwareScan(ctx context.Context, task *asynq.Task) err
 	if err != nil {
 		return err
 	}
-	log.Info().Msgf("message tenant id %s", string(tenantID))
 
-	log.Info().Msgf("payload: %s ", string(task.Payload()))
+	var params utils.MalwareScanParameters
+
+	log.Info().Str("namespace", string(tenantID)).Msgf("StopMalwareScan, payload: %s ", string(task.Payload()))
+
+	if err := json.Unmarshal(task.Payload(), &params); err != nil {
+		log.Error().Str("namespace", string(tenantID)).Msgf("StopMalwareScan, error in Unmarshal: %s", err.Error())
+		return nil
+	}
+
+	scanID := params.ScanID
+
+	obj, found := ScanMap.Load(scanID)
+	if !found {
+		log.Error().Str("namespace", string(tenantID)).Msgf("Failed to Stop scan, may be already completed or errored out, ScanID: %s", scanID)
+		return nil
+	}
+
+	scanner := obj.(*tasks.ScanContext)
+	scanner.StopTriggered.Store(true)
+	scanner.Cancel()
+	log.Error().Str("namespace", string(tenantID)).Msgf("Stop request submitted, ScanID: %s", scanID)
+
+	return nil
+
+}
+
+func (s MalwareScan) StartMalwareScan(ctx context.Context, task *asynq.Task) error {
+	if allocator := ctx.Value(utilsCtl.ContextAllocatorKey); allocator != nil {
+		defer allocator.(*utilsCtl.RedisWorkloadAllocator).Free()
+	} else {
+		return utilsCtl.ErrCtxAllocatorNotFound
+	}
+
+	var err error
+	tenantID, err := directory.ExtractNamespace(ctx)
+	if err != nil {
+		return err
+	}
+
+	log.Info().Str("namespace", string(tenantID)).Msgf("payload: %s ", string(task.Payload()))
 
 	var params utils.MalwareScanParameters
 
@@ -108,7 +116,7 @@ func (s MalwareScan) StartMalwareScan(ctx context.Context, task *asynq.Task) err
 		func(status tasks.ScanStatus) error {
 			sb, err := json.Marshal(status)
 			if err != nil {
-				log.Error().Msgf("%v", err)
+				log.Error().Str("namespace", string(tenantID)).Msgf("%v", err)
 				return err
 			}
 
@@ -130,7 +138,7 @@ func (s MalwareScan) StartMalwareScan(ctx context.Context, task *asynq.Task) err
 	ScanMap.Store(params.ScanID, scanCtx)
 
 	defer func() {
-		log.Info().Msgf("Removing from scan map, scan_id: %s", params.ScanID)
+		log.Info().Str("namespace", string(tenantID)).Msgf("Removing from scan map, scan_id: %s", params.ScanID)
 		ScanMap.Delete(params.ScanID)
 		res <- err
 		close(res)
@@ -162,7 +170,7 @@ func (s MalwareScan) StartMalwareScan(ctx context.Context, task *asynq.Task) err
 	}
 
 	defer func() {
-		log.Info().Msgf("remove auth directory %s", authDir)
+		log.Info().Str("namespace", string(tenantID)).Msgf("remove auth directory %s", authDir)
 		if authDir == "" {
 			return
 		}
@@ -200,10 +208,10 @@ func (s MalwareScan) StartMalwareScan(ctx context.Context, task *asynq.Task) err
 			"docker://" + imageName, "docker-archive:" + imgTar}...)
 	}
 
-	log.Info().Msgf("command: %s", cmd.String())
+	log.Info().Str("namespace", string(tenantID)).Msgf("command: %s", cmd.String())
 	if out, err := workerUtils.RunCommand(cmd); err != nil {
-		log.Error().Err(err).Msg(cmd.String())
-		log.Error().Msgf("output: %s", out.String())
+		log.Error().Str("namespace", string(tenantID)).Err(err).Msg(cmd.String())
+		log.Error().Str("namespace", string(tenantID)).Msgf("output: %s", out.String())
 		return err
 	}
 

--- a/deepfence_worker/tasks/malwarescan/malwarescan.go
+++ b/deepfence_worker/tasks/malwarescan/malwarescan.go
@@ -14,6 +14,7 @@ import (
 	"github.com/deepfence/golang_deepfence_sdk/utils/tasks"
 	"github.com/hibiken/asynq"
 
+	utils_ctl "github.com/deepfence/ThreatMapper/deepfence_utils/controls"
 	"github.com/deepfence/ThreatMapper/deepfence_worker/cronjobs"
 	workerUtils "github.com/deepfence/ThreatMapper/deepfence_worker/utils"
 	malwareScanConstants "github.com/deepfence/YaraHunter/constants"
@@ -53,7 +54,9 @@ func NewMalwareScanner(ingest chan *kgo.Record) MalwareScan {
 }
 
 func (s MalwareScan) StopMalwareScan(ctx context.Context, task *asynq.Task) error {
-	defer cronjobs.ScanWorkloadAllocator.Free()
+	if allocator := ctx.Value(cronjobs.ContextAllocatorKey); allocator != nil {
+		defer allocator.(*utils_ctl.RedisWorkloadAllocator).Free()
+	}
 
 	var params utils.MalwareScanParameters
 
@@ -82,7 +85,9 @@ func (s MalwareScan) StopMalwareScan(ctx context.Context, task *asynq.Task) erro
 }
 
 func (s MalwareScan) StartMalwareScan(ctx context.Context, task *asynq.Task) error {
-	defer cronjobs.ScanWorkloadAllocator.Free()
+	if allocator := ctx.Value(cronjobs.ContextAllocatorKey); allocator != nil {
+		defer allocator.(*utils_ctl.RedisWorkloadAllocator).Free()
+	}
 
 	var err error
 	tenantID, err := directory.ExtractNamespace(ctx)

--- a/deepfence_worker/tasks/sbom/generate_sbom.go
+++ b/deepfence_worker/tasks/sbom/generate_sbom.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	utils_ctl "github.com/deepfence/ThreatMapper/deepfence_utils/controls"
 	"github.com/deepfence/ThreatMapper/deepfence_utils/directory"
 	"github.com/deepfence/ThreatMapper/deepfence_utils/log"
 	"github.com/deepfence/ThreatMapper/deepfence_utils/utils"
@@ -37,7 +38,9 @@ func NewSbomGenerator(ingest chan *kgo.Record) SbomGenerator {
 }
 
 func StopVulnerabilityScan(ctx context.Context, task *asynq.Task) error {
-	defer cronjobs.ScanWorkloadAllocator.Free()
+	if allocator := ctx.Value(cronjobs.ContextAllocatorKey); allocator != nil {
+		defer allocator.(*utils_ctl.RedisWorkloadAllocator).Free()
+	}
 
 	log.Info().Msgf("StopVulnerabilityScan, payload: %s ", string(task.Payload()))
 	var params utils.SbomParameters
@@ -62,7 +65,9 @@ func StopVulnerabilityScan(ctx context.Context, task *asynq.Task) error {
 }
 
 func (s SbomGenerator) GenerateSbom(ctx context.Context, task *asynq.Task) error {
-	defer cronjobs.ScanWorkloadAllocator.Free()
+	if allocator := ctx.Value(cronjobs.ContextAllocatorKey); allocator != nil {
+		defer allocator.(*utils_ctl.RedisWorkloadAllocator).Free()
+	}
 
 	var (
 		params utils.SbomParameters

--- a/deepfence_worker/tasks/secretscan/secretscan.go
+++ b/deepfence_worker/tasks/secretscan/secretscan.go
@@ -13,6 +13,7 @@ import (
 	"github.com/deepfence/SecretScanner/output"
 	secretScan "github.com/deepfence/SecretScanner/scan"
 	"github.com/deepfence/SecretScanner/signature"
+	utils_ctl "github.com/deepfence/ThreatMapper/deepfence_utils/controls"
 	"github.com/deepfence/ThreatMapper/deepfence_utils/directory"
 	"github.com/deepfence/ThreatMapper/deepfence_utils/log"
 	"github.com/deepfence/ThreatMapper/deepfence_utils/utils"
@@ -39,7 +40,9 @@ func NewSecretScanner(ingest chan *kgo.Record) SecretScan {
 }
 
 func (s SecretScan) StopSecretScan(ctx context.Context, task *asynq.Task) error {
-	defer cronjobs.ScanWorkloadAllocator.Free()
+	if allocator := ctx.Value(cronjobs.ContextAllocatorKey); allocator != nil {
+		defer allocator.(*utils_ctl.RedisWorkloadAllocator).Free()
+	}
 
 	var params utils.SecretScanParameters
 
@@ -67,7 +70,9 @@ func (s SecretScan) StopSecretScan(ctx context.Context, task *asynq.Task) error 
 }
 
 func (s SecretScan) StartSecretScan(ctx context.Context, task *asynq.Task) error {
-	defer cronjobs.ScanWorkloadAllocator.Free()
+	if allocator := ctx.Value(cronjobs.ContextAllocatorKey); allocator != nil {
+		defer allocator.(*utils_ctl.RedisWorkloadAllocator).Free()
+	}
 
 	tenantID, err := directory.ExtractNamespace(ctx)
 	if err != nil {

--- a/deepfence_worker/utils/config.go
+++ b/deepfence_worker/utils/config.go
@@ -1,0 +1,18 @@
+package utils
+
+type Config struct {
+	Debug                 bool     `default:"false"`
+	Mode                  string   `default:"worker" required:"true"`
+	MetricsPort           string   `default:"8181" split_words:"true"`
+	KafkaBrokers          []string `default:"deepfence-kafka-broker:9092" required:"true" split_words:"true"`
+	KafkaTopicPartitions  int32    `default:"1" split_words:"true"`
+	KafkaTopicReplicas    int16    `default:"1" split_words:"true"`
+	KafkaTopicRetentionMs string   `default:"86400000" split_words:"true"`
+	RedisHost             string   `default:"deepfence-redis" required:"true" split_words:"true"`
+	RedisDbNumber         int      `default:"0" split_words:"true"`
+	RedisPort             string   `default:"6379" split_words:"true"`
+	RedisPassword         string   `default:"" split_words:"true"`
+	TasksConcurrency      int      `default:"50" split_words:"true"`
+	ProcessQueues         []string `split_words:"true"`
+	MaxScanWorkload       int64    `default:"5" split_words:"true"`
+}


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:
- use redis to track workload allocator counts (backport from TS)
- move worker config to utils
-
