### PR TITLE
Fix typo for cluster search placeholder

### DIFF
--- a/deepfence_frontend/apps/dashboard/src/components/forms/SearchableClusterList.tsx
+++ b/deepfence_frontend/apps/dashboard/src/components/forms/SearchableClusterList.tsx
@@ -150,7 +150,7 @@ export const SearchableClusterList = (props: SearchableClusterListProps) => {
             // no operation
           }}
           getDisplayValue={() => {
-            return props.displayValue ? props.displayValue : 'Select host';
+            return props.displayValue ? props.displayValue : 'Select cluster';
           }}
         />
       }


### PR DESCRIPTION
Changes proposed in this pull request:
- fix typo in search cluster, placeholder should be select cluster
