### PR TITLE
fix: where server container is restarted haproxy shows 503

### DIFF
--- a/haproxy/haproxy.cfg
+++ b/haproxy/haproxy.cfg
@@ -36,6 +36,11 @@ defaults
     default-server init-addr last,libc,none
 
 
+resolvers container
+    parse-resolv-conf
+    # nameserver dns 127.0.0.11:53
+
+
 frontend port_80
     mode http
     bind 0.0.0.0:80 name app_80
@@ -109,7 +114,7 @@ backend deepfence-ui-4042
     # http-response set-header Content-Security-Policy "default-src 'self'"
     # http-response set-header X-Permitted-Cross-Domain-Policies "none"
 
-    server s1 ${UI_SERVICE_NAME}:${UI_SERVICE_PORT} check inter 10s fall 3 rise 1
+    server s1 ${UI_SERVICE_NAME}:${UI_SERVICE_PORT} check inter 5s resolvers container fall 3 rise 1
 
 backend deepfence-server-8080
     mode http
@@ -143,7 +148,7 @@ backend deepfence-server-8080
     # http-response set-header Content-Security-Policy "default-src 'self'"
     # http-response set-header X-Permitted-Cross-Domain-Policies "none"
 
-    server s1 ${API_SERVICE_HOST}:${API_SERVICE_PORT} check inter 10s fall 3 rise 1
+    server s1 ${API_SERVICE_HOST}:${API_SERVICE_PORT} check inter 5s resolvers container fall 3 rise 1
 
 backend deepfence-file-server-9000
     mode http
@@ -183,8 +188,8 @@ backend deepfence-file-server-9000
     # http-response set-header Content-Security-Policy "default-src 'self'"
     # http-response set-header X-Permitted-Cross-Domain-Policies "none"
 
-    # server s1 ${DEEPFENCE_FILE_SERVER_HOST}:${DEEPFENCE_FILE_SERVER_PORT} check inter 10s fall 3 rise 1
-    server s1 ${DEEPFENCE_FILE_SERVER_HOST}:${DEEPFENCE_FILE_SERVER_PORT} check port ${DEEPFENCE_FILE_SERVER_PORT} inter 10s fall 3 rise 1
+    # server s1 ${DEEPFENCE_FILE_SERVER_HOST}:${DEEPFENCE_FILE_SERVER_PORT} check inter 5s resolvers container fall 3 rise 1
+    server s1 ${DEEPFENCE_FILE_SERVER_HOST}:${DEEPFENCE_FILE_SERVER_PORT} check port ${DEEPFENCE_FILE_SERVER_PORT} inter 5s resolvers container fall 3 rise 1
 
 backend options_method_handler
     mode http


### PR DESCRIPTION
Changes proposed in this pull request:
- Solve the issue where the haproxy doesn't recognise that the deepfence-server container has restarted unless haproxy is restarted 

