### PR TITLE
add image_stub_filter to list registry image tags

### DIFF
--- a/deepfence_server/handler/container_registry.go
+++ b/deepfence_server/handler/container_registry.go
@@ -624,7 +624,7 @@ func (h *Handler) getImages(w http.ResponseWriter, r *http.Request) ([]model.Con
 		return images, err
 	}
 
-	images, err = model.ListImages(r.Context(), req.RegistryID, req.ImageFilter, req.Window)
+	images, err = model.ListImages(r.Context(), req.RegistryID, req.ImageFilter, req.ImageStubFilter, req.Window)
 	if err != nil {
 		log.Error().Msgf("failed list images: %v", err)
 		h.respondError(err, w)

--- a/deepfence_server/model/registry.go
+++ b/deepfence_server/model/registry.go
@@ -440,10 +440,7 @@ func ListImages(ctx context.Context, registryID string, filter, stubFilter repor
 	}
 
 	condition := reporters.ParseFieldFilters2CypherWhereConditions("m", mo.Some(filter), true)
-	if condition == "" {
-		condition = reporters.ParseFieldFilters2CypherWhereConditions("l", mo.Some(stubFilter), true)
-	}
-
+	condition += reporters.ParseFieldFilters2CypherWhereConditions("l", mo.Some(stubFilter), condition == "")
 	query := `
 	MATCH (n:RegistryAccount{node_id: $id}) -[:HOSTS]-> (l:ImageStub) <-[:IS]- (m:ContainerImage)
 	` + condition + `

--- a/deepfence_server/model/registry.go
+++ b/deepfence_server/model/registry.go
@@ -440,7 +440,7 @@ func ListImages(ctx context.Context, registryID string, filter, stubFilter repor
 	}
 
 	condition := reporters.ParseFieldFilters2CypherWhereConditions("m", mo.Some(filter), true)
-	condition += reporters.ParseFieldFilters2CypherWhereConditions("l", mo.Some(stubFilter), condition == "")
+	condition += ` ` + reporters.ParseFieldFilters2CypherWhereConditions("l", mo.Some(stubFilter), condition == "")
 	query := `
 	MATCH (n:RegistryAccount{node_id: $id}) -[:HOSTS]-> (l:ImageStub) <-[:IS]- (m:ContainerImage)
 	` + condition + `


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:
-  add image_stub_filter to list registry image tags 
- https://github.com/deepfence/ThreatMapper/issues/1967

