### PR TITLE
(feat.) sendgrid support in email conf

### DIFF
--- a/deepfence_server/apiDocs/operation.go
+++ b/deepfence_server/apiDocs/operation.go
@@ -800,6 +800,9 @@ func (d *OpenAPIDocs) AddSettingsOperations() {
 	d.AddOperation("testConfiguredEmail", http.MethodPost, "/deepfence/settings/email/test",
 		"Test Configured Email", "Test Configured Email",
 		http.StatusOK, []string{tagSettings}, bearerToken, nil, new(MessageResponse))
+	d.AddOperation("testUnconfiguredEmail", http.MethodPost, "/deepfence/settings/email/test-unconfigured",
+		"Test Unconfigured Email", "Test Unconfigured Email",
+		http.StatusOK, []string{tagSettings}, bearerToken, new(EmailConfigurationAdd), new(MessageResponse))
 	d.AddOperation("getSettings", http.MethodGet, "/deepfence/settings/global-settings",
 		"Get settings", "Get all settings",
 		http.StatusOK, []string{tagSettings}, bearerToken, nil, new([]SettingsResponse))

--- a/deepfence_server/go.mod
+++ b/deepfence_server/go.mod
@@ -56,6 +56,8 @@ require (
 
 )
 
+require github.com/sendgrid/rest v2.6.9+incompatible // indirect
+
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.2.0 // indirect
@@ -126,6 +128,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/rs/xid v1.5.0 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
+	github.com/sendgrid/sendgrid-go v3.14.0+incompatible
 	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/deepfence_server/go.sum
+++ b/deepfence_server/go.sum
@@ -264,6 +264,10 @@ github.com/sashabaranov/go-openai v1.17.10 h1:ybvWN+d/rgEK/64U6dsjnOQ9AUya2wBoJK
 github.com/sashabaranov/go-openai v1.17.10/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=
 github.com/segmentio/asm v1.2.0/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
+github.com/sendgrid/rest v2.6.9+incompatible h1:1EyIcsNdn9KIisLW50MKwmSRSK+ekueiEMJ7NEoxJo0=
+github.com/sendgrid/rest v2.6.9+incompatible/go.mod h1:kXX7q3jZtJXK5c5qK83bSGMdV6tsOE70KbHoqJls4lE=
+github.com/sendgrid/sendgrid-go v3.14.0+incompatible h1:KDSasSTktAqMJCYClHVE94Fcif2i7P7wzISv1sU6DUA=
+github.com/sendgrid/sendgrid-go v3.14.0+incompatible/go.mod h1:QRQt+LX/NmgVEvmdRw0VT/QgUn499+iza2FnDca9fg8=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
 github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
 github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=

--- a/deepfence_server/handler/settings.go
+++ b/deepfence_server/handler/settings.go
@@ -58,6 +58,11 @@ func (h *Handler) AddEmailConfiguration(w http.ResponseWriter, r *http.Request) 
 			AmazonSecretKey: req.AmazonSecretKey,
 			SesRegion:       req.SesRegion,
 		})
+	case model.EmailSettingSendGrid:
+		err = h.Validator.Struct(model.EmailConfigurationSendGrid{
+			EmailID: req.EmailID,
+			APIKey:  req.APIKey,
+		})
 	default:
 		h.respondError(&errInvalidEmailConfigType, w)
 		return

--- a/deepfence_server/model/email_configuration.go
+++ b/deepfence_server/model/email_configuration.go
@@ -104,6 +104,13 @@ func (e *EmailConfigurationAdd) Create(ctx context.Context, pgClient *postgresql
 			return err
 		}
 	}
