### PR TITLE
Add host_node_id in CloudNode Account Info

### DIFF
--- a/deepfence_server/model/cloud_node.go
+++ b/deepfence_server/model/cloud_node.go
@@ -75,6 +75,7 @@ type CloudNodeAccountInfo struct {
 	LastScanStatus       string           `json:"last_scan_status"`
 	ScanStatusMap        map[string]int64 `json:"scan_status_map"`
 	Version              string           `json:"version"`
+	HostNodeID           string           `json:"host_node_id"`
 }
 
 func (v CloudNodeAccountInfo) NodeType() string {


### PR DESCRIPTION
Fixes missing parameter host_node_id in search/cloud-accounts API

Changes proposed in this pull request:
- Add host_node_id in CloudNode Account Info
