### PR TITLE
Fix deepfence agent privileges on security hardened clusters

### DIFF
--- a/deployment-scripts/helm-charts/deepfence-agent/templates/deployment.yaml
+++ b/deployment-scripts/helm-charts/deepfence-agent/templates/deployment.yaml
@@ -31,6 +31,9 @@ spec:
         - name: deepfence-cluster-agent
           image: "{{ .Values.cluster_agent.image.name }}:{{ default .Values.global.imageTag .Values.cluster_agent.image.tag }}"
           imagePullPolicy: {{ .Values.cluster_agent.image.pullPolicy }}
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
           env:
             - name: MGMT_CONSOLE_URL
               value: "{{ required "managementConsoleUrl is required" .Values.managementConsoleUrl }}"


### PR DESCRIPTION
Fixes #2311

Changes proposed in this pull request:
- Simple change to specifically run as a root. Assures compliance with https://github.com/deepfence/ThreatMapper/blob/main/deepfence_agent/Dockerfile.cluster-agent#L44 on security hardened clusters
- On kubernetes this error does not appear since kubernetes defaults to user specified while building the image when no securityContext is specified

I would really appreciate if this could be backported into `release-2.3` and released as new helm chart version 
