### PR TITLE
ISSUE-2080: Adding intermediate "DELETE_PENDING" state

### DIFF
--- a/deepfence_utils/utils/constants.go
+++ b/deepfence_utils/utils/constants.go
@@ -67,6 +67,7 @@ const (
 	ScanStatusCancelPending = "CANCEL_PENDING"
 	ScanStatusCancelling    = "CANCELLING"
 	ScanStatusCancelled     = "CANCELLED"
+	ScanStatusDeletePending = "DELETE_PENDING"
 )
 
 // Neo4j Node Labels


### PR DESCRIPTION
Fixes #
https://github.com/deepfence/enterprise-roadmap/issues/2080

Changes proposed in this pull request:
Adding an intermediate state `DELETE_PENDING` for the scans submitted for deletion.