### PR TITLE
add sbom download type, fix not showing of chart in dark mode

### DIFF
--- a/deepfence_frontend/apps/dashboard/src/features/integrations/components/ReportsTable.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/integrations/components/ReportsTable.tsx
@@ -1,6 +1,5 @@
 import {
   capitalize,
-  findKey,
   intersection,
   isEmpty,
   isNil,
@@ -418,7 +417,7 @@ export const ReportFilters = () => {
             });
           }}
         >
-          {['xlsx', 'pdf']
+          {['xlsx', 'pdf', 'sbom']
             .filter((item) => {
               if (!reportTypeSearch.length) return true;
               if (item.includes(reportTypeSearch.toLowerCase())) {

--- a/deepfence_frontend/apps/dashboard/src/features/topology/components/scan-results/ScanResultChart.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/topology/components/scan-results/ScanResultChart.tsx
@@ -58,7 +58,7 @@ export const ScanResultChart = ({
         legend: {
           show: false,
         },
-        series: theme === THEME_DARK ? [series[1]] : series,
+        series,
       }}
       onChartClick={({ name }: { name: string; value: string | number | Date }) => {
         window.open(`${to}=${name.toLowerCase()}`, '_blank', 'noopener, noreferrer');


### PR DESCRIPTION
Fixes https://github.com/deepfence/enterprise-roadmap/issues/2177

Changes proposed in this pull request:
- To include sbom as report type in option
- Fix dark mode miss chart to display
