### PR TITLE
Make AWS Account ID mandatory for ECR registry and S3 integration

### DIFF
--- a/deepfence_server/pkg/integration/s3/types.go
+++ b/deepfence_server/pkg/integration/s3/types.go
@@ -2,9 +2,19 @@ package s3
 
 import (
 	"bytes"
+	"errors"
 
 	"github.com/deepfence/ThreatMapper/deepfence_server/reporters"
 	"github.com/go-playground/validator/v10"
+)
+
+const (
+	trueStr = "true"
+)
+
+var (
+	errAccessKeyMissing = errors.New("access key and secret key are required")
+	errAccountIDMissing = errors.New("account id is required")
 )
 
 type S3 struct {
@@ -28,5 +38,16 @@ type Config struct {
 }
 
 func (s S3) ValidateConfig(validate *validator.Validate) error {
+	if s.Config.UseIAMRole == trueStr {
+		// IAM role based authentication
+		if s.Config.AWSAccountID == "" {
+			return errAccountIDMissing
+		}
+	} else {
+		// Key based authentication
+		if s.Config.AWSAccessKey == "" || s.Config.AWSSecretKey == "" {
+			return errAccessKeyMissing
+		}
+	}
 	return validate.Struct(s.Config)
 }

--- a/deepfence_server/pkg/integration/s3/types.go
+++ b/deepfence_server/pkg/integration/s3/types.go
@@ -33,17 +33,12 @@ type Config struct {
 	S3FolderName         string `json:"s3_folder_name" validate:"required,min=1,max=128" required:"true"`
 	AWSRegion            string `json:"aws_region" validate:"required,oneof=us-east-1 us-east-2 us-west-1 us-west-2 af-south-1 ap-east-1 ap-south-1 ap-northeast-1 ap-northeast-2 ap-northeast-3 ap-southeast-1 ap-southeast-2 ap-southeast-3 ca-central-1 eu-central-1 eu-west-1 eu-west-2 eu-west-3 eu-south-1 eu-north-1 me-south-1 me-central-1 sa-east-1 us-gov-east-1 us-gov-west-1" required:"true"`
 	UseIAMRole           string `json:"use_iam_role" validate:"required,oneof=true false"`
-	AWSAccountID         string `json:"aws_account_id" validate:"omitempty,min=10,max=12"`
+	AWSAccountID         string `json:"aws_account_id" validate:"required,min=10,max=12"`
 	TargetAccountRoleARN string `json:"target_account_role_arn" validate:"omitempty,startswith=arn,min=8"`
 }
 
 func (s S3) ValidateConfig(validate *validator.Validate) error {
-	if s.Config.UseIAMRole == trueStr {
-		// IAM role based authentication
-		if s.Config.AWSAccountID == "" {
-			return errAccountIDMissing
-		}
-	} else {
+	if s.Config.UseIAMRole != trueStr {
 		// Key based authentication
 		if s.Config.AWSAccessKey == "" || s.Config.AWSSecretKey == "" {
 			return errAccessKeyMissing

--- a/deepfence_server/pkg/registry/ecr/client.go
+++ b/deepfence_server/pkg/registry/ecr/client.go
@@ -29,18 +29,8 @@ func listIAMImages(awsRegion, awsAccountID, targetAccountRoleARN string, isPubli
 	// if targetRoleARN is empty, that means
 	// it is not a crossaccount ecr, no need to use stscreds
 	if targetAccountRoleARN != "" {
-		if awsAccountID == "" {
-			return nil, fmt.Errorf("for cross account ECR, account ID is mandatory")
-		}
 		creds := stscreds.NewCredentials(sess, targetAccountRoleARN)
 		awsConfig.Credentials = creds
-	}
-	// in case of single account, fetch accountid if not provided
-	if awsAccountID == "" {
-		awsAccountID, err = getAWSAccountID()
-		if err != nil {
-			return nil, fmt.Errorf("error getting AWS account ID: make sure IAMRole has instance profile ARN attached: %v", err)
-		}
 	}
 
 	if isPublic {

--- a/deepfence_server/pkg/registry/ecr/ecr.go
+++ b/deepfence_server/pkg/registry/ecr/ecr.go
@@ -14,6 +14,7 @@ import (
 
 var (
 	errAccessKeyMissing     = errors.New("access key and secret key are required")
+	errAccountIDMissing     = errors.New("account id is required")
 	errPublicRegistryRegion = errors.New("region should be set to " + publicRegistryRegion + " for public registry")
 )
 
@@ -34,6 +35,9 @@ func (e *RegistryECR) ValidateFields(v *validator.Validate) error {
 	}
 	if e.NonSecret.UseIAMRole == trueStr {
 		// IAM role based authentication
+		if e.NonSecret.AWSAccountID == "" {
+			return errAccountIDMissing
+		}
 		return v.Struct(e)
 	} else {
 		// Key based authentication

--- a/deepfence_server/pkg/registry/ecr/ecr.go
+++ b/deepfence_server/pkg/registry/ecr/ecr.go
@@ -33,19 +33,13 @@ func (e *RegistryECR) ValidateFields(v *validator.Validate) error {
 			return errPublicRegistryRegion
 		}
 	}
-	if e.NonSecret.UseIAMRole == trueStr {
-		// IAM role based authentication
-		if e.NonSecret.AWSAccountID == "" {
-			return errAccountIDMissing
-		}
-		return v.Struct(e)
-	} else {
+	if e.NonSecret.UseIAMRole != trueStr {
 		// Key based authentication
 		if e.NonSecret.AWSAccessKeyID == "" || e.Secret.AWSSecretAccessKey == "" {
 			return errAccessKeyMissing
 		}
-		return v.Struct(e)
 	}
+	return v.Struct(e)
 }
 
 func (e *RegistryECR) IsValidCredential() bool {

--- a/deepfence_server/pkg/registry/ecr/types.go
+++ b/deepfence_server/pkg/registry/ecr/types.go
@@ -21,7 +21,7 @@ type NonSecret struct {
 	IsPublic             string `json:"is_public" validate:"required,oneof=true false"`
 	AWSAccessKeyID       string `json:"aws_access_key_id" validate:"omitempty,min=16,max=128"`
 	AWSRegionName        string `json:"aws_region_name" validate:"required,oneof=us-east-1 us-east-2 us-west-1 us-west-2 af-south-1 ap-east-1 ap-south-1 ap-northeast-1 ap-northeast-2 ap-northeast-3 ap-southeast-1 ap-southeast-2 ap-southeast-3 ca-central-1 eu-central-1 eu-west-1 eu-west-2 eu-west-3 eu-south-1 eu-north-1 me-south-1 me-central-1 sa-east-1 us-gov-east-1 us-gov-west-1"`
-	AWSAccountID         string `json:"aws_account_id" validate:"omitempty,min=10,max=12"` // legacy: registry_id
+	AWSAccountID         string `json:"aws_account_id" validate:"required,min=10,max=12"` // legacy: registry_id
 	TargetAccountRoleARN string `json:"target_account_role_arn" validate:"omitempty,startswith=arn,min=8"`
 }
 


### PR DESCRIPTION
Fixes deepfence/enterprise-roadmap#2156

Changes proposed in this pull request:
- Make account id mandatory for ECR registry and S3 integration
- Remove account id fetch from metadata
