### PR TITLE
add support for TLS redis connection

### DIFF
--- a/deepfence_server/Dockerfile
+++ b/deepfence_server/Dockerfile
@@ -11,6 +11,7 @@ COPY deepfence_server/entrypoint.sh /entrypoint.sh
 RUN apt update && \
     apt install -y \
     bash \
+    ca-certificates \
     curl \
     wget \
     netcat-traditional \

--- a/deepfence_utils/directory/directory.go
+++ b/deepfence_utils/directory/directory.go
@@ -180,10 +180,12 @@ func initRedis() RedisConfig {
 			redisDBNumber = 0
 		}
 	}
+	redisTLSConfig := os.Getenv("DEEPFENCE_REDIS_TLS")
 	return RedisConfig{
 		Endpoint: redisEndpoint,
 		Password: redisPassword,
 		Database: redisDBNumber,
+		TLSConfig: redisTLSConfig,
 	}
 }
 

--- a/deepfence_utils/directory/redis.go
+++ b/deepfence_utils/directory/redis.go
@@ -21,6 +21,11 @@ func newRedisClient(endpoints DBConfigs) (*redis.Client, error) {
 	if endpoints.Redis.Password != "" {
 		redisOptions.Password = endpoints.Redis.Password
 	}
+	if endpoints.Redis.TLSConfig != "" {
+		redisOptions.TLSConfig = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		}
+	}
 	return redis.NewClient(redisOptions), nil
 }
 


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:
- add support for TLS redis connections to support AWS ElastiCache
-
-
