### PR TITLE
update default toleration of cluster agent to empty array

### DIFF
--- a/deployment-scripts/helm-charts/deepfence-agent/values.yaml
+++ b/deployment-scripts/helm-charts/deepfence-agent/values.yaml
@@ -59,11 +59,11 @@ cluster_agent:
   nodeSelector:
     kubernetes.io/os: linux
     # kubernetes.io/arch: amd64
-  tolerations:
-    - operator: "Exists"
-      effect: "NoSchedule"
-    - operator: "Exists"
-      effect: "NoExecute"
+  tolerations: []
+    # - operator: "Exists"
+    #   effect: "NoSchedule"
+    # - operator: "Exists"
+    #   effect: "NoExecute"
   resources:
     requests:
       cpu: 25m


### PR DESCRIPTION
Fixes #

- https://github.com/deepfence/ThreatMapper/issues/2384