### PR TITLE
fix volume path misconfig on neo4j

### DIFF
--- a/deployment-scripts/helm-charts/deepfence-console/templates/database/neo4j/neo4j.yaml
+++ b/deployment-scripts/helm-charts/deepfence-console/templates/database/neo4j/neo4j.yaml
@@ -63,12 +63,16 @@ spec:
           volumeMounts:
             - name: "neo4j"
               mountPath: /data
+              subPath: "data"
             - name: "neo4j"
               mountPath: /logs
+              subPath: "logs"
             - name: "neo4j"
               mountPath: /plugins
+              subPath: "plugins"
             - name: "neo4j"
               mountPath: /backups
+              subPath: "backups"
       {{- with .Values.neo4j.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:
-  fix volume path misconfig on neo4j
- on kubernetes with current volume config there will be data loss if neo4j is restarted, this change fixes that 
- **backup or take dump of neo4j data before upgrading to this changes and restore data after upgrade**
