### PR TITLE
fix(2098): missing to handle severity based on notification type

### DIFF
--- a/deepfence_frontend/apps/dashboard/src/features/integrations/components/useIntegrationTableColumn.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/integrations/components/useIntegrationTableColumn.tsx
@@ -7,7 +7,10 @@ import { ModelIntegrationListResp } from '@/api/generated';
 import { EllipsisIcon } from '@/components/icons/common/Ellipsis';
 import { ErrorIcon, SuccessIcon } from '@/components/icons/common/ScanStatuses';
 import { TruncatedText } from '@/components/TruncatedText';
-import { ActionEnumType } from '@/features/integrations/pages/IntegrationAdd';
+import {
+  ActionEnumType,
+  severityMap,
+} from '@/features/integrations/pages/IntegrationAdd';
 
 import { IntegrationType } from './IntegrationForm';
 
@@ -558,16 +561,22 @@ export const useIntegrationTableColumn = (
           const filters = row.original.filters;
           const containFilter = filters?.fields_filters?.contains_filter;
           const filterIn = containFilter?.filter_in;
-          const hasSeverity = has(filterIn, 'cve_severity');
-          const hasStatus = has(filterIn, 'status');
+          const notificationType = row.original?.notification_type ?? '';
+          const hasSeverityOrStatus = has(filterIn, severityMap[notificationType]);
+
           if (filters?.node_ids && filters?.node_ids.length) {
             displayFilters.node_ids = filters?.node_ids;
           }
 
-          if (hasSeverity) {
-            displayFilters.severities = filterIn?.['cve_severity'] ?? [];
-          } else if (hasStatus) {
-            displayFilters.statuses = filterIn?.['status'] ?? [];
+          if (hasSeverityOrStatus) {
+            if (
+              notificationType === 'Compliance' ||
+              notificationType === 'CloudCompliance'
+            ) {
+              displayFilters.statuses = filterIn?.[severityMap[notificationType]] ?? [];
+            } else {
+              displayFilters.severities = filterIn?.[severityMap[notificationType]] ?? [];
+            }
           }
 
           const configs = row.original.config;


### PR DESCRIPTION
Fixes https://github.com/deepfence/enterprise-roadmap/issues/2098

Changes proposed in this pull request:
- To handle severities filter of integration base on notification type
