### PR TITLE
ISSUE-2084: Fixing the masking and  node id for scan results

### DIFF
--- a/deepfence_server/pkg/registrysync/sync.go
+++ b/deepfence_server/pkg/registrysync/sync.go
@@ -86,7 +86,7 @@ func insertToNeo4j(ctx context.Context, images []model.IngestedContainerImage, r
 		MERGE (n:ContainerImage{node_id:row.node_id})
 		MERGE (s:ImageStub{node_id: row.docker_image_name + "_" + $registry_id, 
 		docker_image_name: row.docker_image_name})
-		MERGE (t:ImageTag{node_id: row.docker_image_name + "_" + row.docker_image_tag + "_" + $registry_id})
+		MERGE (t:ImageTag{node_id: row.docker_image_name + "_" + row.docker_image_tag})
 		MERGE (n) -[:IS]-> (s)
 		MERGE (n) -[:ALIAS]-> (t)
 		MERGE (m:RegistryAccount{node_id:$registry_id})

--- a/deepfence_worker/ingesters/malware.go
+++ b/deepfence_worker/ingesters/malware.go
@@ -6,10 +6,8 @@ import (
 	"time"
 
 	"github.com/deepfence/ThreatMapper/deepfence_utils/directory"
-	"github.com/deepfence/ThreatMapper/deepfence_utils/log"
 	"github.com/deepfence/ThreatMapper/deepfence_utils/utils"
 	ingestersUtil "github.com/deepfence/ThreatMapper/deepfence_utils/utils/ingesters"
-	workerUtil "github.com/deepfence/ThreatMapper/deepfence_worker/utils"
 	"github.com/neo4j/neo4j-go-driver/v4/neo4j"
 )
 
@@ -78,28 +76,12 @@ func malwareToMaps(data []ingestersUtil.Malware,
 		malware := utils.ToMap(i)
 		delete(malware, "meta_rules")
 
-		entityId := ""
-		if _, ok := malware["scan_id"]; ok {
-			scanId := malware["scan_id"].(string)
-			var err error
-			entityId, err = workerUtil.GetEntityIdFromScanID(scanId, string(utils.NEO4JMalwareScan), tx)
-			if err != nil {
-				log.Error().Msgf("Error in getting entityId: %v", err)
-				return nil, err
-			}
-		}
-
 		i.MetaRules.FileSeverity = malware["file_severity"].(string)
 		i.MetaRules.RuleName = malware["rule_name"].(string)
 		i.MetaRules.RuleID = generateMalwareRuleId(i.MetaRules)
 
-		nodeId := generateHashFromString(fmt.Sprintf("%v:%v",
-			i.MetaRules.RuleID, i.CompleteFilename))
-
-		if len(entityId) > 0 {
-			nodeId = nodeId + "_" + entityId
-		}
-		malware["node_id"] = nodeId
+		malware["node_id"] = generateHashFromString(fmt.Sprintf("%v:%v",
+            i.MetaRules.RuleID, i.CompleteFilename))
 
 		malwares = append(malwares, map[string]map[string]interface{}{
 			"Rule":    utils.ToMap(i.MetaRules),

--- a/deepfence_worker/ingesters/secrets.go
+++ b/deepfence_worker/ingesters/secrets.go
@@ -5,10 +5,8 @@ import (
 	"time"
 
 	"github.com/deepfence/ThreatMapper/deepfence_utils/directory"
-	"github.com/deepfence/ThreatMapper/deepfence_utils/log"
 	"github.com/deepfence/ThreatMapper/deepfence_utils/utils"
 	ingestersUtil "github.com/deepfence/ThreatMapper/deepfence_utils/utils/ingesters"
-	workerUtil "github.com/deepfence/ThreatMapper/deepfence_worker/utils"
 	"github.com/neo4j/neo4j-go-driver/v4/neo4j"
 )
 
@@ -78,23 +76,8 @@ func secretsToMaps(data []ingestersUtil.Secret,
 			secret[k] = v
 		}
 
-		entityId := ""
-		if _, ok := secret["scan_id"]; ok {
-			scanId := secret["scan_id"].(string)
-			var err error
-			entityId, err = workerUtil.GetEntityIdFromScanID(scanId, string(utils.NEO4JSecretScan), tx)
-			if err != nil {
-				log.Error().Msgf("Error in getting entityId: %v", err)
-				return nil, err
-			}
-		}
-
-		nodeId := utils.ScanIDReplacer.Replace(fmt.Sprintf("%v:%v",
+		secret["node_id"] = utils.ScanIDReplacer.Replace(fmt.Sprintf("%v:%v", 
 			i.Rule.ID, i.Match.FullFilename))
-		if len(entityId) > 0 {
-			nodeId = nodeId + "_" + entityId
-		}
-		secret["node_id"] = nodeId
 		rule := utils.ToMap(i.Rule)
 		delete(rule, "id")
 		rule["rule_id"] = i.Rule.ID

--- a/deepfence_worker/ingesters/vulnerabilites.go
+++ b/deepfence_worker/ingesters/vulnerabilites.go
@@ -7,7 +7,6 @@ import (
 	"github.com/deepfence/ThreatMapper/deepfence_utils/log"
 	"github.com/deepfence/ThreatMapper/deepfence_utils/utils"
 	ingestersUtil "github.com/deepfence/ThreatMapper/deepfence_utils/utils/ingesters"
-	workerUtil "github.com/deepfence/ThreatMapper/deepfence_worker/utils"
 	"github.com/neo4j/neo4j-go-driver/v4/neo4j"
 )
 
@@ -65,17 +64,11 @@ func CVEsToMaps(ms []ingestersUtil.Vulnerability,
 	for _, v := range ms {
 		data, rule := v.Split()
 
-		entityId, err := workerUtil.GetEntityIdFromScanID(v.ScanID, string(utils.NEO4JVulnerabilityScan), tx)
-		if err != nil {
-			log.Error().Msgf("Error in getting entityId: %v", err)
-			return nil, err
-		}
-
 		res = append(res, map[string]interface{}{
 			"rule":    utils.ToMap(rule),
 			"data":    utils.ToMap(data),
 			"scan_id": v.ScanID,
-			"node_id": workerUtil.GetVulnerabilityNodeID(data.CveCausedByPackage, rule.CveID, entityId),
+			"node_id": data.CveCausedByPackage+rule.CveID,
 		})
 	}
 	return res, nil


### PR DESCRIPTION
Fixes #
https://github.com/deepfence/enterprise-roadmap/issues/2084

Changes proposed in this pull request:
- Changing the node id for the scan results to remove registry id and docker image name
- Added the "MASKED" relationship between the Image Stub and scan results to support Image level masking(mask for all tags for an image).