### PR TITLE
Disable download report and show logs generated

### DIFF
--- a/deepfence_frontend/apps/dashboard/src/features/integrations/components/ReportsTable.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/integrations/components/ReportsTable.tsx
@@ -33,13 +33,26 @@ const ActionDropdown = ({
   trigger: React.ReactNode;
   onTableAction: (row: ModelExportReport, actionType: ActionEnumType) => void;
 }) => {
+  const { status } = row;
+  const isCompleted = useMemo(() => {
+    return status && status.toLowerCase() === 'complete';
+  }, [row]);
+
   return (
     <Dropdown
       triggerAsChild={true}
       align={'start'}
       content={
         <>
-          <DropdownItem onClick={() => onTableAction(row, ActionEnumType.DOWNLOAD)}>
+          <DropdownItem
+            onSelect={() => {
+              if (!isCompleted) {
+                return;
+              }
+              onTableAction(row, ActionEnumType.DOWNLOAD);
+            }}
+            disabled={!isCompleted}
+          >
             Download report
           </DropdownItem>
           <DropdownItem
@@ -180,6 +193,12 @@ export const ReportTable = ({
         pageSize={pageSize}
         onPageResize={(newSize) => {
           setPageSize(newSize);
+        }}
+        getRowId={(row) => {
+          return JSON.stringify({
+            status: row.status,
+            id: row.report_id,
+          });
         }}
         noDataElement={
           <TableNoDataElement text="No reports found, please add new report" />

--- a/deepfence_frontend/apps/dashboard/src/features/settings/pages/DiagnosticLogs.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/settings/pages/DiagnosticLogs.tsx
@@ -151,6 +151,7 @@ const action = async ({ request }: ActionFunctionArgs): Promise<ActionData> => {
       }
       throw logsResponse.error;
     }
+    invalidateAllQueries();
     return {
       success: true,
       message: '',
@@ -177,8 +178,9 @@ const action = async ({ request }: ActionFunctionArgs): Promise<ActionData> => {
       throw logsResponse.error;
     }
     toast.success('Logs generated successfully');
+    invalidateAllQueries();
   }
-  invalidateAllQueries();
+
   return null;
 };
 
@@ -213,7 +215,12 @@ const ConsoleDiagnosticLogsTable = () => {
         maxSize: 85,
       }),
       columnHelper.accessor('message', {
-        cell: (cell) => cell.getValue(),
+        cell: (cell) => {
+          if (!cell.row.original.message) {
+            return 'Logs generated';
+          }
+          return cell.getValue();
+        },
         header: () => 'Message',
         minSize: 75,
         size: 80,
@@ -293,7 +300,12 @@ const AgentDiagnosticLogsTable = () => {
         maxSize: 85,
       }),
       columnHelper.accessor('message', {
-        cell: (cell) => cell.getValue(),
+        cell: (cell) => {
+          if (!cell.row.original.message) {
+            return 'Logs generated';
+          }
+          return cell.getValue();
+        },
         header: () => 'Message',
         minSize: 75,
         size: 80,


### PR DESCRIPTION
Changes proposed in this pull request:
- For error in report creation, disable download report.
- Shows logs generated message in place of empty column.
