### PR TITLE
fix: correct typo occured to occurred in error messages

### DIFF
--- a/deepfence_frontend/apps/dashboard/src/utils/403.ts
+++ b/deepfence_frontend/apps/dashboard/src/utils/403.ts
@@ -18,12 +18,12 @@ export const getResponseErrors = async (error: ResponseError) => {
   try {
     const response = (await error.response.json()) as ApiDocsBadRequestResponse;
     return {
-      message: response.message ?? 'An unknown error has occured',
+      message: response.message ?? 'An unknown error has occurred',
       fieldErrors: response.error_fields,
     };
   } catch {
     return Promise.resolve({
-      message: 'An unknown error has occured',
+      message: 'An unknown error has occurred',
       fieldErrors: undefined,
     });
   }

--- a/deepfence_worker/cronjobs/notification.go
+++ b/deepfence_worker/cronjobs/notification.go
@@ -159,7 +159,7 @@ func TriggerSendNotifications(ctx context.Context, task *asynq.Task) error {
 		if ig.ErrorMsg.String != "" &&
 			time.Since(ig.LastSentTime.Time) < NotificationErrorBackoff {
 			log.Info().Msgf("Skipping integration for %s rowId: %d due to error: %s "+
-				"occured at last attempt, %s ago",
+				"occurred at last attempt, %s ago",
 				ig.IntegrationType, ig.ID,
 				ig.ErrorMsg.String, time.Since(ig.LastSentTime.Time))
 			continue


### PR DESCRIPTION
Fixes a typo in user-visible 403 error messages and a worker log message ('occured' -> 'occurred').