### PR TITLE
Limit resource count for header display to avoid unnecessary large count queries

### DIFF
--- a/deepfence_frontend/apps/dashboard/src/features/topology/pages/Inventory.tsx
+++ b/deepfence_frontend/apps/dashboard/src/features/topology/pages/Inventory.tsx
@@ -7,13 +7,23 @@ import { TopologyHeader } from '@/features/topology/components/TopologyHeader';
 import { queries } from '@/queries';
 import { usePageNavigation } from '@/utils/usePageNavigation';
 
+const MAX_CLOUD_RESOURCE_COUNT = 9999;
+
 function useCloudResourcesCount() {
-  return useSuspenseQuery({ ...queries.search.cloudResourcesCount() });
+  return useSuspenseQuery({
+    ...queries.search.cloudResourcesCount({ maxSize: MAX_CLOUD_RESOURCE_COUNT + 1 }),
+  });
 }
 
 const CloudResourceCount = () => {
   const { data: cloudResourceCount } = useCloudResourcesCount();
-  return <b>{cloudResourceCount}</b>;
+  return (
+    <b>
+      {cloudResourceCount > MAX_CLOUD_RESOURCE_COUNT
+        ? `${MAX_CLOUD_RESOURCE_COUNT}+`
+        : cloudResourceCount}
+    </b>
+  );
 };
 
 const inventoryTabs = [

--- a/deepfence_frontend/apps/dashboard/src/queries/search.tsx
+++ b/deepfence_frontend/apps/dashboard/src/queries/search.tsx
@@ -1563,7 +1563,7 @@ export const searchQueries = createQueryKeys('search', {
       },
     };
   },
-  cloudResourcesCount: () => {
+  cloudResourcesCount: ({ maxSize }: { maxSize: number }) => {
     return {
       queryKey: ['cloudResourcesCount'],
       queryFn: async () => {
@@ -1587,7 +1587,7 @@ export const searchQueries = createQueryKeys('search', {
             },
             window: {
               offset: 0,
-              size: Number.MAX_SAFE_INTEGER,
+              size: maxSize,
             },
           },
         });


### PR DESCRIPTION
Changes
- Updated the cloud resources count query to accept a maxSize parameter, allowing for more flexible data retrieval.
- Modified the Inventory component to display cloud resource counts, showing a '+' sign if the count exceeds the defined maximum limit of 9999.