### PR TITLE
(fix) make vulnerability node_id more unique

### DIFF
--- a/deepfence_worker/ingesters/vulnerabilites.go
+++ b/deepfence_worker/ingesters/vulnerabilites.go
@@ -2,6 +2,7 @@ package ingesters
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/deepfence/ThreatMapper/deepfence_utils/directory"
@@ -73,7 +74,7 @@ func CVEsToMaps(ms []ingestersUtil.Vulnerability) ([]map[string]interface{}, err
 			"rule":    utils.ToMap(rule),
 			"data":    utils.ToMap(data),
 			"scan_id": v.ScanID,
-			"node_id": data.CveCausedByPackagePath + data.CveCausedByPackage + rule.CveID,
+			"node_id": strings.Join([]string{data.CveCausedByPackagePath + data.CveCausedByPackage + rule.CveID}, "_"),
 		})
 	}
 	return res, nil

--- a/deepfence_worker/ingesters/vulnerabilites.go
+++ b/deepfence_worker/ingesters/vulnerabilites.go
@@ -24,9 +24,7 @@ func CommitFuncVulnerabilities(ctx context.Context, ns string, data []ingestersU
 	}
 
 	session := driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
-	if err != nil {
-		return err
-	}
+
 	defer session.Close(ctx)
 
 	tx, err := session.BeginTransaction(ctx, neo4j.WithTxTimeout(30*time.Second))
@@ -39,6 +37,8 @@ func CommitFuncVulnerabilities(ctx context.Context, ns string, data []ingestersU
 	if err != nil {
 		return err
 	}
+
+	log.Debug().Msgf("Committing %d vulnerabilities", len(dataMap))
 
 	if _, err = tx.Run(ctx, `
 		UNWIND $batch as row WITH row.rule as rule, row.data as data, 
@@ -73,7 +73,7 @@ func CVEsToMaps(ms []ingestersUtil.Vulnerability) ([]map[string]interface{}, err
 			"rule":    utils.ToMap(rule),
 			"data":    utils.ToMap(data),
 			"scan_id": v.ScanID,
-			"node_id": data.CveCausedByPackage + rule.CveID,
+			"node_id": data.CveCausedByPackagePath + data.CveCausedByPackage + rule.CveID,
 		})
 	}
 	return res, nil


### PR DESCRIPTION
package (p1),version(v1), package_path (pp1) : vuln(cve1)
package (p1), version(v1), package_path (pp2): vuln(cve1)

In this case we were dropping vulnerabilities.

Example:

Two vulnerability with same cve, same package, same version, **but different package_path** 

```json
{
    "data": {
      "cve_caused_by_package": "github.com/docker/distribution:v2.8.1+incompatible",
      "cve_caused_by_package_path": "/home/deepfence/bin/package-scanner",
      "cve_container_layer": "",
      "cve_id": "CVE-2023-2253",
      "cve_link": "https://www.openwall.com/lists/oss-security/2023/05/09/1",
      "cve_severity": "medium",
      "exploitability_score": 2,
      "has_live_connection": false,
      "init_exploitability_score": 2
    },
    "node_id": "github.com/docker/distribution:v2.8.1+incompatibleCVE-2023-2253",
    "rule": {
      "cve_attack_vector": "cvss:3.1/av:n/ac:l/pr:l/ui:n/s:u/c:n/i:n/a:h",
      "cve_cvss_score": 6.5,
      "cve_description": "A flaw was found in the `/v2/_catalog` endpoint in distribution/distribution, which accepts a parameter to control the maximum number of records returned (query string: `n`). This vulnerability allows a malicious user to submit an unreasonably large value for `n,` causing the allocation of a massive string array, possibly causing a denial of service through excessive use of memory.",
      "cve_fixed_in": "2.8.2-beta.1",
      "cve_id": "CVE-2023-2253",
      "cve_link": "https://www.openwall.com/lists/oss-security/2023/05/09/1",
      "cve_overall_score": 6.5,
      "cve_severity": "medium",
      "cve_type": "golang",
      "exploit_poc": "",
      "parsed_attack_vector": "network",
      "urls": [
        "https://access.redhat.com/security/cve/CVE-2023-2253",
      ]
    },
    "scan_id": ""
  },
```

```json
{
    "data": {
      "cve_caused_by_package": "github.com/docker/distribution:v2.8.1+incompatible",
      "cve_caused_by_package_path": "/usr/local/bin/vessel",
      "cve_container_layer": "",
      "cve_id": "CVE-2023-2253",
      "cve_link": "https://www.openwall.com/lists/oss-security/2023/05/09/1",
      "cve_severity": "medium",
      "exploitability_score": 2,
      "has_live_connection": false,
      "init_exploitability_score": 2
    },
    "node_id": "github.com/docker/distribution:v2.8.1+incompatibleCVE-2023-2253",
    "rule": {
      "cve_attack_vector": "cvss:3.1/av:n/ac:l/pr:l/ui:n/s:u/c:n/i:n/a:h",
      "cve_cvss_score": 6.5,
      "cve_description": "A flaw was found in the `/v2/_catalog` endpoint in distribution/distribution, which accepts a parameter to control the maximum number of records returned (query string: `n`). This vulnerability allows a malicious user to submit an unreasonably large value for `n,` causing the allocation of a massive string array, possibly causing a denial of service through excessive use of memory.",
      "cve_fixed_in": "2.8.2-beta.1",
      "cve_id": "CVE-2023-2253",
      "cve_link": "https://www.openwall.com/lists/oss-security/2023/05/09/1",
      "cve_overall_score": 6.5,
      "cve_severity": "medium",
      "cve_type": "golang",
      "exploit_poc": "",
      "parsed_attack_vector": "network",
      "urls": [
        "https://access.redhat.com/security/cve/CVE-2023-2253",
      ]
    },
    "scan_id": ""
  },
```

Using ID with cve_id + package_name + package_version, might led to dropping of CVEs which we have observed recently.
