### PR TITLE
File server url in Global Setting

### DIFF
--- a/deepfence_server/handler/settings.go
+++ b/deepfence_server/handler/settings.go
@@ -199,7 +199,7 @@ func (h *Handler) UpdateGlobalSettings(w http.ResponseWriter, r *http.Request) {
 	}
 	var value interface{}
 	switch currentSettings.Key {
-	case model.ConsoleURLSettingKey:
+	case model.ConsoleURLSettingKey, model.FileServerURLSettingKey:
 		var parsedURL *url.URL
 		if parsedURL, err = url.ParseRequestURI(strings.TrimSpace(req.Value)); err != nil {
 			h.respondError(&errInvalidURL, w)

--- a/deepfence_server/handler/user.go
+++ b/deepfence_server/handler/user.go
@@ -115,6 +115,21 @@ func (h *Handler) RegisterUser(w http.ResponseWriter, r *http.Request) {
 		h.respondError(err, w)
 		return
 	}
+	fileServerURLSetting := model.Setting{
+		Key: model.FileServerURLSettingKey,
+		Value: &model.SettingValue{
+			Label:       utils.FileServerURLSettingLabel,
+			Value:       consoleURL,
+			Description: utils.FileServerURLSettingDescription,
+		},
+		IsVisibleOnUI: true,
+	}
+	_, err = fileServerURLSetting.Create(ctx, pgClient)
+	if err != nil {
+		log.Error().Msgf(err.Error())
+		h.respondError(err, w)
+		return
+	}
 
 	emailDomain, _ := utils.GetEmailDomain(registerRequest.Email)
 	c := model.Company{

--- a/deepfence_server/model/setting.go
+++ b/deepfence_server/model/setting.go
@@ -19,6 +19,7 @@ import (
 
 const (
 	ConsoleURLSettingKey              = "console_url"
+	FileServerURLSettingKey           = "file_server_url"
 	EmailConfigurationKey             = "email_configuration"
 	EmailSettingSES                   = "amazon_ses"
 	EmailSettingSMTP                  = "smtp"
@@ -65,7 +66,7 @@ type GetAuditLogsRequest struct {
 
 type SettingUpdateRequest struct {
 	ID    int64  `path:"id" validate:"required" required:"true"`
-	Key   string `json:"key" validate:"required,oneof=console_url inactive_delete_scan_results" required:"true" enum:"console_url,inactive_delete_scan_results"`
+	Key   string `json:"key" validate:"required,oneof=console_url file_server_url inactive_delete_scan_results" required:"true" enum:"console_url,file_server_url,inactive_delete_scan_results"`
 	Value string `json:"value" validate:"required" required:"true"`
 }
 

--- a/deepfence_utils/directory/fileserver.go
+++ b/deepfence_utils/directory/fileserver.go
@@ -303,7 +303,7 @@ func (mfm *FileServerFileManager) ExposeFile(ctx context.Context, filePath strin
 	ctx, span := telemetry.NewSpan(ctx, "fileserver", "expose-file")
 	defer span.End()
 
-	consoleIP, err := GetManagementHost(ctx)
+	consoleIP, err := GetFileServerHost(ctx)
 	if err != nil {
 		span.EndWithErr(err)
 		return "", err
@@ -345,7 +345,7 @@ func (mfm *FileServerFileManager) CreatePublicUploadURL(ctx context.Context, fil
 	ctx, span := telemetry.NewSpan(ctx, "fileserver", "create-public-upload-url")
 	defer span.End()
 
-	consoleIP, err := GetManagementHost(ctx)
+	consoleIP, err := GetFileServerHost(ctx)
 	if err != nil {
 		span.EndWithErr(err)
 		return "", err

--- a/deepfence_utils/directory/postgresql.go
+++ b/deepfence_utils/directory/postgresql.go
@@ -17,7 +17,7 @@ import (
 var ErrDatabaseConfigNotFound = errors.New("database config not found")
 
 const (
-	ConsoleURLSettingKey = "console_url"
+	FileServerURLSettingKey = "file_server_url"
 )
 
 type SettingValue struct {
@@ -83,12 +83,12 @@ func NewSQLConnection(ctx context.Context) (*sql.DB, error) {
 	return db, nil
 }
 
-func GetManagementConsoleURL(ctx context.Context) (string, error) {
+func GetFileServerURL(ctx context.Context) (string, error) {
 	pgClient, err := PostgresClient(ctx)
 	if err != nil {
 		return "", err
 	}
-	setting, err := pgClient.GetSetting(ctx, ConsoleURLSettingKey)
+	setting, err := pgClient.GetSetting(ctx, FileServerURLSettingKey)
 	if err != nil {
 		return "", err
 	}
@@ -100,8 +100,8 @@ func GetManagementConsoleURL(ctx context.Context) (string, error) {
 	return fmt.Sprintf("%v", settingVal.Value), nil
 }
 
-func GetManagementHost(ctx context.Context) (string, error) {
-	url, err := GetManagementConsoleURL(ctx)
+func GetFileServerHost(ctx context.Context) (string, error) {
+	url, err := GetFileServerURL(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/deepfence_utils/utils/constants.go
+++ b/deepfence_utils/utils/constants.go
@@ -242,3 +242,8 @@ const (
 	MaskEntity      = "mask_entity"
 	MaskImageTag    = "mask_image_tag"
 )
+
+const (
+	FileServerURLSettingLabel       = "Console File Server URL"
+	FileServerURLSettingDescription = "Serve threat intel feeds to agents. If agents are connected using a different URL than Console URL, please change this"
+)

--- a/deepfence_worker/cronjobs/rules_fetcher.go
+++ b/deepfence_worker/cronjobs/rules_fetcher.go
@@ -101,7 +101,7 @@ func FetchThreatIntel(ctx context.Context, task *asynq.Task) error {
 	log.Info().Msgf("Fetch threat intel")
 	defer log.Info().Msgf("Fetch threat intel done")
 
-	_, err := directory.GetManagementHost(ctx)
+	_, err := directory.GetFileServerHost(ctx)
 	if err != nil {
 		log.Warn().Msg("FetchThreatIntel Management console URL not configured yet")
 		return nil

--- a/deepfence_worker/cronscheduler/init_db.go
+++ b/deepfence_worker/cronscheduler/init_db.go
@@ -68,7 +68,7 @@ func initSqlDatabase(ctx context.Context) error {
 		// Copy ConsoleURLSetting to FileServerURLSetting
 		consoleURLSetting, err := model.GetSettingByKey(ctx, pgClient, model.ConsoleURLSettingKey)
 		// Skip if ConsoleURLSetting is not set
-		if err != nil {
+		if err == nil {
 			fileServerURLSetting := model.Setting{
 				Key: model.FileServerURLSettingKey,
 				Value: &model.SettingValue{
@@ -80,7 +80,7 @@ func initSqlDatabase(ctx context.Context) error {
 			}
 			_, err = fileServerURLSetting.Create(ctx, pgClient)
 			if err != nil {
-
+				log.Error().Err(err).Msg("failed to set FileServerURLSetting")
 			}
 		}
 	}

--- a/deepfence_worker/cronscheduler/init_db.go
+++ b/deepfence_worker/cronscheduler/init_db.go
@@ -7,6 +7,7 @@ import (
 	"github.com/deepfence/ThreatMapper/deepfence_utils/directory"
 	"github.com/deepfence/ThreatMapper/deepfence_utils/log"
 	"github.com/deepfence/ThreatMapper/deepfence_utils/telemetry"
+	"github.com/deepfence/ThreatMapper/deepfence_utils/utils"
 	"github.com/pressly/goose/v3"
 )
 
@@ -59,6 +60,29 @@ func initSqlDatabase(ctx context.Context) error {
 	if err != nil {
 		log.Error().Err(err).Msg("failed to get db client")
 		return err
+	}
+
+	_, err = model.GetSettingByKey(ctx, pgClient, model.FileServerURLSettingKey)
+	if err != nil {
+		// FileServerURLSetting is not set
+		// Copy ConsoleURLSetting to FileServerURLSetting
+		consoleURLSetting, err := model.GetSettingByKey(ctx, pgClient, model.ConsoleURLSettingKey)
+		// Skip if ConsoleURLSetting is not set
+		if err != nil {
+			fileServerURLSetting := model.Setting{
+				Key: model.FileServerURLSettingKey,
+				Value: &model.SettingValue{
+					Label:       utils.FileServerURLSettingLabel,
+					Value:       consoleURLSetting.Value.Value,
+					Description: utils.FileServerURLSettingDescription,
+				},
+				IsVisibleOnUI: true,
+			}
+			_, err = fileServerURLSetting.Create(ctx, pgClient)
+			if err != nil {
+
+			}
+		}
 	}
 
 	err = model.InitializeScheduledTasks(ctx, pgClient)


### PR DESCRIPTION
In case agents connect to console via a URL which is not used in browser, this can be changed to that URL for downloading threat intel feeds and uploading diagnostic logs.

Example: A domain name is configured in Okta and used to open UI. Agents connect via internal ip address or load balancer. Communication with file server can be changed to internal ip now.