### PR TITLE
fix rule id in secret ingestion

### DIFF
--- a/deepfence_worker/ingesters/secrets.go
+++ b/deepfence_worker/ingesters/secrets.go
@@ -12,6 +12,10 @@ import (
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 )
 
+func generateSecretRuleId(r map[string]interface{}) string {
+	return generateHashFromString(r["name"].(string))
+}
+
 func CommitFuncSecrets(ctx context.Context, ns string, data []ingestersUtil.Secret) error {
 	ctx = directory.ContextWithNameSpace(ctx, directory.NamespaceID(ns))
 
@@ -78,12 +82,14 @@ func secretsToMaps(data []ingestersUtil.Secret) ([]map[string]map[string]interfa
 			secret[k] = v
 		}
 
-		secret["node_id"] = utils.ScanIDReplacer.Replace(fmt.Sprintf("%v:%v",
-			i.Rule.ID, i.Match.FullFilename))
 		rule := utils.ToMap(i.Rule)
 		delete(rule, "id")
-		rule["rule_id"] = i.Rule.ID
+		rule["rule_id"] = generateSecretRuleId(rule)
 		rule["level"] = i.Severity.Level
+
+		secret["node_id"] = utils.ScanIDReplacer.Replace(fmt.Sprintf("%v:%v",
+			i.Rule.ID, i.Match.FullFilename))
+
 		secrets = append(secrets, map[string]map[string]interface{}{
 			"Rule":   rule,
 			"Secret": secret,

--- a/deepfence_worker/ingesters/secrets.go
+++ b/deepfence_worker/ingesters/secrets.go
@@ -88,7 +88,7 @@ func secretsToMaps(data []ingestersUtil.Secret) ([]map[string]map[string]interfa
 		rule["level"] = i.Severity.Level
 
 		secret["node_id"] = utils.ScanIDReplacer.Replace(fmt.Sprintf("%v:%v",
-			i.Rule.ID, i.Match.FullFilename))
+			rule["rule_id"], i.Match.FullFilename))
 
 		secrets = append(secrets, map[string]map[string]interface{}{
 			"Rule":   rule,


### PR DESCRIPTION
This was leading to creation of only one `SecretRule` because of missing `rule.ID`, resulting in this
![image](https://github.com/user-attachments/assets/9cd5169b-05eb-4751-9ff2-16d5fd48de91)

All the secrets here are not same, though it shown one because of overwrite.
