### PR TITLE
add api to send test email

### DIFF
--- a/deepfence_server/apiDocs/operation.go
+++ b/deepfence_server/apiDocs/operation.go
@@ -799,7 +799,7 @@ func (d *OpenAPIDocs) AddSettingsOperations() {
 		http.StatusNoContent, []string{tagSettings}, bearerToken, new(ConfigIDPathReq), nil)
 	d.AddOperation("testConfiguredEmail", http.MethodPost, "/deepfence/settings/email/test",
 		"Test Configured Email", "Test Configured Email",
-		http.StatusOK, []string{tagSettings}, bearerToken, new(EmailConfigurationTest), new(MessageResponse))
+		http.StatusOK, []string{tagSettings}, bearerToken, nil, new(MessageResponse))
 	d.AddOperation("getSettings", http.MethodGet, "/deepfence/settings/global-settings",
 		"Get settings", "Get all settings",
 		http.StatusOK, []string{tagSettings}, bearerToken, nil, new([]SettingsResponse))

--- a/deepfence_server/apiDocs/operation.go
+++ b/deepfence_server/apiDocs/operation.go
@@ -797,6 +797,9 @@ func (d *OpenAPIDocs) AddSettingsOperations() {
 	d.AddOperation("deleteEmailConfiguration", http.MethodDelete, "/deepfence/settings/email/{config_id}",
 		"Delete Email Configurations", "Delete Email Smtp / ses Configurations in system",
 		http.StatusNoContent, []string{tagSettings}, bearerToken, new(ConfigIDPathReq), nil)
+	d.AddOperation("testConfiguredEmail", http.MethodPost, "/deepfence/settings/email/test",
+		"Test Configured Email", "Test Configured Email",
+		http.StatusOK, []string{tagSettings}, bearerToken, new(EmailConfigurationTest), new(MessageResponse))
 	d.AddOperation("getSettings", http.MethodGet, "/deepfence/settings/global-settings",
 		"Get settings", "Get all settings",
 		http.StatusOK, []string{tagSettings}, bearerToken, nil, new([]SettingsResponse))

--- a/deepfence_server/constants/api-messages/success.go
+++ b/deepfence_server/constants/api-messages/success.go
@@ -9,6 +9,7 @@ const (
 	SuccessIntegrationUpdated         = "integration updated successfully"
 	SuccessIntegrationCreated         = "integration added successfully"
 	SuccessEmailConfigCreated         = "email configuration added successfully"
+	SuccessEmailConfigTest            = "test email sent successfully"
 	ErrIntegrationDoesNotExist        = "integration does not exist"
 	ErrIntegrationTypeCannotBeUpdated = "integration type cannot be updated"
 	ErrIntegrationTypeEmpty           = "integration type cannot be empty"

--- a/deepfence_server/handler/settings.go
+++ b/deepfence_server/handler/settings.go
@@ -156,11 +156,10 @@ func (h *Handler) TestConfiguredEmail(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 	ctx := r.Context()
 
-	// get email from body
-	var req model.EmailConfigurationTest
-	err := httpext.DecodeJSON(r, httpext.NoQueryParams, MaxPostRequestSize, &req)
+	user, statusCode, _, err := h.GetUserFromJWT(ctx)
 	if err != nil {
-		h.respondError(&BadDecoding{err}, w)
+		log.Debug().Msgf("error getting user from jwt: %v", err)
+		h.respondWithErrorCode(err, w, statusCode)
 		return
 	}
 
@@ -170,7 +169,7 @@ func (h *Handler) TestConfiguredEmail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = emailSender.Send([]string{req.EmailID}, "Deepfence Testmail", "This is a test email", "", nil)
+	err = emailSender.Send([]string{user.Email}, "Deepfence Testmail", "This is a test email", "", nil)
 	if err != nil {
 		h.respondError(&InternalServerError{err}, w)
 		return

--- a/deepfence_server/model/email_configuration.go
+++ b/deepfence_server/model/email_configuration.go
@@ -37,6 +37,10 @@ type EmailConfigurationAdd struct {
 	SesRegion       string `json:"ses_region"`
 }
 
+type EmailConfigurationTest struct {
+	EmailID string `json:"email_id" validate:"required,email"`
+}
+
 type EmailConfigurationResp struct {
 	ID              int64  `json:"id"`
 	EmailProvider   string `json:"email_provider"`

--- a/deepfence_server/model/email_configuration.go
+++ b/deepfence_server/model/email_configuration.go
@@ -37,10 +37,6 @@ type EmailConfigurationAdd struct {
 	SesRegion       string `json:"ses_region"`
 }
 
-type EmailConfigurationTest struct {
-	EmailID string `json:"email_id" validate:"required,email"`
-}
-
 type EmailConfigurationResp struct {
 	ID              int64  `json:"id"`
 	EmailProvider   string `json:"email_provider"`

--- a/deepfence_server/router/router.go
+++ b/deepfence_server/router/router.go
@@ -218,6 +218,7 @@ func SetupRoutes(r *chi.Mux, serverPort string, serveOpenapiDocs bool, ingestC c
 				r.Post("/email", dfHandler.AuthHandler(ResourceSettings, PermissionWrite, dfHandler.AddEmailConfiguration))
 				r.Get("/email", dfHandler.AuthHandler(ResourceSettings, PermissionRead, dfHandler.GetEmailConfiguration))
 				r.Delete("/email/{config_id}", dfHandler.AuthHandler(ResourceSettings, PermissionDelete, dfHandler.DeleteEmailConfiguration))
+				r.Post("/email/test", dfHandler.AuthHandler(ResourceSettings, PermissionDelete, dfHandler.TestConfiguredEmail))
 				r.Put("/agent/version", dfHandler.AuthHandler(ResourceSettings, PermissionWrite, dfHandler.UploadAgentBinaries))
 				r.Get("/agent/versions", dfHandler.AuthHandler(ResourceSettings, PermissionWrite, dfHandler.ListAgentVersion))
 			})


### PR DESCRIPTION
ref: https://github.com/deepfence/ThreatMapper/issues/1367

Adds API to send email to configured email. API needs an email which is receipt email.