### PR TITLE
(feat.) add matomo for analytics support 

### DIFF
--- a/deepfence_frontend/apps/dashboard/index.html
+++ b/deepfence_frontend/apps/dashboard/index.html
@@ -11,7 +11,7 @@
       href="https://fonts.googleapis.com/css2?family=Nunito+Sans:ital,wght@0,400;0,600;0,700;0,800;0,900;1,400;1,600;1,700;1,800;1,900&display=swap"
       rel="stylesheet"
     />
-    <matomo-analytics></matomo-analytics>
+    <analytics-tracking></analytics-tracking>
   </head>
   <body class="overflow-hidden">
     <div id="root"></div>

--- a/deepfence_frontend/apps/dashboard/index.html
+++ b/deepfence_frontend/apps/dashboard/index.html
@@ -11,25 +11,7 @@
       href="https://fonts.googleapis.com/css2?family=Nunito+Sans:ital,wght@0,400;0,600;0,700;0,800;0,900;1,400;1,600;1,700;1,800;1,900&display=swap"
       rel="stylesheet"
     />
-    <!-- Matomo -->
-    <script>
-      var _paq = (window._paq = window._paq || []);
-      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-      _paq.push(['trackPageView']);
-      _paq.push(['enableLinkTracking']);
-      (function () {
-        var u = '//analytics.deepfence.io/';
-        _paq.push(['setTrackerUrl', u + 'matomo.php']);
-        _paq.push(['setSiteId', '1']);
-        var d = document,
-          g = d.createElement('script'),
-          s = d.getElementsByTagName('script')[0];
-        g.async = true;
-        g.src = u + 'matomo.js';
-        s.parentNode.insertBefore(g, s);
-      })();
-    </script>
-    <!-- End Matomo Code -->
+    <matomo-analytics></matomo-analytics>
   </head>
   <body class="overflow-hidden">
     <div id="root"></div>

