### PR TITLE
fix cypher query in diff

### DIFF
--- a/deepfence_server/reporters/scan/scan_reporters.go
+++ b/deepfence_server/reporters/scan/scan_reporters.go
@@ -713,11 +713,12 @@ func GetScanResultDiff[T any](ctx context.Context, scanType utils.Neo4jScanType,
 	OPTIONAL MATCH (n) -[:SCANNED]-> (f)
 	OPTIONAL MATCH (c:ContainerImage{node_id: f.docker_image_id}) -[:ALIAS] ->(t) -[ma:MASKED]-> (d)
 	OPTIONAL MATCH (cb:ContainerImage{node_id: n.docker_image_id}) -[:IS] ->(is) -[mis:MASKED]-> (d)
+	WITH e, d, r, collect(ma) as ma_list, collect(mis) as mis_list
 	WITH apoc.map.merge( e{.*}, 
-	d{.*, masked: coalesce(d.masked or r.masked or e.masked or head(collect(ma.masked)) or head(collect(mis.masked)), false), 
-	name: coalesce(e.name, d.name, '')}) AS d` +
+	d{.*, masked: coalesce(d.masked or r.masked or e.masked or head(ma_list).masked or head(mis_list).masked, false), 
+	name: coalesce(e.name, d.name, '')}) AS merged_data` +
 		reporters.ParseFieldFilters2CypherWhereConditions("d", mo.Some(ff), true) +
-		ffCondition + ` RETURN d ` +
+		ffCondition + ` RETURN merged_data ` +
 		fw.FetchWindow2CypherQuery()
 	log.Debug().Msgf("diff query: %v", query)
 	nres, err := tx.Run(ctx, query,


### PR DESCRIPTION
diff query was returning the below exception:
```cypher
Tue, 16 Apr 2024 13:20:34 +0000 DBG scan/scan_reporters.go:722 diff query:
        MATCH (m:VulnerabilityScan{node_id: $base_scan_id}) -[r:DETECTED]-> (d2)
        WITH collect(d2) as dset
        MATCH (n:VulnerabilityScan{node_id: $compare_to_scan_id}) -[r:DETECTED]-> (d)
        WHERE NOT d in dset
        OPTIONAL MATCH (d) -[:IS]-> (e)
        OPTIONAL MATCH (n) -[:SCANNED]-> (f)
        OPTIONAL MATCH (c:ContainerImage{node_id: f.docker_image_id}) -[:ALIAS] ->(t) -[ma:MASKED]-> (d)
        OPTIONAL MATCH (cb:ContainerImage{node_id: n.docker_image_id}) -[:IS] ->(is) -[mis:MASKED]-> (d)
        WITH apoc.map.merge( e{.*},
        d{.*, masked: coalesce(d.masked or r.masked or e.masked or head(collect(ma.masked)) or head(collect(mis.masked)), false),
        name: coalesce(e.name, d.name, '')}) AS d RETURN d  SKIP 0 LIMIT 99999
Tue, 16 Apr 2024 13:20:34 +0000 ERR handler/scan_reports.go:278 Neo4jError: Neo.ClientError.Statement.SyntaxError (Aggregation column contains implicit grouping expressions. For example, in 'RETURN n.a, n.a + n.b + count(*)' the aggregation expression 'n.a + n.b + count(*)' includes the implicit grouping key 'n.b'. It may be possible to rewrite the query by extracting these grouping/aggregation expressions into a preceding WITH clause. Illegal expression(s): e, e.masked, e.name, r.masked, d.masked, d.name, d (line 10, column 23 (offset: 490))
"       WITH apoc.map.merge( e{.*},"
                       ^)
```
