### PR TITLE
Fix image tags empty table

### DIFF
--- a/deepfence_frontend/apps/dashboard/api-spec.json
+++ b/deepfence_frontend/apps/dashboard/api-spec.json
@@ -13678,6 +13678,11 @@
         "required": ["node_ids"],
         "type": "object",
         "properties": {
+          "container_names": {
+            "type": "array",
+            "items": { "type": "string" },
+            "nullable": true
+          },
           "fields_filters": { "$ref": "#/components/schemas/ReportersFieldsFilters" },
           "node_ids": {
             "type": "array",
@@ -14107,10 +14112,11 @@
         }
       },
       "ModelRegistryImagesReq": {
-        "required": ["registry_id", "image_filter", "window"],
+        "required": ["registry_id", "image_filter", "image_stub_filter", "window"],
         "type": "object",
         "properties": {
           "image_filter": { "$ref": "#/components/schemas/ReportersFieldsFilters" },
+          "image_stub_filter": { "$ref": "#/components/schemas/ReportersFieldsFilters" },
           "registry_id": { "type": "string" },
           "window": { "$ref": "#/components/schemas/ModelFetchWindow" }
         }
@@ -15282,7 +15288,12 @@
         "type": "object",
         "properties": {
           "sbom_format": {
-            "enum": ["syft-json@11.0.1", "cyclonedx-json@1.5", "spdx-json@2.3"],
+            "enum": [
+              "syft-json@11.0.1",
+              "cyclonedx-json@1.5",
+              "spdx-json@2.2",
+              "spdx-json@2.3"
+            ],
             "type": "string"
           }
         }

--- a/deepfence_frontend/apps/dashboard/src/api/generated/models/ModelRegistryImagesReq.ts
+++ b/deepfence_frontend/apps/dashboard/src/api/generated/models/ModelRegistryImagesReq.ts
@@ -40,6 +40,12 @@ export interface ModelRegistryImagesReq {
     image_filter: ReportersFieldsFilters;
     /**
      * 
+     * @type {ReportersFieldsFilters}
+     * @memberof ModelRegistryImagesReq
+     */
+    image_stub_filter: ReportersFieldsFilters;
+    /**
+     * 
      * @type {string}
      * @memberof ModelRegistryImagesReq
      */
@@ -58,6 +64,7 @@ export interface ModelRegistryImagesReq {
 export function instanceOfModelRegistryImagesReq(value: object): boolean {
     let isInstance = true;
     isInstance = isInstance && "image_filter" in value;
+    isInstance = isInstance && "image_stub_filter" in value;
     isInstance = isInstance && "registry_id" in value;
     isInstance = isInstance && "window" in value;
 
@@ -75,6 +82,7 @@ export function ModelRegistryImagesReqFromJSONTyped(json: any, ignoreDiscriminat
     return {
         
         'image_filter': ReportersFieldsFiltersFromJSON(json['image_filter']),
+        'image_stub_filter': ReportersFieldsFiltersFromJSON(json['image_stub_filter']),
         'registry_id': json['registry_id'],
         'window': ModelFetchWindowFromJSON(json['window']),
     };
@@ -90,6 +98,7 @@ export function ModelRegistryImagesReqToJSON(value?: ModelRegistryImagesReq | nu
     return {
         
         'image_filter': ReportersFieldsFiltersToJSON(value.image_filter),
+        'image_stub_filter': ReportersFieldsFiltersToJSON(value.image_stub_filter),
         'registry_id': value.registry_id,
         'window': ModelFetchWindowToJSON(value.window),
     };

--- a/deepfence_frontend/apps/dashboard/src/api/generated/models/UtilsReportOptions.ts
+++ b/deepfence_frontend/apps/dashboard/src/api/generated/models/UtilsReportOptions.ts
@@ -34,6 +34,7 @@ export interface UtilsReportOptions {
 export const UtilsReportOptionsSbomFormatEnum = {
     SyftJson1101: 'syft-json@11.0.1',
     CyclonedxJson15: 'cyclonedx-json@1.5',
+    SpdxJson22: 'spdx-json@2.2',
     SpdxJson23: 'spdx-json@2.3'
 } as const;
 export type UtilsReportOptionsSbomFormatEnum = typeof UtilsReportOptionsSbomFormatEnum[keyof typeof UtilsReportOptionsSbomFormatEnum];

--- a/deepfence_frontend/apps/dashboard/src/queries/registry.tsx
+++ b/deepfence_frontend/apps/dashboard/src/queries/registry.tsx
@@ -243,6 +243,21 @@ export const registryQueries = createQueryKeys('registry', {
               order_fields: [],
             },
             contains_filter: {
+              filter_in: {},
+            },
+            not_contains_filter: {
+              filter_in: {},
+            },
+          },
+          image_stub_filter: {
+            compare_filter: [],
+            match_filter: {
+              filter_in: {},
+            },
+            order_filter: {
+              order_fields: [],
+            },
+            contains_filter: {
               filter_in: {
                 docker_image_name: [imageId],
               },


### PR DESCRIPTION
Fixes https://github.com/deepfence/ThreatMapper/issues/1967
- Image tag list empty is fixed by using new filter field
