### PR TITLE
remove double malware scanner init in worker

### DIFF
--- a/deepfence_worker/tasks/malwarescan/malwarescan.go
+++ b/deepfence_worker/tasks/malwarescan/malwarescan.go
@@ -137,7 +137,7 @@ func (s MalwareScan) StartMalwareScan(ctx context.Context, task *asynq.Task) err
 		return fmt.Errorf("registry id is empty in params %+v: %w", params, err)
 	}
 
-	opts, yaraconfig, yr = initMalwareScanner()
+	// opts, yaraconfig, yr = initMalwareScanner()
 	yrScanner, err := yr.NewScanner()
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:
- init malware scanner is called in init() function 
-
-
