### PR TITLE
Allow use of created_at for Scan timestamp display on UI

### DIFF
--- a/deepfence_server/reporters/search/search.go
+++ b/deepfence_server/reporters/search/search.go
@@ -169,7 +169,7 @@ func constructIndirectMatchInit(
 
 	if doReturn {
 		if extendedField != "" {
-			query += "\n"+`MATCH (` + name + `) -[:IS]-> (e) ` +
+			query += "\n" + `MATCH (` + name + `) -[:IS]-> (e) ` +
 				reporters.ParseFieldFilters2CypherWhereConditions("e", mo.Some(extendedFilter.Filters), true) +
 				reporters.OrderFilter2CypherCondition("e", extendedFilter.Filters.OrderFilter, []string{name}) +
 				` RETURN ` + reporters.FieldFilterCypher(name, filter.InFieldFilter) + `, e` +
@@ -480,7 +480,7 @@ func searchGenericScanInfoReport(ctx context.Context, scanType utils.Neo4jScanTy
 	    ORDER BY n.updated_at DESC` +
 		scanFilter.Window.FetchWindow2CypherQuery() +
 		`}` +
-		` RETURN n.node_id as scan_id, n.status as status, n.status_message as status_message, n.updated_at as updated_at, m.node_id as node_id, COALESCE(m.node_type, m.cloud_provider) as node_type, m.node_name as node_name` +
+		` RETURN n.node_id as scan_id, n.status as status, n.status_message as status_message, n.created_at as created_at, n.updated_at as updated_at, m.node_id as node_id, COALESCE(m.node_type, m.cloud_provider) as node_type, m.node_name as node_name` +
 		reporters.OrderFilter2CypherCondition("", scanFilter.Filters.OrderFilter, nil) +
 		fw.FetchWindow2CypherQuery()
 	log.Debug().Msgf("search query: %v", query)
@@ -507,10 +507,11 @@ func searchGenericScanInfoReport(ctx context.Context, scanType utils.Neo4jScanTy
 			ScanID:         rec.Values[0].(string),
 			Status:         rec.Values[1].(string),
 			StatusMessage:  rec.Values[2].(string),
-			UpdatedAt:      rec.Values[3].(int64),
-			NodeID:         rec.Values[4].(string),
-			NodeType:       rec.Values[5].(string),
-			NodeName:       rec.Values[6].(string),
+			CreatedAt:      rec.Values[3].(int64),
+			UpdatedAt:      rec.Values[4].(int64),
+			NodeID:         rec.Values[5].(string),
+			NodeType:       rec.Values[6].(string),
+			NodeName:       rec.Values[7].(string),
 			SeverityCounts: counts,
 		})
 	}


### PR DESCRIPTION
Fixes deepfence/enterprise-roadmap#2077

Changes proposed in this pull request:
- Add created_at to queries corresponding to Scan APIs