--- a/deepfence_frontend/apps/dashboard/index.html
+++ b/deepfence_frontend/apps/dashboard/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -11,6 +11,25 @@
       href="https://fonts.googleapis.com/css2?family=Nunito+Sans:ital,wght@0,400;0,600;0,700;0,800;0,900;1,400;1,600;1,700;1,800;1,900&display=swap"
       rel="stylesheet"
     />
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function () {
+        var u = '//analytics.deepfence.io/';
+        _paq.push(['setTrackerUrl', u + 'matomo.php']);
+        _paq.push(['setSiteId', '1']);
+        var d = document,
+          g = d.createElement('script'),
+          s = d.getElementsByTagName('script')[0];
+        g.async = true;
+        g.src = u + 'matomo.js';
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <!-- End Matomo Code -->
   </head>
   <body class="overflow-hidden">
     <div id="root"></div>

--- a/deepfence_frontend/apps/dashboard/vite.config.ts
+++ b/deepfence_frontend/apps/dashboard/vite.config.ts
@@ -13,37 +13,37 @@ const current = fileURLToPath(import.meta.url);
 const root = path.dirname(current);
 
 const matomoPlugin = (enable: string) => {
-  if (!enable) {
+  if (enable.trim() === 'true') {
     return {
       name: 'analytics-tracking',
       transformIndexHtml(html) {
-        return html.replace(/<analytics-tracking>(.*?)<\/analytics-tracking>/, '');
+        return html.replace(
+          /<analytics-tracking>(.*?)<\/analytics-tracking>/,
+          `<script>
+          var _paq = (window._paq = window._paq || []);
+          /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+          _paq.push(['trackPageView']);
+          _paq.push(['enableLinkTracking']);
+          (function () {
+            var u = '//analytics.deepfence.io/';
+            _paq.push(['setTrackerUrl', u + 'matomo.php']);
+            _paq.push(['setSiteId', '1']);
+            var d = document,
+              g = d.createElement('script'),
+              s = d.getElementsByTagName('script')[0];
+            g.async = true;
+            g.src = u + 'matomo.js';
+            s.parentNode.insertBefore(g, s);
+          })();
+        </script>`,
+        );
       },
     };
   }
   return {
     name: 'analytics-tracking',
     transformIndexHtml(html) {
-      return html.replace(
-        /<analytics-tracking>(.*?)<\/analytics-tracking>/,
-        `<script>
-        var _paq = (window._paq = window._paq || []);
-        /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-        _paq.push(['trackPageView']);
-        _paq.push(['enableLinkTracking']);
-        (function () {
-          var u = '//analytics.deepfence.io/';
-          _paq.push(['setTrackerUrl', u + 'matomo.php']);
-          _paq.push(['setSiteId', '1']);
-          var d = document,
-            g = d.createElement('script'),
-            s = d.getElementsByTagName('script')[0];
-          g.async = true;
-          g.src = u + 'matomo.js';
-          s.parentNode.insertBefore(g, s);
-        })();
-      </script>`,
-      );
+      return html.replace(/<analytics-tracking>(.*?)<\/analytics-tracking>/, '');
     },
   };
 };

--- a/deepfence_frontend/apps/dashboard/vite.config.ts
+++ b/deepfence_frontend/apps/dashboard/vite.config.ts
@@ -12,6 +12,42 @@ import webfontDownload from 'vite-plugin-webfont-dl';
 const current = fileURLToPath(import.meta.url);
 const root = path.dirname(current);
 
+const matomoPlugin = (enable: string) => {
+  if (!enable) {
+    return {
+      name: 'matomo-analytics',
+      transformIndexHtml(html) {
+        return html.replace(/<matomo-analytics>(.*?)<\/matomo-analytics>/, '');
+      },
+    };
+  }
+  return {
+    name: 'matomo-analytics',
+    transformIndexHtml(html) {
+      return html.replace(
+        /<matomo-analytics>(.*?)<\/matomo-analytics>/,
+        `<script>
+        var _paq = (window._paq = window._paq || []);
+        /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+        _paq.push(['trackPageView']);
+        _paq.push(['enableLinkTracking']);
+        (function () {
+          var u = '//analytics.deepfence.io/';
+          _paq.push(['setTrackerUrl', u + 'matomo.php']);
+          _paq.push(['setSiteId', '1']);
+          var d = document,
+            g = d.createElement('script'),
+            s = d.getElementsByTagName('script')[0];
+          g.async = true;
+          g.src = u + 'matomo.js';
+          s.parentNode.insertBefore(g, s);
+        })();
+      </script>`,
+      );
+    },
+  };
+};
+
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   const viteEnv = loadEnv(mode, '.');
@@ -19,6 +55,7 @@ export default defineConfig(({ mode }) => {
     plugins: [
       react(),
       webfontDownload(),
+      matomoPlugin(process.env.ENABLE_MATOMO),
       ...(mode === 'production' ? [visualizer()] : []),
     ],
     test: {

--- a/deepfence_frontend/apps/dashboard/vite.config.ts
+++ b/deepfence_frontend/apps/dashboard/vite.config.ts
@@ -15,17 +15,17 @@ const root = path.dirname(current);
 const matomoPlugin = (enable: string) => {
   if (!enable) {
     return {
-      name: 'matomo-analytics',
+      name: 'analytics-tracking',
       transformIndexHtml(html) {
-        return html.replace(/<matomo-analytics>(.*?)<\/matomo-analytics>/, '');
+        return html.replace(/<analytics-tracking>(.*?)<\/analytics-tracking>/, '');
       },
     };
   }
   return {
-    name: 'matomo-analytics',
+    name: 'analytics-tracking',
     transformIndexHtml(html) {
       return html.replace(
-        /<matomo-analytics>(.*?)<\/matomo-analytics>/,
+        /<analytics-tracking>(.*?)<\/analytics-tracking>/,
         `<script>
         var _paq = (window._paq = window._paq || []);
         /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -55,7 +55,7 @@ export default defineConfig(({ mode }) => {
     plugins: [
       react(),
       webfontDownload(),
-      matomoPlugin(process.env.ENABLE_MATOMO),
+      matomoPlugin(process.env.ENABLE_ANALYTICS),
       ...(mode === 'production' ? [visualizer()] : []),
     ],
     test: {


### PR DESCRIPTION
Analytics are sent to: https://analytics.deepfence.io

earlier attempt to enable analytics: #548 