+	if e.APIKey != "" {
+		e.APIKey, err = aes.Encrypt(e.APIKey)
+		if err != nil {
+			log.Error().Msgf(err.Error())
+			return err
+		}
+	}
 	settingVal, err := json.Marshal(*e)
 	if err != nil {
 		log.Error().Msgf(err.Error())

--- a/deepfence_server/model/email_configuration.go
+++ b/deepfence_server/model/email_configuration.go
@@ -25,6 +25,11 @@ type EmailConfigurationSES struct {
 	SesRegion       string `json:"ses_region" validate:"required,oneof=us-east-1 us-east-2 us-west-1 us-west-2 af-south-1 ap-east-1 ap-south-1 ap-northeast-1 ap-northeast-2 ap-northeast-3 ap-southeast-1 ap-southeast-2 ap-southeast-3 ca-central-1 eu-central-1 eu-west-1 eu-west-2 eu-west-3 eu-south-1 eu-north-1 me-south-1 me-central-1 sa-east-1 us-gov-east-1 us-gov-west-1"`
 }
 
+type EmailConfigurationSendGrid struct {
+	EmailID string `json:"email_id" validate:"required,email"`
+	APIKey  string `json:"apikey" validate:"required,min=3,max=128"`
+}
+
 type EmailConfigurationAdd struct {
 	EmailProvider   string `json:"email_provider"`
 	CreatedByUserID int64  `json:"created_by_user_id"`
@@ -35,6 +40,7 @@ type EmailConfigurationAdd struct {
 	AmazonAccessKey string `json:"amazon_access_key"`
 	AmazonSecretKey string `json:"amazon_secret_key"`
 	SesRegion       string `json:"ses_region"`
+	APIKey          string `json:"apikey"`
 }
 
 type EmailConfigurationResp struct {

--- a/deepfence_server/model/setting.go
+++ b/deepfence_server/model/setting.go
@@ -23,6 +23,7 @@ const (
 	EmailConfigurationKey             = "email_configuration"
 	EmailSettingSES                   = "amazon_ses"
 	EmailSettingSMTP                  = "smtp"
+	EmailSettingSendGrid              = "sendgrid"
 	InactiveNodesDeleteScanResultsKey = "inactive_delete_scan_results"
 	ConsoleIDKey                      = "console_id"
 )

--- a/deepfence_server/router/router.go
+++ b/deepfence_server/router/router.go
@@ -219,6 +219,7 @@ func SetupRoutes(r *chi.Mux, serverPort string, serveOpenapiDocs bool, ingestC c
 				r.Get("/email", dfHandler.AuthHandler(ResourceSettings, PermissionRead, dfHandler.GetEmailConfiguration))
 				r.Delete("/email/{config_id}", dfHandler.AuthHandler(ResourceSettings, PermissionDelete, dfHandler.DeleteEmailConfiguration))
 				r.Post("/email/test", dfHandler.AuthHandler(ResourceSettings, PermissionDelete, dfHandler.TestConfiguredEmail))
+				r.Post("/email/test-unconfigured", dfHandler.AuthHandler(ResourceSettings, PermissionDelete, dfHandler.TestUnconfiguredEmail))
 				r.Put("/agent/version", dfHandler.AuthHandler(ResourceSettings, PermissionWrite, dfHandler.UploadAgentBinaries))
 				r.Get("/agent/versions", dfHandler.AuthHandler(ResourceSettings, PermissionWrite, dfHandler.ListAgentVersion))
 			})

--- a/deepfence_worker/go.mod
+++ b/deepfence_worker/go.mod
@@ -222,6 +222,8 @@ require (
 	github.com/sashabaranov/go-openai v1.17.10 // indirect
 	github.com/scylladb/go-set v1.0.3-0.20200225121959-cc7b2070d91e // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
+	github.com/sendgrid/rest v2.6.9+incompatible // indirect
+	github.com/sendgrid/sendgrid-go v3.14.0+incompatible // indirect
 	github.com/sethvargo/go-retry v0.2.4 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect

--- a/deepfence_worker/go.sum
+++ b/deepfence_worker/go.sum
@@ -775,6 +775,10 @@ github.com/sebdah/goldie/v2 v2.5.3 h1:9ES/mNN+HNUbNWpVAlrzuZ7jE+Nrczbj8uFRjM7624
 github.com/sebdah/goldie/v2 v2.5.3/go.mod h1:oZ9fp0+se1eapSRjfYbsV/0Hqhbuu3bJVvKI/NNtssI=
 github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=
 github.com/segmentio/asm v1.2.0/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
+github.com/sendgrid/rest v2.6.9+incompatible h1:1EyIcsNdn9KIisLW50MKwmSRSK+ekueiEMJ7NEoxJo0=
+github.com/sendgrid/rest v2.6.9+incompatible/go.mod h1:kXX7q3jZtJXK5c5qK83bSGMdV6tsOE70KbHoqJls4lE=
+github.com/sendgrid/sendgrid-go v3.14.0+incompatible h1:KDSasSTktAqMJCYClHVE94Fcif2i7P7wzISv1sU6DUA=
+github.com/sendgrid/sendgrid-go v3.14.0+incompatible/go.mod h1:QRQt+LX/NmgVEvmdRw0VT/QgUn499+iza2FnDca9fg8=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=


### PR DESCRIPTION
This PR adds:
- Sendgrid support in email configuration
- API `/deepfence/settings/email/test-unconfigured` to send test email using unconfigured credentials. (test email is sent to registered user)


related: https://github.com/deepfence/ThreatMapper/pull/2051

ref issue: https://github.com/deepfence/ThreatMapper/issues/2048