### PR TITLE
Enforce DEEPFENCE_FILE_SERVER_PORT to be a string

### DIFF
--- a/deployment-scripts/helm-charts/deepfence-console/templates/deepfence-console-config.yaml
+++ b/deployment-scripts/helm-charts/deepfence-console/templates/deepfence-console-config.yaml
@@ -16,7 +16,7 @@ data:
   DEEPFENCE_FILE_SERVER_EXTERNAL: "false"
   {{- else }}
   DEEPFENCE_FILE_SERVER_HOST: {{ .Values.fileserver.fileServerHost }}
-  DEEPFENCE_FILE_SERVER_PORT: {{ .Values.fileserver.fileServerPort }}
+  DEEPFENCE_FILE_SERVER_PORT: {{ .Values.fileserver.fileServerPort | quote }}
   DEEPFENCE_FILE_SERVER_EXTERNAL: "true"
   {{- end }}
 


### PR DESCRIPTION
ConfigMap in version "v1" cannot be handled as a ConfigMap: json: cannot unmarshal number into Go struct field ConfigMap.data of type string

due to the template not quoting the port for an external S3 instance, the configmap will not be able to be applied

add quoting to the value for the port

Fixes #

Changes proposed in this pull request:
add ` | quote` to the template that pulls the port number from values
