### PR TITLE
Fix incorrect scan status on the node with a failed scan history

### DIFF
--- a/deepfence_utils/utils/kafka.go
+++ b/deepfence_utils/utils/kafka.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"time"
 
 	"github.com/deepfence/ThreatMapper/deepfence_utils/log"
 	"github.com/rs/zerolog"
@@ -83,6 +84,8 @@ func StartKafkaProducer(
 		kgo.SeedBrokers(brokers...),
 		kgo.WithLogger(KgoLogger),
 		kgo.UnknownTopicRetries(3),
+		kgo.RecordRetries(10),
+		kgo.AutoCommitInterval(1 * time.Second),
 	}
 
 	kClient, err := kgo.NewClient(opts...)

--- a/deepfence_worker/cronjobs/neo4j.go
+++ b/deepfence_worker/cronjobs/neo4j.go
@@ -298,9 +298,10 @@ func CleanUpDB(ctx context.Context, task *asynq.Task) error {
 			MATCH (n:`+string(ts)+`) -[:SCANNED]-> (r)
 			WHERE n.retries >= 3
 			WITH n, r LIMIT 10000
-			SET n.status = $new_status,
-				r.`+ingestersUtil.ScanStatusField[ts]+`=n.status,
-				r.`+ingestersUtil.LatestScanIDField[ts]+`=n.node_id`,
+			SET n.status = $new_status
+			WITH n, r
+			MATCH (r) WHERE r.`+ingestersUtil.LatestScanIDField[ts]+`=n.node_id
+			SET r.`+ingestersUtil.ScanStatusField[ts]+`=n.status`,
 			map[string]interface{}{
 				"time_ms":    dbScanTimeout.Milliseconds(),
 				"new_status": utils.ScanStatusFailed,


### PR DESCRIPTION
For a given host, secret scan 1 ended in `ERROR`, after retrying 3 times.
Secret scan 2 succeeded.

Latest scan id and status will always be scan 1 (ERROR).

In the neo4j cleanup, when setting host scan status as `ERROR`, we should check if it is the latest scan. This should not happen for old scans.