### PR TITLE
fix haproxy resolver fails on kubernets with out full service dns names

### DIFF
--- a/deployment-scripts/helm-charts/deepfence-console/templates/deepfence-router.yaml
+++ b/deployment-scripts/helm-charts/deepfence-console/templates/deepfence-router.yaml
@@ -39,15 +39,15 @@ spec:
             - name: FORCE_HTTPS_REDIRECT
               value: "{{ .Values.router.forceHttpsRedirect }}"
             - name: UI_SERVICE_NAME
-              value: {{ include "deepfence-console.fullname" . }}-ui
+              value: {{ include "deepfence-console.fullname" . }}-ui.{{ .Release.Namespace }}.svc.{{ .Values.router.cluster_domain }}
             - name: UI_SERVICE_PORT
               value: {{ .Values.ui.service.port | quote }}
             - name: API_SERVICE_HOST
-              value: {{ include "deepfence-console.fullname" . }}-server
+              value: {{ include "deepfence-console.fullname" . }}-server.{{ .Release.Namespace }}.svc.{{ .Values.router.cluster_domain }}
             - name: API_SERVICE_PORT
               value: {{ .Values.server.service.port | quote }}
             - name: DEEPFENCE_FILE_SERVER_HOST
-              value: {{ include "deepfence-console.fullname" . }}-file-server
+              value: {{ include "deepfence-console.fullname" . }}-file-server.{{ .Release.Namespace }}.svc.{{ .Values.router.cluster_domain }}
             - name: DEEPFENCE_FILE_SERVER_PORT
               value: "9000"
           envFrom:

--- a/deployment-scripts/helm-charts/deepfence-console/values.yaml
+++ b/deployment-scripts/helm-charts/deepfence-console/values.yaml
@@ -273,6 +273,9 @@ router:
     # Overrides the image tag whose default is .global.imageTag
     # tag: 2.2.0
   forceHttpsRedirect: true
+  # used to in service name generation
+  # <service>.<namespace>.svc.<cluster_domain>
+  cluster_domain: "cluster.local"
   podAnnotations: {}
   podSecurityContext: {}
   securityContext: {}

--- a/haproxy/haproxy.cfg
+++ b/haproxy/haproxy.cfg
@@ -38,6 +38,7 @@ defaults
 
 resolvers container
     parse-resolv-conf
+    accepted_payload_size 8192
     # nameserver dns 127.0.0.11:53
 
 


### PR DESCRIPTION

Changes proposed in this pull request:
- fix haproxy resolver fails on kubernetes with out full service dns names
-
-
