### PR TITLE
Remove duplicate app label

### DIFF
--- a/deployment-scripts/helm-charts/deepfence-router/templates/service.yaml
+++ b/deployment-scripts/helm-charts/deepfence-router/templates/service.yaml
@@ -4,7 +4,6 @@ kind: Service
 metadata:
   name: {{ .Values.service.name }}
   labels:
-    app: deepfence-router
     {{- include "deepfence-router.labels" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
   {{- with .Values.service.annotations }}


### PR DESCRIPTION
label is already defined in helper function: https://github.com/deepfence/ThreatMapper/blob/a56e9dbdeb3eacc2232e0b281e222a5f62d961be/deployment-scripts/helm-charts/deepfence-router/templates/_helpers.tpl#L52


helm install throws:
Helm install failed for release threatmapper/deepfence-router with chart deepfence-router@2.3.1: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:
 line 9: mapping key "app" already defined at line 7

Fixes #

Changes proposed in this pull request:
- remove one instance of the app label to allow deployment to work.
