### PR TITLE
ISSUE-2036: Using node_name for container notifications

### DIFF
--- a/deepfence_server/model/integration.go
+++ b/deepfence_server/model/integration.go
@@ -29,8 +29,9 @@ type IntegrationAddReq struct {
 }
 
 type IntegrationFilters struct {
-	FieldsFilters reporters.FieldsFilters `json:"fields_filters"`
-	NodeIds       []NodeIdentifier        `json:"node_ids" required:"true"`
+	FieldsFilters  reporters.FieldsFilters `json:"fields_filters"`
+	NodeIds        []NodeIdentifier        `json:"node_ids" required:"true"`
+	ContainerNames []string                `json:"container_names" required:"false"`
 }
 
 func (i *IntegrationAddReq) IntegrationExists(ctx context.Context, pgClient *postgresqlDb.Queries) (bool, error) {


### PR DESCRIPTION
Fixes #
https://github.com/deepfence/enterprise-roadmap/issues/2036

Changes proposed in this pull request:
- Using the field `node_name` to the query for checking notifications for the container.