### PR TITLE
Disable inlining for image assets caused by vite 5

### DIFF
--- a/deepfence_frontend/apps/dashboard/vite.config.ts
+++ b/deepfence_frontend/apps/dashboard/vite.config.ts
@@ -81,6 +81,7 @@ export default defineConfig(({ mode }) => {
       commonjsOptions: {
         include: [/tailwind-preset/, /node_modules/],
       },
+      assetsInlineLimit: 0,
     },
     server: {
       host: true,


### PR DESCRIPTION
Changes proposed in this pull request:
- Fixes thumbnail images not loading for some pages.