### PR TITLE
Improve error handling for start scan forms

### DIFF
--- a/deepfence_frontend/apps/dashboard/src/components/scan-configure-forms/ComplianceScanConfigureForm.tsx
+++ b/deepfence_frontend/apps/dashboard/src/components/scan-configure-forms/ComplianceScanConfigureForm.tsx
@@ -149,6 +149,12 @@ export const scanPostureApiAction = async ({
           success: false,
           message,
         };
+      } else if (startComplianceScanResponse.error.response.status >= 500) {
+        console.error(startComplianceScanResponse.error);
+        return {
+          success: false,
+          message: 'Something went wrong, please try again later.',
+        };
       }
       throw startComplianceScanResponse.error;
     }

--- a/deepfence_frontend/apps/dashboard/src/components/scan-configure-forms/MalwareScanConfigureForm.tsx
+++ b/deepfence_frontend/apps/dashboard/src/components/scan-configure-forms/MalwareScanConfigureForm.tsx
@@ -168,6 +168,12 @@ export const scanMalwareApiAction = async ({
           success: false,
           message,
         };
+      } else if (startMalwareScanResponse.error.response.status >= 500) {
+        console.error(startMalwareScanResponse.error);
+        return {
+          success: false,
+          message: 'Something went wrong, please try again later.',
+        };
       }
       throw startMalwareScanResponse.error;
     }

--- a/deepfence_frontend/apps/dashboard/src/components/scan-configure-forms/SecretScanConfigureForm.tsx
+++ b/deepfence_frontend/apps/dashboard/src/components/scan-configure-forms/SecretScanConfigureForm.tsx
@@ -167,6 +167,12 @@ export const scanSecretApiAction = async ({
           success: false,
           message,
         };
+      } else if (startSecretScanResponse.error.response.status >= 500) {
+        console.error(startSecretScanResponse.error);
+        return {
+          success: false,
+          message: 'Something went wrong, please try again later.',
+        };
       }
       throw startSecretScanResponse.error;
     }

--- a/deepfence_frontend/apps/dashboard/src/components/scan-configure-forms/StopScanForm.tsx
+++ b/deepfence_frontend/apps/dashboard/src/components/scan-configure-forms/StopScanForm.tsx
@@ -67,6 +67,12 @@ export const actionStopScan = async ({
         success: false,
         message,
       };
+    } else if (result.error.response.status >= 500) {
+      console.error(result.error);
+      return {
+        success: false,
+        message: 'Something went wrong, please try again later.',
+      };
     }
     throw result.error;
   }

--- a/deepfence_frontend/apps/dashboard/src/components/scan-configure-forms/VulnerabilityScanConfigureForm.tsx
+++ b/deepfence_frontend/apps/dashboard/src/components/scan-configure-forms/VulnerabilityScanConfigureForm.tsx
@@ -248,6 +248,12 @@ export const scanVulnerabilityApiAction = async ({
           success: false,
           message,
         };
+      } else if (startVulnerabilityScanResponse.error.response.status >= 500) {
+        console.error(startVulnerabilityScanResponse.error);
+        return {
+          success: false,
+          message: 'Something went wrong, please try again later.',
+        };
       }
       throw startVulnerabilityScanResponse.error;
     }


### PR DESCRIPTION
Changes proposed in this pull request:
- Show error messages on start scan form in case of server errors.